### PR TITLE
GH-321 Persist `For Each` node's "with break" status

### DIFF
--- a/src/script/nodes/flow_control/for_each.cpp
+++ b/src/script/nodes/flow_control/for_each.cpp
@@ -59,6 +59,33 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+void OScriptNodeForEach::_get_property_list(List<PropertyInfo>* r_list) const
+{
+    r_list->push_back(PropertyInfo(Variant::BOOL, "with_break", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
+}
+
+bool OScriptNodeForEach::_get(const StringName& p_name, Variant& r_value) const
+{
+    if (p_name.match("with_break"))
+    {
+        r_value = _with_break;
+        return true;
+    }
+    return false;
+}
+
+bool OScriptNodeForEach::_set(const StringName& p_name, const Variant& p_value)
+{
+    if (p_name.match("with_break"))
+    {
+        _with_break = p_value;
+        _notify_pins_changed();
+        return true;
+    }
+    return false;
+}
+
+
 void OScriptNodeForEach::post_initialize()
 {
     // Automatically coerces old element pins to using NIL for Any rather than OBJECT

--- a/src/script/nodes/flow_control/for_each.h
+++ b/src/script/nodes/flow_control/for_each.h
@@ -28,6 +28,12 @@ class OScriptNodeForEach : public OScriptNode
 protected:
     bool _with_break{ false };  //! Whether break is enabled
 
+    //~ Begin Wrapped Interface
+    void _get_property_list(List<PropertyInfo>* r_list) const;
+    bool _get(const StringName& p_name, Variant& r_value) const;
+    bool _set(const StringName& p_name, const Variant& p_value);
+    //~ End Wrapped Interface
+
     /// Set whether the break pin is used.
     /// @param p_break_status true if the break pin is visible, false otherwise
     void _set_with_break(bool p_break_status);


### PR DESCRIPTION
Fixes #321