### PR TITLE
Allow compiling orchestrator as doubles.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,183 @@
+name: 🛠️ Build All
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref_name }}"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+#          - identifier: linux-debug
+#            name: 🐧 Linux (Debug)
+#            build_type: Debug
+#            runner: ubuntu-20.04
+#            target: template_debug
+#            platform: linux
+#            arch: x86_64
+          - identifier: linux-release
+            name: 🐧 Linux (Release)
+            build_type: Release
+            runner: ubuntu-20.04
+            target: template_release
+            platform: linux
+            arch: x86_64
+            precision: double
+#          - identifier: windows-debug
+#            name: 🪟 Windows (Debug)
+#            build_type: Debug
+#            runner: windows-latest
+#            target: template_debug
+#            platform: windows
+#            arch: x86_64
+          - identifier: windows-release
+            name: 🪟 Windows (Release)
+            build_type: Release
+            runner: windows-latest
+            target: template_release
+            platform: windows
+            arch: x86_64
+            precision: double
+#          - identifier: macos-debug
+#            name: 🍎 MacOS (Debug)
+#            build_type: Debug
+#            runner: macos-latest
+#            target: template_debug
+#            platform: macos
+          - identifier: macos-release
+            name: 🍎 MacOS (Release)
+            build_type: Release
+            runner: macos-latest
+            target: template_release
+            platform: macos
+            precision: double
+          - identifier: android-arm64
+            name: 🤖 Android Arm64
+            build_type: Release
+            runner: ubuntu-20.04
+            platform: android
+            arch: arm64-v8a
+            precision: double
+          - identifier: android-arm32
+            name: 🤖 Android Arm32
+            build_type: Release
+            runner: ubuntu-20.04
+            platform: android
+            arch: armeabi-v7a
+            precision: double
+
+    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.name }}
+
+    steps:
+
+      - name: Checkout project
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Linux Dependencies
+        if: startsWith(matrix.identifier, 'linux-')
+        uses: ./.github/actions/linux-deps
+
+      - name: Setup Windows Dependencies
+        if: startsWith(matrix.identifier, 'windows-')
+        uses: ./.github/actions/windows-deps
+
+      - name: Setup MacOS Dependencies
+        if: startsWith(matrix.identifier, 'macos-')
+        uses: ./.github/actions/macos-deps
+
+      - name: Setup Android Dependencies
+        if: startsWith(matrix.identifier, 'android-')
+        uses: ./.github/actions/android-deps
+
+      - name: Setup Base Dependencies
+        uses: ./.github/actions/base-deps
+
+      - name: ccache (Linux/Mac)
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ccache-${{ matrix.identifier }}
+
+      - name: Build Orchestrator (Linux/MacOS)
+        if: startsWith(matrix.identifier, 'linux-') || startsWith(matrix.identifier, 'macos-')
+        shell: sh
+        run: |
+          cmake -B ${{ github.workspace }}/.out-${{ matrix.identifier }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -S ${{ github.workspace }} -G Ninja -DGODOT_FLOAT_PRECISION=${{ matrix.precision }}
+          cmake --build ${{ github.workspace }}/.out-${{ matrix.identifier }} --target orchestrator -j 18
+
+      - name: Build Orchestrator (Windows)
+        if: startsWith(matrix.identifier, 'windows-')
+        shell: bash
+        run: |
+          cmake -B '${{ github.workspace }}/.out-${{ matrix.identifier }}' -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER=cl -DCMAKE_C_COMPILER=cl -S '${{ github.workspace }}' -G Ninja -DGODOT_FLOAT_PRECISION=${{ matrix.precision }}
+          cmake --build '${{ github.workspace }}/.out-${{ matrix.identifier }}' --target orchestrator -j 18
+
+      - name: Build Orchestrator (Android)
+        if: startsWith(matrix.identifier, 'android-')
+        shell: sh
+        run: |
+          cmake -B ${{ github.workspace }}/.out-${{ matrix.identifier }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_ANDROID_ARCH_ABI=${{ matrix.arch }} -DANDROID_ABI=${{ matrix.arch }} -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DANDROID_TOOLCHAIN_NAME=arm-linux-androideabi-4.9 -DANDROID_PLATFORM=android-23 -DANDROID_TOOLCHAIN=clang -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache -S ${{ github.workspace }}  -DGODOT_FLOAT_PRECISION=${{ matrix.precision }}
+          cmake --build ${{ github.workspace }}/.out-${{ matrix.identifier }} --target orchestrator -j 18
+
+      - name: Prepare addon files
+        shell: bash
+        run: |
+          cp '${{ github.workspace }}/AUTHORS.md' '${{ github.workspace }}/project/addons/orchestrator/'
+          cp '${{ github.workspace }}/CHANGELOG.md' '${{ github.workspace }}/project/addons/orchestrator/'
+          cp '${{ github.workspace }}/README.md' '${{ github.workspace }}/project/addons/orchestrator/'
+          cp '${{ github.workspace }}/LICENSE' '${{ github.workspace }}/project/addons/orchestrator/'
+
+      - name: Upload artifact (Demo)
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.event.repository.name }}-demo-${{ matrix.identifier }}
+          retention-days: 1
+          path: |
+            ${{ github.workspace }}/project/
+
+      - name: Upload artifact (Plugin)
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.event.repository.name }}-plugin-${{ matrix.identifier }}
+          retention-days: 1
+          path: |
+            ${{ github.workspace }}/project
+            !${{ github.workspace }}/project/addons/orchestrator/*debug*
+            !${{ github.workspace }}/project/scenes
+            !${{ github.workspace }}/project/icon.svg
+            !${{ github.workspace }}/project/project.godot
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Combine Artifacts
+    steps:
+      - name: Download Plugin Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ github.event.repository.name }}-plugin-*
+          merge-multiple: true
+
+      - name: Upload Plugin Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.event.repository.name }}-plugin
+          retention-days: 1
+          path: |
+            ${{ github.workspace }}
+
+#      - name: Remove Transient Artifacts
+#        uses: geekyeggo/delete-artifact@v4
+#        with:
+#          name: |
+#            ${{ github.event.repository.name}}-plugin-*
+#          failOnError: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,80 +14,67 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 ##
-CMAKE_MINIMUM_REQUIRED(VERSION 3.20 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.20)
 
 SET(GDEXTENSION_LIB_NAME orchestrator)
 SET(GDEXTENSION_LIB_PATH "${CMAKE_CURRENT_SOURCE_DIR}/project/addons/orchestrator")
 
-# Configurable options
-OPTION(AUTOFORMAT_SRC_ON_CONFIGURE "If enabled, clang-format will be used to format all sources in /src during configuration" OFF)
+# This doesn't work for editor plugins
+# ADD_COMPILE_DEFINITIONS(HOT_RELOAD_ENABLED)
+add_compile_definitions(TOOLS_ENABLED)
 
-# Set basic CMAKE properties
+set(GODOT_FLOAT_PRECISION "single" CACHE STRING "")
+
+OPTION(
+        AUTOFORMAT_SRC_ON_CONFIGURE
+        "If enabled, clang-format will be used to format all sources in src/ during configuration"
+        OFF
+)
+
 SET(CMAKE_CXX_STANDARD 20)
 SET(CMAKE_CXX_EXTENSIONS ON)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 SET(CMAKE_COLOR_DIAGNOSTICS ON)
 SET(CMAKE_MESSAGE_LOG_LEVEL STATUS)
 
-# Get the current repository Git commit hash
-# This is used when creating the data from VERSION to show the commit hash in the about box
 FIND_PACKAGE(Git QUIET)
-IF (GIT_FOUND)
+IF(GIT_FOUND)
     EXECUTE_PROCESS(
             COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
             WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
             OUTPUT_VARIABLE GIT_COMMIT_HASH
-            OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    EXECUTE_PROCESS(
-            COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
-            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/extern/godot-cpp"
-            OUTPUT_VARIABLE GODOT_CPP_GIT_COMMIT_HASH
-            OUTPUT_STRIP_TRAILING_WHITESPACE)
-ELSE ()
-    # In this case the about box will simply show an unknown git commit
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+ELSE()
     SET(GIT_COMMIT_HASH "<Unknown>")
-    SET(GODOT_CPP_GIT_COMMIT_HASH "<Unknown>")
-ENDIF ()
+ENDIF()
 
-FIND_PACKAGE( Python3 REQUIRED COMPONENTS Interpreter )
+INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/_generated)
 
-# Setup the CMAKE_MODULE_PATH
 LIST(APPEND CMAKE_MODULE_PATH
-        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
+        "${CMAKE_CURRENT_SOURCE_DIR}/cmake/"
+        "${CMAKE_CURRENT_SOURCE_DIR}/extern/godot-cpp/cmake/"
+)
 
-# Include and execute various CMAKE modules
 INCLUDE(generate-authors)
 INCLUDE(generate-license)
 INCLUDE(generate-version)
 INCLUDE(generate-donors)
 INCLUDE(godot-extension-db-generator)
-INCLUDE(godot-docs-generator)
 
 # Generation steps
-GENERATE_AUTHORS()
 GENERATE_LICENSE()
 GENERATE_VERSION()
+GENERATE_AUTHORS()
 GENERATE_DONORS()
 GENERATE_GODOT_EXTENSION_DB()
-GENERATE_GODOT_DOCUMENTATION()
-
-# Configure project
-PROJECT("${GDEXTENSION_LIB_NAME}" LANGUAGES C CXX VERSION ${RESOLVED_VERSION})
-
-# Generate library resource
-IF (WIN32)
-    SET(win32_product_name "${RESOLVED_VERSION_NAME}")
-    SET(win32_file_version "${PROJECT_VERSION_MAJOR},${PROJECT_VERSION_MINOR},${PROJECT_VERSION_PATCH},0")
-    SET(win32_product_version "${PROJECT_VERSION_MAJOR},${PROJECT_VERSION_MINOR},${PROJECT_VERSION_PATCH},0")
-    SET(win32_file_description "Godot ${win32_product_name} Plug-in")
-    CONFIGURE_FILE(cmake/templates/windows.rc.in ${CMAKE_CURRENT_BINARY_DIR}/_generated/version.rc @ONLY)
-ENDIF ()
 
 # MacOS universal binary support
 IF (APPLE)
     SET(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build architectures for OSX" FORCE)
 ENDIF ()
+
+PROJECT("${GDEXTENSION_LIB_NAME}" LANGUAGES C CXX VERSION ${RESOLVED_VERSION})
 
 # Compiler Identification
 SET(compiler_is_clang "$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>")
@@ -102,122 +89,117 @@ FILE(GLOB_RECURSE gdext_sources
         CONFIGURE_DEPENDS
         "${CMAKE_CURRENT_SOURCE_DIR}/src/*.[hc]"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/*.[hc]pp"
-        # Includes the generated doc data from /doc_classes
-        "${CMAKE_BINARY_DIR}/_generated/*.cpp"
-        "${DOC_DATA_CPP_FILE}"
-        # Include windows version resource, if exists
-        "${CMAKE_CURRENT_BINARY_DIR}/_generated/version.rc")
+)
+
+if ("${GODOT_FLOAT_PRECISION}" STREQUAL "double")
+	add_compile_definitions(REAL_T_IS_DOUBLE)
+endif()
 
 # GDExtension library
 ADD_LIBRARY(${PROJECT_NAME} SHARED ${gdext_sources})
 
+## Import compiler warnings from godot-cpp
+INCLUDE(GodotCompilerWarnings)
+
 # Setup compiler options for GDExtension Library based on the compiler used
 TARGET_COMPILE_OPTIONS(${PROJECT_NAME} PUBLIC
         $<${compiler_is_msvc}:
-            /EHsc
-            /utf-8
-            /Zc:preprocessor
-            /wd5054 # operator '|' deprecated between enumerations of different types
-            $<$<CONFIG:Debug>:
-                /MDd
-            >
-            $<$<CONFIG:Release>:
-                /MT
-                /O2
-            >
+        /EHsc
+        /utf-8
+		$<$<STREQUAL:${GODOT_FLOAT_PRECISION},double>:/DREAL_T_IS_DOUBLE>
+        /Zc:preprocessor
+        /wd5054 # operator '|' deprecated between enumerations of different types
+        $<$<CONFIG:Debug>:
+        /MDd
+        >
+        $<$<CONFIG:Release>:
+        /MD
+        /O2
+        >
         >
         $<$<NOT:${compiler_is_msvc}>:
-            -Wno-unused-value
-            $<${compiler_is_gnu}:
-                -Wno-attributes
-                -Wno-attributes=r1::
-            >
-            $<${compiler_is_clang}:
-                -Wno-ignored-attributes
-                -Wno-unknown-attributes
-            >
-            $<$<CONFIG:Debug>:
-                -g
-                -fno-omit-frame-pointer
-                -O0
-            >
-            $<$<CONFIG:Release>:
-                -O3
-            >
-        >)
-
-# Handle setting this that godot-cpp doesn't yet set
-IF (NOT GODOTCPP_TARGET STREQUAL "template_release")
-    TARGET_COMPILE_DEFINITIONS(${PROJECT_NAME} PRIVATE TOOLS_ENABLED)
-ENDIF ()
+        -g
+        -Wno-unused-value
+        $<${compiler_is_gnu}:
+        -Wno-attributes
+        -Wno-attributes=r1::
+        >
+        $<${compiler_is_clang}:
+        -Wno-ignored-attributes
+        -Wno-unknown-attributes
+        >
+        $<$<CONFIG:Debug>:
+        -fno-omit-frame-pointer
+        -O0
+        >
+        $<$<CONFIG:Release>:
+        -O3
+        >
+        >
+)
 
 find_program(ccache_exe ccache)
-IF (ccache_exe)
-    SET(CMAKE_VS_GLOBALS "TrackFileAccess=false" "UseMultiToolTask=true" "DebugInformationFormat=OldStyle")
-ENDIF ()
-
-# Add the special "_generated" directory to the include list
-# This is where the generator CMAKE module steps creates automated files
-INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR}/_generated)
+if (ccache_exe)
+    set(CMAKE_VS_GLOBALS
+            "TrackFileAccess=false"
+            "UseMultiToolTask=true"
+            "DebugInformationFormat=OldStyle"
+    )
+endif()
 
 # Include directories for GDExtension library
 TARGET_INCLUDE_DIRECTORIES(${PROJECT_NAME} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
-IF (NOT APPLE AND NOT EMSCRIPTEN)
+IF (NOT APPLE)
     # Linker options for the GDExtension library
     TARGET_LINK_OPTIONS(${PROJECT_NAME} PRIVATE
             $<$<NOT:${compiler_is_msvc}>:
-                -static-libgcc
-                -static-libstdc++
-                -Wl,-R,'$$ORIGIN'
-                $<$<CONFIG:Release>:
-                    $<$<PLATFORM_ID:Android>:-s>
-                >
-            >)
+            -static-libgcc
+            -static-libstdc++
+            -Wl,-R,'$$ORIGIN'
+            >
+    )
 ENDIF ()
 
-IF (AUTOFORMAT_SRC_ON_CONFIGURE MATCHES ON)
+if (AUTOFORMAT_SRC_ON_CONFIGURE MATCHES ON)
     include(clang-format)
 ENDIF ()
 
 # Dependency linking
-TARGET_LINK_LIBRARIES(${PROJECT_NAME} PUBLIC godot-cpp)
+TARGET_LINK_LIBRARIES(${PROJECT_NAME}
+        PUBLIC godot::cpp
+)
 
 SET(GDEXTENSION_LIB_PREFIX "")
-
-### Get useful properties of the library
-get_target_property( GODOTCPP_PLATFORM godot-cpp GODOTCPP_PLATFORM   )
-get_target_property( GODOTCPP_TARGET   godot-cpp GODOTCPP_TARGET     )
-get_target_property( GODOTCPP_ARCH     godot-cpp GODOTCPP_ARCH       )
-
-# Converts GODOT_ARCH to the old system bits for unchanged file names.
-IF (APPLE)
-    SET(ORCHESTRATOR_ARCH "universal")
-ELSEIF(NOT ANDROID AND GODOTCPP_ARCH STREQUAL "arm64")
-    SET(ORCHESTRATOR_ARCH "arm64")
+IF (NOT ANDROID)
+    IF (CMAKE_SIZEOF_VOID_P EQUAL 8)
+        SET(system_bits 64)
+    ELSE ()
+        SET(system_bits 32)
+    ENDIF ()
 ELSE ()
-    MATH( EXPR ORCHESTRATOR_ARCH "${CMAKE_SIZEOF_VOID_P} * 8")
-ENDIF ()
-
-IF (ANDROID)
     SET(GDEXTENSION_LIB_PREFIX "lib")
+    IF (CMAKE_ANDROID_ARCH STREQUAL "arm64")
+        SET(system_bits 64)
+    ELSE ()
+        SET(system_bits 32)
+    ENDIF ()
 ENDIF ()
 
-# Converts GODOTCPP_PLATFORM to ORCHESTRATOR_PLATFORM
-# This handles all android builds as "android" rather than specific platforms
-IF (ANDROID)
-    SET(ORCHESTRATOR_PLATFORM "android")
-ELSE ()
-    SET(ORCHESTRATOR_PLATFORM "${GODOTCPP_PLATFORM}")
-ENDIF ()
+STRING(TOLOWER "${PROJECT_NAME}.${CMAKE_SYSTEM_NAME}.${system_bits}.${CMAKE_BUILD_TYPE}" gde_lib_name)
 
-IF (GODOTCPP_TARGET STREQUAL "template_release")
-    SET(ORCHESTRATOR_TARGET "release")
-ELSEIF (GODOTCPP_TARGET STREQUAL "template_debug")
-    SET(ORCHESTRATOR_TARGET "debug")
-ELSE ()
-    SET(ORCHESTRATOR_TARGET "${GODOTCPP_TARGET}")
-ENDIF ()
+# Generate library resource
+IF(WIN32)
+    SET(win32_product_name "${RESOLVED_VERSION_NAME}")
+    SET(win32_file_version "${PROJECT_VERSION_MAJOR},${PROJECT_VERSION_MINOR},${PROJECT_VERSION_PATCH},0")
+    SET(win32_product_version "${PROJECT_VERSION_MAJOR},${PROJECT_VERSION_MINOR},${PROJECT_VERSION_PATCH},0")
+    SET(win32_file_description "Godot ${win32_product_name}")
+    CONFIGURE_FILE(cmake/windows.rc.in ${CMAKE_CURRENT_BINARY_DIR}/_generated/version.rc @ONLY)
+ENDIF()
+
+IF (WIN32)
+    LIST(APPEND gdext_sources "${CMAKE_CURRENT_BINARY_DIR}/_generated/version.rc")
+ENDIF()
 
 SET_TARGET_PROPERTIES(${PROJECT_NAME}
         PROPERTIES
@@ -230,27 +212,8 @@ SET_TARGET_PROPERTIES(${PROJECT_NAME}
         RUNTIME_OUTPUT_DIRECTORY "${GDEXTENSION_LIB_PATH}"
         CMAKE_PDB_OUTPUT_DIRECTORY "${GDEXTENSION_LIB_PATH}"
         CMAKE_COMPILE_PDB_OUTPUT_DIRECTORY "${GDEXTENSION_LIB_PATH}"
-        OUTPUT_NAME "${PROJECT_NAME}.${ORCHESTRATOR_PLATFORM}.${ORCHESTRATOR_ARCH}.${ORCHESTRATOR_TARGET}")
-
-IF (EMSCRIPTEN)
-    SET(ORCHESTRATOR_WEB_OUTPUT_NAME "${PROJECT_NAME}.${ORCHESTRATOR_PLATFORM}.${ORCHESTRATOR_TARGET}.wasm32")
-    IF (NOT GODOTCPP_THREADS)
-        SET(ORCHESTRATOR_WEB_OUTPUT_NAME "${ORCHESTRATOR_WEB_OUTPUT_NAME}.nothreads")
-    ENDIF ()
-    SET_TARGET_PROPERTIES(${PROJECT_NAME} PROPERTIES SUFFIX ".wasm")
-    SET_TARGET_PROPERTIES(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "${ORCHESTRATOR_WEB_OUTPUT_NAME}")
-ENDIF()
+        OUTPUT_NAME "${gde_lib_name}"
+)
 
 INCLUDE(cmake-utils)
-
 PRINT_PROJECT_VARIABLES()
-
-# For any local development or user tasks, a "CMakeUserLists.txt" file can be included in the
-# root of the project. This file can include any additional local development items, such as
-# copying build files to test projects, etc.
-#
-# This is not included in version control on purpose, as this is user environment driven.
-#
-IF (EXISTS "${CMAKE_SOURCE_DIR}/CMakeUserLists.txt")
-    INCLUDE("${CMAKE_SOURCE_DIR}/CMakeUserLists.txt")
-ENDIF ()


### PR DESCRIPTION
Fixes #447 - Currently hard set to doubles for testing, needs a better design for how to release.