### PR TITLE
GH-58 Initial support for undo/redo

### DIFF
--- a/src/editor/component_panels/component_panel.h
+++ b/src/editor/component_panels/component_panel.h
@@ -117,6 +117,10 @@ protected:
     /// @return the HBoxContainer child of the top panel, never null
     HBoxContainer* _get_panel_hbox() const { return _panel_hbox; }
 
+    /// Specifies whether remove can be undone.
+    /// @return true if the remove can be undone, false otherwise.
+    virtual bool _can_remove_be_undone() const { return false; }
+
     /// Get the prefix used for creating new elements
     /// @return the new unique name prefix
     virtual String _get_unique_name_prefix() const { return "item"; }
@@ -159,10 +163,21 @@ protected:
     /// Handles when an item is selected
     virtual void _handle_item_selected() { }
 
+    /// Returns whether an item can be renamed
+    /// @param p_old_name the old name
+    /// @param p_new_name the new name
+    /// @return true if the rename can be applied, false otherwise
+    virtual bool _can_be_renamed(const String& p_old_name, const String& p_new_name) { return false; }
+
+    /// Renames an item
+    /// @param p_old_name the old name
+    /// @param p_new_name the new name
+    void _rename_item(const String& p_old_name, const String& p_new_name) { _handle_item_renamed(p_old_name, p_new_name); }
+
     /// Handles when an item is renamed
     /// @param p_old_name the old name
     /// @param p_new_name the new name
-    virtual bool _handle_item_renamed(const String& p_old_name, const String& p_new_name) { return false; }
+    virtual void _handle_item_renamed(const String& p_old_name, const String& p_new_name) { }
 
     /// Handles the removal of the item
     /// @param p_item the tree item to be removed

--- a/src/editor/component_panels/functions_panel.cpp
+++ b/src/editor/component_panels/functions_panel.cpp
@@ -152,7 +152,7 @@ void OrchestratorScriptFunctionsComponentPanel::_handle_item_activated(TreeItem*
     _show_function_graph(p_item);
 }
 
-bool OrchestratorScriptFunctionsComponentPanel::_handle_item_renamed(const String& p_old_name, const String& p_new_name)
+bool OrchestratorScriptFunctionsComponentPanel::_can_be_renamed(const String& p_old_name, const String& p_new_name)
 {
     if (_get_existing_names().has(p_new_name))
     {
@@ -160,9 +160,13 @@ bool OrchestratorScriptFunctionsComponentPanel::_handle_item_renamed(const Strin
         return false;
     }
 
+    return true;
+}
+
+void OrchestratorScriptFunctionsComponentPanel::_handle_item_renamed(const String& p_old_name, const String& p_new_name)
+{
     _orchestration->rename_function(p_old_name, p_new_name);
     emit_signal("graph_renamed", p_old_name, p_new_name);
-    return true;
 }
 
 void OrchestratorScriptFunctionsComponentPanel::_handle_remove(TreeItem* p_item)

--- a/src/editor/component_panels/functions_panel.h
+++ b/src/editor/component_panels/functions_panel.h
@@ -47,7 +47,8 @@ protected:
     bool _handle_add_new_item(const String& p_name) override;
     void _handle_item_selected() override;
     void _handle_item_activated(TreeItem* p_item) override;
-    bool _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
+    bool _can_be_renamed(const String& p_old_name, const String& p_new_name) override;
+    void _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
     void _handle_remove(TreeItem* p_item) override;
     void _handle_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button) override;
     Dictionary _handle_drag_data(const Vector2& p_position) override;

--- a/src/editor/component_panels/graphs_panel.cpp
+++ b/src/editor/component_panels/graphs_panel.cpp
@@ -176,17 +176,20 @@ void OrchestratorScriptGraphsComponentPanel::_handle_item_activated(TreeItem* p_
         _focus_graph_function(p_item);
 }
 
-bool OrchestratorScriptGraphsComponentPanel::_handle_item_renamed(const String& p_old_name, const String& p_new_name)
+bool OrchestratorScriptGraphsComponentPanel::_can_be_renamed(const String& p_old_name, const String& p_new_name)
 {
     if (_get_existing_names().has(p_new_name))
     {
         _show_notification("A graph with the name '" + p_new_name + "' already exists.");
         return false;
     }
+    return true;
+}
 
+void OrchestratorScriptGraphsComponentPanel::_handle_item_renamed(const String& p_old_name, const String& p_new_name)
+{
     _orchestration->rename_graph(p_old_name, p_new_name);
     emit_signal("graph_renamed", p_old_name, p_new_name);
-    return true;
 }
 
 void OrchestratorScriptGraphsComponentPanel::_handle_remove(TreeItem* p_item)

--- a/src/editor/component_panels/graphs_panel.h
+++ b/src/editor/component_panels/graphs_panel.h
@@ -45,7 +45,8 @@ protected:
     void _handle_context_menu(int p_id) override;
     bool _handle_add_new_item(const String& p_name) override;
     void _handle_item_activated(TreeItem* p_item) override;
-    bool _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
+    bool _can_be_renamed(const String& p_old_name, const String& p_new_name) override;
+    void _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
     void _handle_remove(TreeItem* p_item) override;
     void _handle_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button) override;
     //~ End OrchestratorScriptComponentPanel Interface

--- a/src/editor/component_panels/signals_panel.cpp
+++ b/src/editor/component_panels/signals_panel.cpp
@@ -82,16 +82,19 @@ void OrchestratorScriptSignalsComponentPanel::_handle_item_activated(TreeItem* p
     OrchestratorPlugin::get_singleton()->get_editor_interface()->edit_resource(signal);
 }
 
-bool OrchestratorScriptSignalsComponentPanel::_handle_item_renamed(const String& p_old_name, const String& p_new_name)
+bool OrchestratorScriptSignalsComponentPanel::_can_be_renamed(const String& p_old_name, const String& p_new_name)
 {
     if (_get_existing_names().has(p_new_name))
     {
         _show_notification("A signal with the name '" + p_new_name + "' already exists.");
         return false;
     }
-
-    _orchestration->rename_custom_user_signal(p_old_name, p_new_name);
     return true;
+}
+
+void OrchestratorScriptSignalsComponentPanel::_handle_item_renamed(const String& p_old_name, const String& p_new_name)
+{
+    _orchestration->rename_custom_user_signal(p_old_name, p_new_name);
 }
 
 void OrchestratorScriptSignalsComponentPanel::_handle_remove(TreeItem* p_item)

--- a/src/editor/component_panels/signals_panel.h
+++ b/src/editor/component_panels/signals_panel.h
@@ -42,7 +42,8 @@ protected:
     bool _handle_add_new_item(const String& p_name) override;
     void _handle_item_selected() override;
     void _handle_item_activated(TreeItem* p_item) override;
-    bool _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
+    bool _can_be_renamed(const String& p_old_name, const String& p_new_name) override;
+    void _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
     void _handle_remove(TreeItem* p_item) override;
     Dictionary _handle_drag_data(const Vector2& p_position) override;
     //~ End OrchestratorScriptViewSection Interface

--- a/src/editor/component_panels/variables_panel.h
+++ b/src/editor/component_panels/variables_panel.h
@@ -44,7 +44,8 @@ protected:
     bool _handle_add_new_item(const String& p_name) override;
     void _handle_item_selected() override;
     void _handle_item_activated(TreeItem* p_item) override;
-    bool _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
+    bool _can_be_renamed(const String& p_old_name, const String& p_new_name) override;
+    void _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
     void _handle_remove(TreeItem* p_item) override;
     void _handle_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button) override;
     Dictionary _handle_drag_data(const Vector2& p_position) override;

--- a/src/editor/graph/graph_edit.cpp
+++ b/src/editor/graph/graph_edit.cpp
@@ -39,6 +39,7 @@
 #include <godot_cpp/classes/confirmation_dialog.hpp>
 #include <godot_cpp/classes/display_server.hpp>
 #include <godot_cpp/classes/editor_inspector.hpp>
+#include <godot_cpp/classes/editor_undo_redo_manager.hpp>
 #include <godot_cpp/classes/geometry2d.hpp>
 #include <godot_cpp/classes/input.hpp>
 #include <godot_cpp/classes/input_event_action.hpp>
@@ -280,11 +281,49 @@ void OrchestratorGraphEdit::_bind_methods()
 {
     ClassDB::bind_method(D_METHOD("_synchronize_child_order"), &OrchestratorGraphEdit::_synchronize_child_order);
 
+    // Needed for undo/redo
+    ClassDB::bind_method(D_METHOD("_link", "source", "source_port", "target", "target_port"), &OrchestratorGraphEdit::_link);
+    ClassDB::bind_method(D_METHOD("_unlink", "source", "source_port", "target", "target_port"), &OrchestratorGraphEdit::_unlink);
+
     ADD_SIGNAL(MethodInfo("nodes_changed"));
     ADD_SIGNAL(MethodInfo("focus_requested", PropertyInfo(Variant::OBJECT, "target")));
     ADD_SIGNAL(MethodInfo("collapse_selected_to_function"));
     ADD_SIGNAL(MethodInfo("expand_node", PropertyInfo(Variant::INT, "node_id")));
     ADD_SIGNAL(MethodInfo("validation_requested"));
+}
+
+void OrchestratorGraphEdit::_link(const StringName& p_source, int p_source_port, const StringName& p_target, int p_target_port)
+{
+    if (OrchestratorGraphNode* source = _get_by_name<OrchestratorGraphNode>(p_source))
+    {
+        if (OrchestratorGraphNode* target = _get_by_name<OrchestratorGraphNode>(p_target))
+        {
+            OrchestratorGraphNodePin* source_pin = source->get_output_pin(p_source_port);
+            OrchestratorGraphNodePin* target_pin = target->get_input_pin(p_target_port);
+            if (!source_pin || !target_pin)
+                return;
+
+            // Connect the two pins
+            source_pin->link(target_pin);
+        }
+    }
+}
+
+void OrchestratorGraphEdit::_unlink(const StringName& p_source, int p_source_port, const StringName& p_target, int p_target_port)
+{
+    if (OrchestratorGraphNode* source = _get_by_name<OrchestratorGraphNode>(p_source))
+    {
+        if (OrchestratorGraphNode* target = _get_by_name<OrchestratorGraphNode>(p_target))
+        {
+            OrchestratorGraphNodePin* source_pin = source->get_output_pin(p_source_port);
+            OrchestratorGraphNodePin* target_pin = target->get_input_pin(p_target_port);
+            if (!source_pin || !target_pin)
+                return;
+
+            // Disconnect the two pins
+            source_pin->unlink(target_pin);
+        }
+    }
 }
 
 void OrchestratorGraphEdit::clear_selection()
@@ -1292,42 +1331,24 @@ void OrchestratorGraphEdit::_on_action_menu_action_selected(OrchestratorGraphAct
     p_handler->execute(this, _saved_mouse_position);
 }
 
-void OrchestratorGraphEdit::_on_connection(const StringName& p_from_node, int p_from_port, const StringName& p_to_node,
-                                 int p_to_port)
+void OrchestratorGraphEdit::_on_connection(const StringName& p_from_node, int p_from_port, const StringName& p_to_node, int p_to_port)
 {
     _drag_context.reset();
 
-    if (OrchestratorGraphNode* source = _get_by_name<OrchestratorGraphNode>(p_from_node))
-    {
-        if (OrchestratorGraphNode* target = _get_by_name<OrchestratorGraphNode>(p_to_node))
-        {
-            OrchestratorGraphNodePin* source_pin = source->get_output_pin(p_from_port);
-            OrchestratorGraphNodePin* target_pin = target->get_input_pin(p_to_port);
-            if (!source_pin || !target_pin)
-                return;
-
-            // Connect the two pins
-            source_pin->link(target_pin);
-        }
-    }
+    EditorUndoRedoManager* undo = OrchestratorPlugin::get_singleton()->get_undo_redo();
+    undo->create_action("Orchestration: Connect nodes");
+    undo->add_do_method(this, "_link", p_from_node, p_from_port, p_to_node, p_to_port);
+    undo->add_undo_method(this, "_unlink", p_from_node, p_from_port, p_to_node, p_to_port);
+    undo->commit_action();
 }
 
-void OrchestratorGraphEdit::_on_disconnection(const StringName& p_from_node, int p_from_port, const StringName& p_to_node,
-                                    int p_to_port)
+void OrchestratorGraphEdit::_on_disconnection(const StringName& p_from_node, int p_from_port, const StringName& p_to_node, int p_to_port)
 {
-    if (OrchestratorGraphNode* source = _get_by_name<OrchestratorGraphNode>(p_from_node))
-    {
-        if (OrchestratorGraphNode* target = _get_by_name<OrchestratorGraphNode>(p_to_node))
-        {
-            OrchestratorGraphNodePin* source_pin = source->get_output_pin(p_from_port);
-            OrchestratorGraphNodePin* target_pin = target->get_input_pin(p_to_port);
-            if (!source_pin || !target_pin)
-                return;
-
-            // Disconnect the two pins
-            source_pin->unlink(target_pin);
-        }
-    }
+    EditorUndoRedoManager* undo = OrchestratorPlugin::get_singleton()->get_undo_redo();
+    undo->create_action("Orchestration: Disconnect nodes");
+    undo->add_do_method(this, "_unlink", p_from_node, p_from_port, p_to_node, p_to_port);
+    undo->add_undo_method(this, "_link", p_from_node, p_from_port, p_to_node, p_to_port);
+    undo->commit_action();
 }
 
 void OrchestratorGraphEdit::_on_attempt_connection_from_empty(const StringName& p_to_node, int p_to_port, const Vector2& p_position)

--- a/src/editor/graph/graph_edit.h
+++ b/src/editor/graph/graph_edit.h
@@ -141,6 +141,9 @@ class OrchestratorGraphEdit : public GraphEdit
 protected:
     static void _bind_methods();
 
+    void _link(const StringName& p_source, int p_source_port, const StringName& p_target, int p_target_port);
+    void _unlink(const StringName& p_source, int p_source_port, const StringName& p_target, int p_target_port);
+
 public:
     // The OrchestratorGraphEdit maintains a static clipboard so that data can be shared across different graph
     // instances easily in the tab view, and so these methods are called by the MainView during the

--- a/src/editor/graph/graph_node.h
+++ b/src/editor/graph/graph_node.h
@@ -220,7 +220,7 @@ private:
     /// Called when the graph node is moved
     /// @param p_old_pos old position
     /// @param p_new_pos new position
-    void _on_node_moved(Vector2 p_old_pos, Vector2 p_new_pos);
+    void _on_node_moved(const Vector2 p_old_pos, const Vector2 p_new_pos);
 
     /// Called when the graph node is resized
     void _on_node_resized();

--- a/src/editor/graph/pins/graph_node_pin_bool.h
+++ b/src/editor/graph/pins/graph_node_pin_bool.h
@@ -19,6 +19,8 @@
 
 #include "editor/graph/graph_node_pin.h"
 
+#include <godot_cpp/classes/check_box.hpp>
+
 /// An implementation of OrchestratorGraphNodePin for boolean pin types that provides a check-box
 /// to represent the default value associated with the pin.
 class OrchestratorGraphNodePinBool : public OrchestratorGraphNodePin
@@ -28,6 +30,8 @@ class OrchestratorGraphNodePinBool : public OrchestratorGraphNodePin
     static void _bind_methods();
 
 protected:
+    CheckBox* _check_box{ nullptr };
+
     OrchestratorGraphNodePinBool() = default;
 
     /// Called when the default value is changed in the UI.

--- a/src/editor/graph/pins/graph_node_pin_color.h
+++ b/src/editor/graph/pins/graph_node_pin_color.h
@@ -19,6 +19,8 @@
 
 #include "editor/graph/graph_node_pin.h"
 
+#include <godot_cpp/classes/color_picker_button.hpp>
+
 /// An implementation of OrchestratorGraphNodePin for color types, offering a color picker button
 /// that opens a color dialog that the user can interact with.
 class OrchestratorGraphNodePinColor : public OrchestratorGraphNodePin
@@ -28,6 +30,8 @@ class OrchestratorGraphNodePinColor : public OrchestratorGraphNodePin
     static void _bind_methods();
 
 protected:
+    ColorPickerButton* _button{ nullptr };
+
     OrchestratorGraphNodePinColor() = default;
 
     /// Called when the default value is changed in the UI.

--- a/src/editor/graph/pins/graph_node_pin_enum.h
+++ b/src/editor/graph/pins/graph_node_pin_enum.h
@@ -42,12 +42,12 @@ class OrchestratorGraphNodePinEnum : public OrchestratorGraphNodePin
     };
 
 protected:
+    OptionButton* _button{ nullptr };
     List<ListItem> _items; //! All the items that are in the drop-down list
 
     /// Dispatched when the user makes a selection.
     /// @param p_index the choice index that was selected
-    /// @param p_button the button widget
-    void _on_item_selected(int p_index, OptionButton* p_button);
+    void _on_item_selected(int p_index);
 
     /// Generate the list of items for the drop-down
     void _generate_items();

--- a/src/editor/graph/pins/graph_node_pin_file.h
+++ b/src/editor/graph/pins/graph_node_pin_file.h
@@ -36,7 +36,8 @@ class OrchestratorGraphNodePinFile : public OrchestratorGraphNodePin
     static void _bind_methods();
 
 protected:
-    Button* _clear_button;
+    Button* _file_button{ nullptr };
+    Button* _clear_button{ nullptr };
 
     OrchestratorGraphNodePinFile() = default;
 
@@ -48,23 +49,19 @@ protected:
     String _get_default_text() const;
 
     /// Dispatched when the clear button is clicked
-    /// @param p_button the button control, should not be null
-    void _on_clear_file(Button* p_button);
+    void _on_clear_file();
 
     /// Dispatched when the button is clicked
-    /// @param p_button the button control, should not be null
-    void _on_show_file_dialog(Button* p_button);
+    void _on_show_file_dialog();
 
     /// Dispatched when a file is selected
     /// @param p_file_name the selected file
     /// @param p_dialog the file dialog, should not be null
-    /// @param p_button the button control, should not be null
-    void _on_file_selected(const String& p_file_name, FileDialog* p_dialog, Button* p_button);
+    void _on_file_selected(const String& p_file_name, FileDialog* p_dialog);
 
     /// Dispatched when the file dialog window is closed or cancelled
     /// @param p_dialog the file dialog, should not be null
-    /// @param p_button the button control, should not be null
-    void _on_file_canceled(FileDialog* p_dialog, Button* p_button);
+    void _on_file_canceled(FileDialog* p_dialog);
 
 public:
     OrchestratorGraphNodePinFile(OrchestratorGraphNode* p_node, const Ref<OScriptNodePin>& p_pin);

--- a/src/editor/graph/pins/graph_node_pin_numeric.h
+++ b/src/editor/graph/pins/graph_node_pin_numeric.h
@@ -19,10 +19,7 @@
 
 #include "editor/graph/graph_node_pin.h"
 
-namespace godot
-{
-    class LineEdit;
-}
+#include <godot_cpp/classes/line_edit.hpp>
 
 /// An implementation of OrchestratorGraphNodePin for types that want to represent their default values
 /// using a string-based text field for numeric data entry.
@@ -33,6 +30,8 @@ class OrchestratorGraphNodePinNumeric : public OrchestratorGraphNodePin
     static void _bind_methods();
 
 protected:
+    LineEdit* _line_edit{ nullptr };
+
     OrchestratorGraphNodePinNumeric() = default;
 
     /// Sets the default value.
@@ -42,12 +41,10 @@ protected:
 
     /// Called when the user hits "ENTER" in the line edit widget.
     /// @param p_value the submitted value
-    /// @param p_line_edit the line edit widget
-    void _on_text_submitted(const String& p_value, LineEdit* p_line_edit);
+    void _on_text_submitted(const String& p_value);
 
     /// Called when focus is lost on the line edit widget.
-    /// @param p_line_edit the line edit widget
-    void _on_focus_lost(const LineEdit* p_line_edit);
+    void _on_focus_lost();
 
     //~ Begin OrchestratorGraphNodePin Interface
     Control* _get_default_value_widget() override;

--- a/src/editor/graph/pins/graph_node_pin_string.cpp
+++ b/src/editor/graph/pins/graph_node_pin_string.cpp
@@ -16,6 +16,9 @@
 //
 #include "graph_node_pin_string.h"
 
+#include "editor/plugins/orchestrator_editor_plugin.h"
+
+#include <godot_cpp/classes/editor_undo_redo_manager.hpp>
 #include <godot_cpp/classes/line_edit.hpp>
 #include <godot_cpp/classes/text_edit.hpp>
 
@@ -30,60 +33,74 @@ void OrchestratorGraphNodePinString::_bind_methods()
 
 void OrchestratorGraphNodePinString::_set_default_value(const String& p_value)
 {
-    _pin->set_default_value(p_value);
-}
-
-void OrchestratorGraphNodePinString::_on_text_changed(TextEdit* p_text_edit)
-{
-    if (p_text_edit)
-        _set_default_value(p_text_edit->get_text());
-}
-
-void OrchestratorGraphNodePinString::_on_text_submitted(const String& p_value, LineEdit* p_line_edit)
-{
-    if (p_line_edit)
+    if (_pin->get_effective_default_value() != p_value)
     {
-        _set_default_value(p_line_edit->get_text());
-        p_line_edit->release_focus();
+        if (_pin->is_multiline_text())
+        {
+            // TextEdit reacts weirdly with UndoRedo - for now skipped.
+            _pin->set_default_value(p_value);
+        }
+        else
+        {
+            EditorUndoRedoManager* undo = OrchestratorPlugin::get_singleton()->get_undo_redo();
+            undo->create_action("Orchestration: Change string pin");
+            undo->add_do_method(_pin.ptr(), "set_default_value", p_value);
+            undo->add_do_method(_line_edit, "set_text", p_value);
+            undo->add_undo_method(_pin.ptr(), "set_default_value", _pin->get_effective_default_value());
+            undo->add_undo_method(_line_edit, "set_text", _pin->get_effective_default_value());
+            undo->commit_action();
+        }
     }
 }
 
-void OrchestratorGraphNodePinString::_on_focus_lost(LineEdit* p_line_edit)
+void OrchestratorGraphNodePinString::_on_text_changed()
 {
-    if (p_line_edit)
-        _set_default_value(p_line_edit->get_text());
+    if (_text_edit)
+        _set_default_value(_text_edit->get_text());
+}
+
+void OrchestratorGraphNodePinString::_on_text_submitted(const String& p_value)
+{
+    if (_line_edit)
+    {
+        _set_default_value(p_value);
+        _line_edit->release_focus();
+    }
+}
+
+void OrchestratorGraphNodePinString::_on_focus_lost()
+{
+    if (_line_edit)
+        _set_default_value(_line_edit->get_text());
 }
 
 Control* OrchestratorGraphNodePinString::_get_default_value_widget()
 {
     if (_pin->is_multiline_text())
     {
-        TextEdit* text_edit = memnew(TextEdit);
-        text_edit->set_placeholder("No value...");
-        text_edit->set_h_size_flags(Control::SIZE_EXPAND);
-        text_edit->set_v_size_flags(Control::SIZE_EXPAND);
-        text_edit->set_h_grow_direction(Control::GROW_DIRECTION_END);
-        text_edit->set_custom_minimum_size(Vector2(350, 0));
-        text_edit->set_text(_pin->get_effective_default_value());
-        text_edit->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
-        text_edit->set_line_wrapping_mode(TextEdit::LINE_WRAPPING_BOUNDARY);
-        text_edit->set_fit_content_height_enabled(true);
-        text_edit->connect("text_changed",
-                           callable_mp(this, &OrchestratorGraphNodePinString::_on_text_changed).bind(text_edit));
-        return text_edit;
+        _text_edit = memnew(TextEdit);
+        _text_edit->set_placeholder("No value...");
+        _text_edit->set_h_size_flags(Control::SIZE_EXPAND);
+        _text_edit->set_v_size_flags(Control::SIZE_EXPAND);
+        _text_edit->set_h_grow_direction(Control::GROW_DIRECTION_END);
+        _text_edit->set_custom_minimum_size(Vector2(350, 0));
+        _text_edit->set_text(_pin->get_effective_default_value());
+        _text_edit->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
+        _text_edit->set_line_wrapping_mode(TextEdit::LINE_WRAPPING_BOUNDARY);
+        _text_edit->set_fit_content_height_enabled(true);
+        _text_edit->connect("text_changed", callable_mp(this, &OrchestratorGraphNodePinString::_on_text_changed));
+        return _text_edit;
     }
 
-    LineEdit* line_edit = memnew(LineEdit);
-    line_edit->set_custom_minimum_size(Vector2(30, 0));
-    line_edit->set_expand_to_text_length_enabled(true);
-    line_edit->set_h_size_flags(Control::SIZE_EXPAND);
-    line_edit->set_text(_pin->get_effective_default_value());
-    line_edit->set_select_all_on_focus(true);
-    line_edit->connect("text_submitted",
-                       callable_mp(this, &OrchestratorGraphNodePinString::_on_text_submitted).bind(line_edit));
-    line_edit->connect("focus_exited",
-                       callable_mp(this, &OrchestratorGraphNodePinString::_on_focus_lost).bind(line_edit));
-    return line_edit;
+    _line_edit = memnew(LineEdit);
+    _line_edit->set_custom_minimum_size(Vector2(30, 0));
+    _line_edit->set_expand_to_text_length_enabled(true);
+    _line_edit->set_h_size_flags(Control::SIZE_EXPAND);
+    _line_edit->set_text(_pin->get_effective_default_value());
+    _line_edit->set_select_all_on_focus(true);
+    _line_edit->connect("text_submitted", callable_mp(this, &OrchestratorGraphNodePinString::_on_text_submitted));
+    _line_edit->connect("focus_exited", callable_mp(this, &OrchestratorGraphNodePinString::_on_focus_lost));
+    return _line_edit;
 }
 
 bool OrchestratorGraphNodePinString::_render_default_value_below_label() const

--- a/src/editor/graph/pins/graph_node_pin_string.h
+++ b/src/editor/graph/pins/graph_node_pin_string.h
@@ -19,11 +19,8 @@
 
 #include "editor/graph/graph_node_pin.h"
 
-namespace godot
-{
-    class LineEdit;
-    class TextEdit;
-}
+#include <godot_cpp/classes/line_edit.hpp>
+#include <godot_cpp/classes/text_edit.hpp>
 
 /// An implementation of OrchestratorGraphNodePin for types that want to represent their default values
 /// using a string-based text field for data entry.
@@ -34,6 +31,9 @@ class OrchestratorGraphNodePinString : public OrchestratorGraphNodePin
     static void _bind_methods();
 
 protected:
+    TextEdit* _text_edit{ nullptr };
+    LineEdit* _line_edit{ nullptr };
+
     OrchestratorGraphNodePinString() = default;
 
     /// Sets the default value on the pin
@@ -41,17 +41,14 @@ protected:
     void _set_default_value(const String& p_value);
 
     /// Called when the text edit's (multi-line text) text changes
-    /// @param p_text_edit the text edit widget
-    void _on_text_changed(TextEdit* p_text_edit);
+    void _on_text_changed();
 
     /// Called when the line edit's text submitted handler.
     /// @param p_value the text value submitted
-    /// @param p_line_edit the line edit widget
-    void _on_text_submitted(const String& p_value, LineEdit* p_line_edit);
+    void _on_text_submitted(const String& p_value);
 
     /// Called when focus is lost on the line edit widget.
-    /// @param p_line_edit the line edit widget
-    void _on_focus_lost(LineEdit* p_line_edit);
+    void _on_focus_lost();
 
     //~ Begin OrchestratorGraphNodePin Interface
     Control* _get_default_value_widget() override;

--- a/src/editor/graph/pins/graph_node_pin_struct.h
+++ b/src/editor/graph/pins/graph_node_pin_struct.h
@@ -33,6 +33,10 @@ class OrchestratorGraphNodePinStruct : public OrchestratorGraphNodePin
 
     Vector<LineEdit*> _edits;   //! Line edits for each sub-component
 
+    /// Sets the value in the pin edits
+    /// @param p_value
+    void _set_ui_value(const Variant& p_value);
+
     /// Calculates the number of grid columns for the pin type
     /// @param p_type the pin type
     /// @return the number of grid columns

--- a/src/script/node.cpp
+++ b/src/script/node.cpp
@@ -111,7 +111,11 @@ void OScriptNode::set_size(const Vector2& p_size)
 
 void OScriptNode::set_position(const Vector2& p_position)
 {
-    _position = p_position;
+    if (_position != p_position)
+    {
+        _position = p_position;
+        emit_changed();
+    }
 }
 
 #if GODOT_VERSION >= 0x040300

--- a/src/script/node_pin.cpp
+++ b/src/script/node_pin.cpp
@@ -25,6 +25,10 @@
 
 void OScriptNodePin::_bind_methods()
 {
+    // Needed for undo/redo
+    ClassDB::bind_method(D_METHOD("set_default_value", "value"), &OScriptNodePin::set_default_value);
+    ClassDB::bind_method(D_METHOD("get_default_value"), &OScriptNodePin::get_default_value);
+
     BIND_ENUM_CONSTANT(EPinDirection::PD_Input)
     BIND_ENUM_CONSTANT(EPinDirection::PD_Output)
     BIND_ENUM_CONSTANT(EPinDirection::PD_MAX)
@@ -342,7 +346,7 @@ void OScriptNodePin::set_default_value(const Variant& p_default_value)
         {
             set_block_signals(true);
             node->pin_default_value_changed(Ref<OScriptNodePin>(this));
-            set_block_signals(true);
+            set_block_signals(false);
         }
         emit_changed();
     }


### PR DESCRIPTION
Fixes #58 

This PR currently supported the following undo/redo operations:

* Moving nodes
* Changing pin default values
* Connect and disconnect pins
* Renaming components (graphs, functions, variables, signals)
* Changing the Orchestration base type
* Export variable toggle in component panel
* Inspector changes already supported by Godot