### PR TITLE
GH-724 Fix copy-n-paste between two orchestrations

### DIFF
--- a/src/common/method_utils.h
+++ b/src/common/method_utils.h
@@ -55,6 +55,12 @@ namespace MethodUtils
     /// @param p_method the method
     /// @return the number of arguments that have no default values
     size_t get_argument_count_without_defaults(const MethodInfo& p_method);
+
+    //// Checks whether two <code>MethodInfo</code> structures have the same structures
+    /// @param p_method_a the left method structure
+    /// @param p_method_b the right method structure
+    /// @return true if the method structures are the same, false otherwise
+    bool has_same_signature(const MethodInfo& p_method_a, const MethodInfo& p_method_b);
 }
 
 #endif // ORCHESTRATOR_METHOD_UTILS_H

--- a/src/editor/graph/graph_edit.cpp
+++ b/src/editor/graph/graph_edit.cpp
@@ -20,7 +20,9 @@
 #include "common/callable_lambda.h"
 #include "common/dictionary_utils.h"
 #include "common/logger.h"
+#include "common/method_utils.h"
 #include "common/name_utils.h"
+#include "common/property_utils.h"
 #include "common/scene_utils.h"
 #include "common/settings.h"
 #include "common/string_utils.h"
@@ -2016,26 +2018,76 @@ void OrchestratorGraphEdit::_on_copy_nodes_request()
 {
     _clipboard->reset();
 
-    for_each_graph_node([&](OrchestratorGraphNode* node) {
-        if (node->is_selected())
+    const Vector<Ref<OScriptNode>> selected = get_selected_script_nodes();
+    if (selected.is_empty())
+    {
+        _notify("No nodes selected, nothing copied to clipboard.", "Clipboard error");
+        return;
+    }
+
+    // Check if any selected nodes cannot be copied, showing message if not.
+    for (const Ref<OScriptNode>& node : selected)
+    {
+        if (!node->can_duplicate())
         {
-            Ref<OScriptNode> script_node = node->get_script_node();
-
-            if (!script_node->can_duplicate())
-            {
-                WARN_PRINT_ONCE_ED("There are some nodes that cannot be copied, they were not placed on the clipboard.");
-                return;
-            }
-
-            const int id = script_node->get_id();
-            _clipboard->positions[id] = script_node->get_position();
-            _clipboard->nodes[id] = _script_graph->copy_node(id, true);
+            _notify(vformat("Cannot duplicate node '%s' (%d).", node->get_node_title(), node->get_id()), "Clipboard error");
+            return;
         }
-    });
+    }
 
+    // Local cache of copied objects
+    // Prevents creating multiple instances on paste of the same function, variable, or signal
+    RBSet<Ref<OScriptFunction>> functions_cache;
+    RBSet<Ref<OScriptVariable>> variables_cache;
+    RBSet<Ref<OScriptSignal>> signals_cache;
+
+    // Perform copy to clipboard
+    for (const Ref<OScriptNode>& node : selected)
+    {
+        const Ref<OScriptNodeCallScriptFunction> call_function_node = node;
+        if (call_function_node.is_valid())
+        {
+            const Ref<OScriptFunction> function = call_function_node->get_function();
+            if (!functions_cache.has(function))
+            {
+                functions_cache.insert(function);
+                _clipboard->functions.insert(function->duplicate());
+            }
+        }
+
+        const Ref<OScriptNodeVariable> variable_node = node;
+        if (variable_node.is_valid())
+        {
+            const Ref<OScriptVariable> variable = variable_node->get_variable();
+            if (!variables_cache.has(variable))
+            {
+                variables_cache.insert(variable);
+                _clipboard->variables.insert(variable->duplicate());
+            }
+        }
+
+        const Ref<OScriptNodeEmitSignal> emit_signal_node = node;
+        if (emit_signal_node.is_valid())
+        {
+            const Ref<OScriptSignal> signal = emit_signal_node->get_signal();
+            if (!signals_cache.has(signal))
+            {
+                signals_cache.insert(signal);
+                _clipboard->signals.insert(signal->duplicate());
+            }
+        }
+
+        const int node_id = node->get_id();
+        _clipboard->positions[node_id] = node->get_position();
+        _clipboard->nodes[node_id] = _script_graph->copy_node(node_id, true);
+    }
+
+    // Connections between pasted nodes, copy connections
     for (const OScriptConnection& E : get_orchestration()->get_connections())
+    {
         if (_clipboard->nodes.has(E.from_node) && _clipboard->nodes.has(E.to_node))
             _clipboard->connections.insert(E);
+    }
 }
 
 void OrchestratorGraphEdit::_on_cut_nodes_request()
@@ -2105,15 +2157,97 @@ void OrchestratorGraphEdit::_on_paste_nodes_request()
     if (_clipboard->is_empty())
         return;
 
-    Vector<int> duplications;
-    RBSet<Vector2> existing_positions;
-    for (const KeyValue<int, Vector2>& E : _clipboard->positions)
+    Orchestration* orchestration = _script_graph->get_orchestration();
+
+    // Iterate copied function declarations and assert if paste is invalid
+    // Functions are unique in that we do not clone their nodes or structure, so the function must exist
+    // in the target orchestration with the same signature for the paste to be valid.
+    for (const Ref<OScriptFunction>& E : _clipboard->functions)
     {
-        existing_positions.insert(E.value.snapped(Vector2(2, 2)));
-        duplications.push_back(E.key);
+        if (!orchestration->has_function(E->get_function_name()))
+        {
+            _notify(vformat("Function '%s' does not exist in this orchestration.", E->get_function_name()), "Clipboard error");
+            return;
+        }
+
+        // Exists, verify if its identical
+        const Ref<OScriptFunction> other = orchestration->find_function(E->get_function_name());
+        if (!MethodUtils::has_same_signature(E->get_method_info(), other->get_method_info()))
+        {
+            _notify(vformat("Function '%s' exists with a different definition.", E->get_function_name()), "Clipboard error");
+            return;
+        }
     }
 
-    Vector2 mouse_up_position = get_screen_position() + get_local_mouse_position();
+    // Iterate copied variable declarations and assert if paste is invalid
+    Vector<Ref<OScriptVariable>> variables_to_create;
+    for (const Ref<OScriptVariable>& E : _clipboard->variables)
+    {
+        if (!orchestration->has_variable(E->get_variable_name()))
+        {
+            variables_to_create.push_back(E);
+            continue;
+        }
+
+        // Exists, verify if its identical
+        const Ref<OScriptVariable> other = orchestration->get_variable(E->get_variable_name());
+        if (!PropertyUtils::are_equal(E->get_info(), other->get_info()))
+        {
+            _notify(vformat("Variable '%s' exists with a different definition.", E->get_variable_name()), "Clipboard error");
+            return;
+        }
+    }
+
+    // Iterate copied signal declarations and assert if paste is invalid
+    Vector<Ref<OScriptSignal>> signals_to_create;
+    for (const Ref<OScriptSignal>& E : _clipboard->signals)
+    {
+        if (!orchestration->has_custom_signal(E->get_signal_name()))
+        {
+            signals_to_create.push_back(E);
+            continue;
+        }
+
+        // When signal exists, verify whether the signal has the same signature and fail if it doesn't.
+        const Ref<OScriptSignal> other = orchestration->get_custom_signal(E->get_signal_name());
+        if (!MethodUtils::has_same_signature(E->get_method_info(), other->get_method_info()))
+        {
+            _notify(vformat("Signal '%s' exists with a different definition.", E->get_signal_name()), "Clipboard error");
+            return;
+        }
+    }
+
+    for (const KeyValue<int, Ref<OScriptNode>>& E : _clipboard->nodes)
+    {
+        const Ref<OScriptNodeCallScriptFunction> call_script_function_node = E.value;
+        if (call_script_function_node.is_valid())
+        {
+            const StringName function_name = call_script_function_node->get_function()->get_function_name();
+            const Ref<OScriptFunction> this_function = get_orchestration()->find_function(function_name);
+            if (this_function.is_valid())
+            {
+                // Since source OScriptFunction matches this OScriptFunction declaration, copy the
+                // GUID from this orchestrations script function and set it on the node
+                call_script_function_node->set("guid", this_function->get_guid().to_string());
+            }
+        }
+    }
+
+    // Iterate variables to be created
+    for (const Ref<OScriptVariable>& E : variables_to_create)
+    {
+        Ref<OScriptVariable> new_variable = orchestration->create_variable(E->get_variable_name());
+        new_variable->copy_persistent_state(E);
+    }
+
+    // Iterate signals to be created
+    for (const Ref<OScriptSignal>& E : signals_to_create)
+    {
+        Ref<OScriptSignal> new_signal = orchestration->create_custom_signal(E->get_signal_name());
+        new_signal->copy_persistent_state(E);
+    }
+
+    const Vector2 mouse_up_position = get_screen_position() + get_local_mouse_position();
     Vector2 position_offset = (get_scroll_offset() + (mouse_up_position - get_screen_position())) / get_zoom();
     if (is_snapping_enabled())
     {
@@ -2146,6 +2280,8 @@ void OrchestratorGraphEdit::_on_paste_nodes_request()
         if (OrchestratorGraphNode* node = _get_node_by_id(selected_id))
             node->set_selected(true);
     }
+
+    emit_signal("nodes_changed");
 }
 
 void OrchestratorGraphEdit::_on_script_changed()

--- a/src/editor/graph/graph_edit.h
+++ b/src/editor/graph/graph_edit.h
@@ -19,7 +19,10 @@
 
 #include "actions/action_menu.h"
 #include "common/version.h"
-#include "graph_node.h"
+#include "editor/graph/graph_node.h"
+#include "script/function.h"
+#include "script/signals.h"
+#include "script/variable.h"
 
 #include <functional>
 
@@ -98,6 +101,9 @@ class OrchestratorGraphEdit : public GraphEdit
         HashMap<int, Ref<OScriptNode>> nodes;
         HashMap<int, Vector2> positions;
         RBSet<OScriptConnection> connections;
+        RBSet<Ref<OScriptFunction>> functions;
+        RBSet<Ref<OScriptVariable>> variables;
+        RBSet<Ref<OScriptSignal>> signals;
 
         /// Returns whether the clipboard is empty
         bool is_empty() const
@@ -111,6 +117,9 @@ class OrchestratorGraphEdit : public GraphEdit
             nodes.clear();
             positions.clear();
             connections.clear();
+            signals.clear();
+            variables.clear();
+            functions.clear();
         }
     };
 

--- a/src/script/nodes/signals/emit_signal.cpp
+++ b/src/script/nodes/signals/emit_signal.cpp
@@ -16,6 +16,7 @@
 //
 #include "emit_signal.h"
 
+#include "common/macros.h"
 #include "common/property_utils.h"
 #include "common/variant_utils.h"
 
@@ -182,7 +183,7 @@ void OScriptNodeEmitSignal::post_placed_new_node()
     super::post_placed_new_node();
 
     if (_signal.is_valid() && _is_in_editor())
-        _signal->connect("changed", callable_mp(this, &OScriptNodeEmitSignal::_on_signal_changed));
+        OCONNECT(_signal, "changed", callable_mp(this, &OScriptNodeEmitSignal::_on_signal_changed));
 }
 
 void OScriptNodeEmitSignal::allocate_default_pins()

--- a/src/script/nodes/variables/variable_set.cpp
+++ b/src/script/nodes/variables/variable_set.cpp
@@ -133,7 +133,7 @@ String OScriptNodeVariableSet::get_tooltip_text() const
 
 String OScriptNodeVariableSet::get_node_title() const
 {
-    return vformat("Set %s", _variable->get_variable_name());
+    return vformat("Set %s", _variable_name);
 }
 
 void OScriptNodeVariableSet::reallocate_pins_during_reconstruction(const Vector<Ref<OScriptNodePin>>& p_old_pins)

--- a/src/script/signals.cpp
+++ b/src/script/signals.cpp
@@ -119,3 +119,10 @@ size_t OScriptSignal::get_argument_count() const
     return _method.arguments.size();
 }
 
+void OScriptSignal::copy_persistent_state(const Ref<OScriptSignal>& p_other)
+{
+    _method = p_other->_method;
+
+    notify_property_list_changed();
+    emit_changed();
+}

--- a/src/script/signals.h
+++ b/src/script/signals.h
@@ -72,6 +72,10 @@ public:
     /// Get the number of function arguments
     /// @return the number of arguments
     size_t get_argument_count() const;
+
+    /// Copy the persistent state from one signal to this signal
+    /// @param p_other the other signal to source state from
+    void copy_persistent_state(const Ref<OScriptSignal>& p_other);
 };
 
 #endif  // ORCHESTRATOR_SCRIPT_SIGNALS_H

--- a/src/script/variable.cpp
+++ b/src/script/variable.cpp
@@ -424,3 +424,21 @@ void OScriptVariable::set_constant(bool p_constant)
         emit_changed();
     }
 }
+
+void OScriptVariable::copy_persistent_state(const Ref<OScriptVariable>& p_other)
+{
+    _category = p_other->_category;
+    _classification = p_other->_classification;
+    _constant = p_other->_constant;
+    _default_value = p_other->_default_value;
+    _description = p_other->_description;
+    _exportable = p_other->_exportable;
+    _exported = p_other->_exported;
+    _type_category = p_other->_type_category;
+    _type_subcategory = p_other->_type_subcategory;
+    _value_list = p_other->_value_list;
+    _info = p_other->_info;
+
+    notify_property_list_changed();
+    emit_changed();
+}

--- a/src/script/variable.h
+++ b/src/script/variable.h
@@ -169,6 +169,10 @@ public:
     /// Sets whether the variable is a constant
     /// @param p_constant whether the variable is constant
     void set_constant(bool p_constant);
+
+    /// Copy the persistent state from one variable to this variable
+    /// @param p_other the other variable to source state from
+    void copy_persistent_state(const Ref<OScriptVariable>& p_other);
 };
 
 #endif  // ORCHESTRATOR_SCRIPT_VARIABLE_H


### PR DESCRIPTION
Fixes #724 

This change allows the copy-n-paste of nodes that call script functions, emit script signals, or get or set script variable values. The granular behavior for each node type is as follows:

* Emit Script Signal Node
  * If the signal does not exist, it's created before the emit signal node is placed.
  * If the signal exists with the name, but the definition differs, an error is displayed & paste fails.
  * If the signal exists with the same name and the definition matches, the emit signal node is placed only.

* Get/Set Variable Node
  * If the variable does not exist, it's created before the get/set variable node is placed.
  * If the variable exists with the same name but is defined differently, an error is displayed & paste fails.
  * If the variable exists with the same name and the definition matches, the get/set variable node is placed only.

* Call Script Function
  * If the script function does not exist, an error is displayed & paste fails.
  * If the script function with the same name exists but is defined differently, an error is displayed & paste fails.
  * If the script function with the same name exists and the definition matches, the call script function node is placed only.

The goals of this change were primarily to avoid the crash that users were previously experiencing, but to also make the copy and paste across Orchestrations much easier. For script functions, it's expected that users would create the function first in the target orchestration before pasting any nodes that call such function. This also means that the contents of the script function itself isn't automatically copied & pasted when copying a "call script function" node.

In addition to the above, when selecting nodes and pressing the `ui_copy` (`Ctrl+C`) operation, if a node cannot be duplicated such as event nodes, rather than printing a message to the Output Panel, users will be presented a dialog window instead and the clipboard will not be populated. Users will need to unselect such nodes and re-execute the copy operation.