### PR TITLE
Draft - Make dialogue panel more easily extended.

### DIFF
--- a/project/addons/orchestrator/scenes/dialogue_message.gd
+++ b/project/addons/orchestrator/scenes/dialogue_message.gd
@@ -15,6 +15,7 @@
 ## limitations under the License.
 ##
 extends CanvasLayer
+class_name OrchestratorDialogue
 
 ## A required signal that should be emitted when the Dialogue UI completes
 ## all its user interactions. This informs Orchestrator that it is then
@@ -40,10 +41,10 @@ var selection : int
 var _current_tween : Tween
 var _current_choices : Dictionary
 
-@onready var speaker 	  = $MarginContainer/PanelContainer/MarginContainer/VBoxContainer/Speaker
-@onready var speaker_text = $MarginContainer/PanelContainer/MarginContainer/VBoxContainer/SpeakerText
-@onready var response_tpl = $MarginContainer/PanelContainer/MarginContainer/VBoxContainer/ResponseTemplate
-@onready var next_button  = $MarginContainer/PanelContainer/MarginContainer/VBoxContainer/NextButton
+@onready var speaker 	  = %Speaker
+@onready var speaker_text = %SpeakerText
+@onready var response_tpl = %ResponseTemplate
+@onready var next_button  = %NextButton
 
 func _ready() -> void:
 	response_tpl.visible = false

--- a/project/addons/orchestrator/scenes/dialogue_message.tscn
+++ b/project/addons/orchestrator/scenes/dialogue_message.tscn
@@ -44,6 +44,7 @@ theme_override_constants/margin_bottom = 10
 layout_mode = 2
 
 [node name="Speaker" type="Label" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
 layout_mode = 2
 text = "Speaker Name"
 horizontal_alignment = 1
@@ -52,6 +53,7 @@ horizontal_alignment = 1
 layout_mode = 2
 
 [node name="SpeakerText" type="Label" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(700, 0)
 layout_mode = 2
 text = "Speaker Text that will be shown."
@@ -62,12 +64,14 @@ autowrap_mode = 2
 layout_mode = 2
 
 [node name="ResponseTemplate" type="Button" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
 visible = false
 layout_mode = 2
 text = "Some Response (If choices are provided)"
 alignment = 0
 
 [node name="NextButton" type="Button" parent="MarginContainer/PanelContainer/MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
 visible = false
 layout_mode = 2
 size_flags_horizontal = 8


### PR DESCRIPTION
I made a few small changes to make extending the dialogue panel easier.

- Use unique name access in dialogue scene
- Add class_name identifier

This allows adding functionality as easy as:
![Screenshot from 2024-10-01 14-26-33](https://github.com/user-attachments/assets/8b7c9f80-9f18-4a8d-951c-bb9ba6f6f34d)

Where I duplicated the default scene, detached the script and added this one and a `TextureRect` for a portrait.

This produces no functional change in the Orchestrator base as far as a user would be concerned.

