### PR TITLE
Create an Events panel for the orchestration editor.

### DIFF
--- a/src/editor/component_panels/events_panel.cpp
+++ b/src/editor/component_panels/events_panel.cpp
@@ -1,0 +1,321 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editor/component_panels/events_panel.h"
+
+#include "common/callable_lambda.h"
+#include "common/dictionary_utils.h"
+#include "common/scene_utils.h"
+#include "common/settings.h"
+#include "editor/script_connections.h"
+#include "script/script.h"
+
+#include <godot_cpp/classes/button.hpp>
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/h_box_container.hpp>
+#include <godot_cpp/classes/input_event_key.hpp>
+#include <godot_cpp/classes/popup_menu.hpp>
+#include <godot_cpp/classes/shortcut.hpp>
+#include <godot_cpp/classes/tree.hpp>
+
+void OrchestratorScriptEventsComponentPanel::_show_function_graph(TreeItem* p_item)
+{
+    // Function name and graph names are synonymous
+    const String function_name = _get_tree_item_name(p_item);
+    emit_signal("show_graph_requested", function_name);
+    emit_signal("focus_node_requested", function_name, _orchestration->get_function_node_id(function_name));
+    _tree->deselect_all();
+}
+
+void OrchestratorScriptEventsComponentPanel::_update_slots()
+{
+    if (_orchestration->get_type() != OrchestrationType::OT_Script)
+        return;
+
+    const Ref<OScript> script = _orchestration->get_self();
+    const Vector<Node*> script_nodes = SceneUtils::find_all_nodes_for_script_in_edited_scene(script);
+    const String base_type = script->get_instance_base_type();
+
+    _iterate_tree_items(callable_mp_lambda(this, [&](TreeItem* item) {
+        if (item->has_meta("__name"))
+        {
+            Ref<OScriptGraph> graph = _orchestration->get_graph(item->get_meta("__name"));
+            if (graph.is_valid())// && graph->get_flags().has_flag(OScriptGraph::GraphFlags::GF_FUNCTION))
+            {
+                const String function_name = item->get_meta("__name");
+                if (SceneUtils::has_any_signals_connected_to_function(function_name, base_type, script_nodes))
+                {
+                    if (item->get_button_count(0) == 0)
+                    {
+                        item->add_button(0, SceneUtils::get_editor_icon("Slot"));
+                        item->set_meta("__slot", true);
+                    }
+                }
+                else if (item->get_button_count(0) > 0)
+                {
+                    item->erase_button(0, 0);
+                    item->remove_meta("__slot");
+                }
+            }
+        }
+    }));
+}
+
+PackedStringArray OrchestratorScriptEventsComponentPanel::_get_existing_names() const
+{
+    return _orchestration->get_event_names();
+}
+
+String OrchestratorScriptEventsComponentPanel::_get_tooltip_text() const
+{
+    return "Experimental Custom Events panel.";
+}
+
+String OrchestratorScriptEventsComponentPanel::_get_remove_confirm_text(TreeItem* p_item) const
+{
+    return "Removing an event will eliminate it...";
+}
+
+bool OrchestratorScriptEventsComponentPanel::_populate_context_menu(TreeItem* p_item)
+{
+    _context_menu->add_item("Open in Graph", CM_OPEN_EVENT_GRAPH, KEY_ENTER);
+    _context_menu->add_icon_item(SceneUtils::get_editor_icon("Rename"), "Rename", CM_RENAME_EVENT, KEY_F2);
+    _context_menu->add_icon_item(SceneUtils::get_editor_icon("Remove"), "Remove", CM_REMOVE_EVENT, KEY_DELETE);
+
+    if (p_item->has_meta("__slot") && p_item->get_meta("__slot"))
+    {
+        _context_menu->add_icon_item(SceneUtils::get_editor_icon("Unlinked"), "Disconnect", CM_DISCONNECT_SLOT);
+        _context_menu->set_item_tooltip(_context_menu->get_item_index(CM_DISCONNECT_SLOT), "Disconnect the slot function from the signal.");
+    }
+
+    return true;
+}
+
+void OrchestratorScriptEventsComponentPanel::_handle_context_menu(int p_id)
+{
+    switch (p_id)
+    {
+        case CM_OPEN_EVENT_GRAPH:
+            _show_function_graph(_tree->get_selected());
+            break;
+        case CM_RENAME_EVENT:
+            _edit_selected_tree_item();
+            break;
+        case CM_REMOVE_EVENT:
+            _confirm_removal(_tree->get_selected());
+            break;
+        case CM_DISCONNECT_SLOT:
+            _disconnect_slot(_tree->get_selected());
+            break;
+    }
+}
+
+bool OrchestratorScriptEventsComponentPanel::_handle_add_new_item(const String& p_name)
+{
+    if (_new_function_callback.is_valid())
+    {
+        // TODO: re-enable this:
+        const Ref<OScriptFunction> result = _new_function_callback.call(p_name);
+        // return result.is_valid();
+    }
+    return false;
+}
+
+void OrchestratorScriptEventsComponentPanel::_handle_item_selected()
+{
+    TreeItem* item = _tree->get_selected();
+    if (item)
+    {
+        const Ref<OScriptFunction> function = _orchestration->find_function(StringName(_get_tree_item_name(item)));
+        if (function.is_valid())
+        {
+            const Ref<OScriptNode> node = function->get_owning_node();
+            if (node.is_valid())
+                EditorInterface::get_singleton()->edit_resource(node);
+        }
+    }
+}
+
+void OrchestratorScriptEventsComponentPanel::_handle_item_activated(TreeItem* p_item)
+{
+    _show_function_graph(p_item);
+}
+
+bool OrchestratorScriptEventsComponentPanel::_handle_item_renamed(const String& p_old_name, const String& p_new_name)
+{
+    if (_get_existing_names().has(p_new_name))
+    {
+        _show_notification("An event with the name '" + p_new_name + "' already exists.");
+        return false;
+    }
+
+    if (!p_new_name.is_valid_identifier())
+    {
+        _show_invalid_name("event");
+        return false;
+    }
+
+    if (!_orchestration->rename_function(p_old_name, p_new_name))
+        return false;
+
+    emit_signal("graph_renamed", p_old_name, p_new_name);
+    return true;
+}
+
+void OrchestratorScriptEventsComponentPanel::_handle_remove(TreeItem* p_item)
+{
+    // Function name and graph names are synonymous
+    const String function_name = _get_tree_item_name(p_item);
+    emit_signal("close_graph_requested", function_name);
+
+    _orchestration->remove_function(function_name);
+}
+
+void OrchestratorScriptEventsComponentPanel::_handle_button_clicked(TreeItem* p_item, int p_column, int p_id,
+                                                                    int p_mouse_button)
+{
+    if (_orchestration->get_type() != OrchestrationType::OT_Script)
+        return;
+
+    const Ref<OScript> script = _orchestration->get_self();
+    const Vector<Node*> nodes = SceneUtils::find_all_nodes_for_script_in_edited_scene(script);
+
+    OrchestratorScriptConnectionsDialog* dialog = memnew(OrchestratorScriptConnectionsDialog);
+    add_child(dialog);
+    dialog->popup_connections(_get_tree_item_name(p_item), nodes);
+}
+
+Dictionary OrchestratorScriptEventsComponentPanel::_handle_drag_data(const Vector2& p_position)
+{
+    Dictionary data;
+
+    TreeItem* selected = _tree->get_selected();
+    if (selected)
+    {
+        Ref<OScriptFunction> function = _orchestration->find_function(StringName(_get_tree_item_name(selected)));
+        if (function.is_valid())
+        {
+            data["type"] = "function";
+            data["functions"] = DictionaryUtils::from_method(function->get_method_info());
+        }
+    }
+    return data;
+}
+
+void OrchestratorScriptEventsComponentPanel::_handle_tree_gui_input(const Ref<InputEvent>& p_event, TreeItem* p_item)
+{
+    const Ref<InputEventKey> key = p_event;
+    if (key.is_valid() && key->is_pressed() && !key->is_echo())
+    {
+        if (key->get_keycode() == KEY_ENTER)
+        {
+            _handle_context_menu(CM_OPEN_EVENT_GRAPH);
+            accept_event();
+        }
+        else if (key->get_keycode() == KEY_F2)
+        {
+            _handle_context_menu(CM_RENAME_EVENT);
+            accept_event();
+        }
+        else if (key->get_keycode() == KEY_DELETE)
+        {
+            _handle_context_menu(CM_REMOVE_EVENT);
+            accept_event();
+        }
+    }
+}
+
+void OrchestratorScriptEventsComponentPanel::update()
+{
+    _clear_tree();
+
+    OrchestratorSettings* settings = OrchestratorSettings::get_singleton();
+    bool use_friendly_names = settings->get_setting("ui/components_panel/show_function_friendly_names", true);
+
+    PackedStringArray event_names = _orchestration->get_event_names();
+    if (!event_names.is_empty())
+    {
+        event_names.sort();
+        for (const StringName event_name : event_names)
+        {
+            Ref<OScriptFunction> event = _orchestration->find_event(event_name);
+
+            String friendly_name = event->get_function_name();
+            if (use_friendly_names)
+                friendly_name = event->get_function_name().capitalize();
+
+            _create_item(_tree->get_root(), event_name, event_name, "MemberMethod");
+        }
+    }
+
+    if (_tree->get_root()->get_child_count() == 0)
+    {
+        TreeItem* item = _tree->get_root()->create_child();
+        item->set_text(0, "No events defined");
+        item->set_selectable(0, false);
+        return;
+    }
+
+    _update_slots();
+
+    OrchestratorScriptComponentPanel::update();
+}
+
+void OrchestratorScriptEventsComponentPanel::_notification(int p_what)
+{
+    #if GODOT_VERSION < 0x040300
+    // Godot does not dispatch to parent (shrugs)
+    OrchestratorScriptComponentPanel::_notification(p_what);
+    #endif
+
+    if (p_what == NOTIFICATION_READY)
+    {
+        _slot_update_timer = memnew(Timer);
+        _slot_update_timer->set_wait_time(1);
+        _slot_update_timer->set_autostart(true);
+        _slot_update_timer->connect("timeout", callable_mp(this, &OrchestratorScriptEventsComponentPanel::_update_slots));
+        add_child(_slot_update_timer);
+
+        // HBoxContainer* container = _get_panel_hbox();
+
+        // _override_button = memnew(Button);
+        // _override_button->set_focus_mode(FOCUS_NONE);
+        // _override_button->set_button_icon(SceneUtils::get_editor_icon("Override"));
+        // _override_button->set_tooltip_text("Override a Godot virtual function");
+        // container->add_child(_override_button);
+
+        // _override_button->connect("pressed", callable_mp_lambda(this, [=, this] { emit_signal("override_function_requested"); }));
+    }
+    // else if (p_what == NOTIFICATION_THEME_CHANGED)
+    // {
+    //     if (_override_button)
+    //         _override_button->set_button_icon(SceneUtils::get_editor_icon("Override"));
+    // }
+}
+
+void OrchestratorScriptEventsComponentPanel::_bind_methods()
+{
+    ADD_SIGNAL(MethodInfo("show_graph_requested", PropertyInfo(Variant::STRING, "graph_name")));
+    ADD_SIGNAL(MethodInfo("close_graph_requested", PropertyInfo(Variant::STRING, "graph_name")));
+    ADD_SIGNAL(MethodInfo("graph_renamed", PropertyInfo(Variant::STRING, "old_name"), PropertyInfo(Variant::STRING, "new_name")));
+    ADD_SIGNAL(MethodInfo("focus_node_requested", PropertyInfo(Variant::STRING, "graph_name"), PropertyInfo(Variant::INT, "node_id")));
+    // ADD_SIGNAL(MethodInfo("override_function_requested"));
+}
+
+OrchestratorScriptEventsComponentPanel::OrchestratorScriptEventsComponentPanel(Orchestration* p_orchestration, Callable p_new_function_callback)
+    : OrchestratorScriptComponentPanel("Events", p_orchestration), _new_function_callback(p_new_function_callback)
+{
+}

--- a/src/editor/component_panels/events_panel.h
+++ b/src/editor/component_panels/events_panel.h
@@ -1,0 +1,86 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ORCHESTRATOR_SCRIPT_EVENTS_COMPONENT_PANEL_H
+#define ORCHESTRATOR_SCRIPT_EVENTS_COMPONENT_PANEL_H
+
+#include "editor/component_panels/component_panel.h"
+
+#include <godot_cpp/classes/timer.hpp>
+
+class OrchestratorScriptEventsComponentPanel : public OrchestratorScriptComponentPanel
+{
+    GDCLASS(OrchestratorScriptEventsComponentPanel, OrchestratorScriptComponentPanel);
+    static void _bind_methods();
+
+    enum ContextMenuIds
+    {
+        CM_OPEN_EVENT_GRAPH,
+        CM_RENAME_EVENT,
+        CM_REMOVE_EVENT,
+        CM_DISCONNECT_SLOT
+    };
+
+    // Button* _override_button{ nullptr };
+    Callable _new_function_callback;
+
+    Timer* _slot_update_timer{ nullptr };
+
+protected:
+    //~ Begin OrchestratorScriptComponentPanel Interface
+    String _get_unique_name_prefix() const override { return "NewEvent"; }
+    PackedStringArray _get_existing_names() const override;
+    String _get_tooltip_text() const override;
+    String _get_remove_confirm_text(TreeItem* p_item) const override;
+    String _get_item_name() const override { return "Event"; }
+    bool _populate_context_menu(TreeItem* p_item) override;
+    void _handle_context_menu(int p_id) override;
+    bool _handle_add_new_item(const String& p_name) override;
+    void _handle_item_selected() override;
+    void _handle_item_activated(TreeItem* p_item) override;
+    bool _handle_item_renamed(const String& p_old_name, const String& p_new_name) override;
+    void _handle_remove(TreeItem* p_item) override;
+    void _handle_button_clicked(TreeItem* p_item, int p_column, int p_id, int p_mouse_button) override;
+    Dictionary _handle_drag_data(const Vector2& p_position) override;
+    void _handle_tree_gui_input(const Ref<InputEvent>& p_event, TreeItem* p_item) override;
+    //~ End OrchestratorScriptComponentPanel Interface
+
+    //~ Begin Signal handlers
+    void _show_function_graph(TreeItem* p_item);
+    //~ End Signal handlers
+
+    /// Updates the slot icons on tree items
+    void _update_slots();
+
+    /// Default constructor
+    OrchestratorScriptEventsComponentPanel() = default;
+
+public:
+    //~ Begin OrchestratorScriptViewSection Interface
+    void update() override;
+    //~ End OrchestratorScriptViewSection Interface
+
+    //~ Begin Wrapped Interface
+    void _notification(int p_what);
+    //~ End Wrapped Interface
+
+    /// Construct the function component panel
+    /// @param p_orchestration the orchestration
+    /// @param p_new_function_callback the callable to call when a new function is to be added
+    explicit OrchestratorScriptEventsComponentPanel(Orchestration* p_orchestration, Callable p_new_function_callback);
+};
+
+#endif // ORCHESTRATOR_SCRIPT_EVENTS_COMPONENT_PANEL_H

--- a/src/editor/register_editor_types.cpp
+++ b/src/editor/register_editor_types.cpp
@@ -19,6 +19,7 @@
 #include "about_dialog.h"
 #include "editor/component_panels/component_panel.h"
 #include "editor/component_panels/functions_panel.h"
+#include "editor/component_panels/events_panel.h"
 #include "editor/component_panels/graphs_panel.h"
 #include "editor/component_panels/macros_panel.h"
 #include "editor/component_panels/signals_panel.h"
@@ -119,6 +120,7 @@ void register_editor_types()
     ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptConnectionsDialog)
     ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptComponentPanel)
     ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptFunctionsComponentPanel)
+    ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptEventsComponentPanel)
     ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptGraphsComponentPanel)
     ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptMacrosComponentPanel)
     ORCHESTRATOR_REGISTER_INTERNAL_CLASS(OrchestratorScriptSignalsComponentPanel)

--- a/src/editor/script_editor_viewport.cpp
+++ b/src/editor/script_editor_viewport.cpp
@@ -19,6 +19,7 @@
 #include "api/extension_db.h"
 #include "common/name_utils.h"
 #include "editor/component_panels/functions_panel.h"
+#include "editor/component_panels/events_panel.h"
 #include "editor/component_panels/graphs_panel.h"
 #include "editor/component_panels/macros_panel.h"
 #include "editor/component_panels/signals_panel.h"
@@ -36,6 +37,7 @@ void OrchestratorScriptEditorViewport::_update_components()
 {
     _graphs->update();
     _functions->update();
+    _events->update();
     _macros->update();
     _variables->update();
     _signals->update();
@@ -94,6 +96,7 @@ void OrchestratorScriptEditorViewport::_save_state()
         state["panels"] = panel_states;
         panel_states["graphs"] = _graphs->is_collapsed();
         panel_states["functions"] = _functions->is_collapsed();
+        panel_states["events"] = _events->is_collapsed();
         panel_states["macros"] = _macros->is_collapsed();
         panel_states["variables"] = _variables->is_collapsed();
         panel_states["signals"] = _signals->is_collapsed();
@@ -138,6 +141,7 @@ void OrchestratorScriptEditorViewport::_restore_state()
             const Dictionary& panel_state = state["panels"];
             _graphs->set_collapsed(panel_state.get("graphs", false));
             _functions->set_collapsed(panel_state.get("functions", false));
+            _events->set_collapsed(panel_state.get("events", false));
             _macros->set_collapsed(panel_state.get("macros", false));
             _variables->set_collapsed(panel_state.get("variables", false));
             _signals->set_collapsed(panel_state.get("signals", false));
@@ -180,6 +184,37 @@ Ref<OScriptFunction> OrchestratorScriptEditorViewport::_create_new_function(cons
     _functions->update();
 
     return entry->get_function();
+}
+
+Ref<OScriptFunction> OrchestratorScriptEditorViewport::_create_new_event(const String& p_name)
+{
+    UtilityFunctions::print("I should create an event block now.");
+
+    // TODO: create a node...
+    // Ref<OScriptGraph> graph = _orchestration->get_graph("EventGraph");
+    // ERR_FAIL_COND_V_MSG(!graph.is_valid(), {}, "Failed to find EventGraph");
+
+    // MethodInfo mi;
+    // mi.name = p_name;
+    // mi.flags = METHOD_FLAG_NORMAL;
+    // mi.return_val.type = Variant::NIL;
+    // mi.return_val.hint = PROPERTY_HINT_NONE;
+    // mi.return_val.usage = PROPERTY_USAGE_DEFAULT;
+
+    // OScriptNodeInitContext context;
+    // context.method = mi;
+
+    // // TODO: make a node to spawn...
+    // const Ref<OScriptNodeFunctionEntry> entry = graph->create_node<OScriptNodeFunctionEntry>(context);
+    // if (!entry.is_valid())
+    // {
+    //     ERR_FAIL_V_MSG({}, "Failed to create function entry node for function " + p_name);
+    // }
+
+    // _events->update();
+
+    // return entry->get_function();
+    return nullptr;
 }
 
 void OrchestratorScriptEditorViewport::_show_graph(const String& p_name)
@@ -569,6 +604,17 @@ void OrchestratorScriptEditorViewport::_notification(int p_what)
         _functions->connect("graph_renamed", callable_mp(this, &OrchestratorScriptEditorViewport::_graph_renamed));
         _functions->connect("scroll_to_item", callable_mp(this, &OrchestratorScriptEditorViewport::_scroll_to_item));
         _component_container->add_child(_functions);
+
+        // TODO: cleanup
+        Callable create_event = callable_mp(this, &OrchestratorScriptEditorViewport::_create_new_event);
+        _events = memnew(OrchestratorScriptEventsComponentPanel(_orchestration, create_event));
+        _events->connect("show_graph_requested", callable_mp(this, &OrchestratorScriptEditorViewport::_show_graph));
+        // _events->connect("close_graph_requested", callable_mp(this, &OrchestratorScriptEditorViewport::_close_graph));
+        _events->connect("focus_node_requested", callable_mp(this, &OrchestratorScriptEditorViewport::_focus_node));
+        // _events->connect("override_function_requested", callable_mp(this, &OrchestratorScriptEditorViewport::_override_godot_function));
+        _events->connect("graph_renamed", callable_mp(this, &OrchestratorScriptEditorViewport::_graph_renamed));
+        _events->connect("scroll_to_item", callable_mp(this, &OrchestratorScriptEditorViewport::_scroll_to_item));
+        _component_container->add_child(_events);
 
         _macros = memnew(OrchestratorScriptMacrosComponentPanel(_orchestration));
         _macros->connect("scroll_to_item", callable_mp(this, &OrchestratorScriptEditorViewport::_scroll_to_item));

--- a/src/editor/script_editor_viewport.h
+++ b/src/editor/script_editor_viewport.h
@@ -37,6 +37,8 @@ protected:
     OrchestratorScriptComponentPanel* _macros{ nullptr };     //! Macros section
     OrchestratorScriptComponentPanel* _variables{ nullptr };  //! Variables section
     OrchestratorScriptComponentPanel* _signals{ nullptr };    //! Signals section
+    OrchestratorScriptComponentPanel* _events{ nullptr };     //! Events section
+    
 
     //~ Begin Godot Interface
     void _notification(int p_what);
@@ -60,6 +62,11 @@ protected:
     /// @param p_has_return whether function has a return node
     /// @return the newly constructed function
     Ref<OScriptFunction> _create_new_function(const String& p_name, bool p_has_return);
+
+    /// Creates a new event in the script
+    /// @param p_name the event name
+    /// @return the newly constructed function
+    Ref<OScriptFunction> _create_new_event(const String& p_name);
 
     /// Shows the graph with the given name, adding the tab if it doesn't exist.
     /// @param p_name the graph name

--- a/src/orchestration/orchestration.h
+++ b/src/orchestration/orchestration.h
@@ -66,6 +66,7 @@ protected:
     RBSet<OScriptConnection> _connections;                 //! The connections between nodes in the orchestration
     HashMap<int, Ref<OScriptNode>> _nodes;                 //! Map of all nodes within this orchestration
     HashMap<StringName, Ref<OScriptFunction>> _functions;  //! Map of all orchestration functions
+    HashMap<StringName, Ref<OScriptFunction>> _events;     //! Map of all orchestration events
     HashMap<StringName, Ref<OScriptVariable>> _variables;  //! Map of all orchestration variables
     HashMap<StringName, Ref<OScriptSignal>> _signals;      //! Map of all user-defined signals
     HashMap<StringName, Ref<OScriptGraph>> _graphs;        //! Map of all defined graphs
@@ -81,6 +82,8 @@ protected:
     void _set_graphs_internal(const TypedArray<OScriptGraph>& p_graphs);
     TypedArray<OScriptFunction> _get_functions_internal() const;
     void _set_functions_internal(const TypedArray<OScriptFunction>& p_functions);
+    TypedArray<OScriptFunction> _get_events_internal() const;
+    void _set_events_internal(const TypedArray<OScriptFunction>& p_functions);
     TypedArray<OScriptVariable> _get_variables_internal() const;
     void _set_variables_internal(const TypedArray<OScriptVariable>& p_variables);
     TypedArray<OScriptSignal> _get_signals_internal() const;
@@ -194,7 +197,7 @@ public:
     Vector<Ref<OScriptGraph>> get_graphs() const;
     //~ End Graph Interface
 
-    //~ Begin Function API
+    //~ Begin Function Interface
     bool has_function(const StringName& p_name) const;
     Ref<OScriptFunction> create_function(const MethodInfo& p_method, int p_node_id, bool p_user_defined = false);
     void remove_function(const StringName& p_name);
@@ -205,6 +208,18 @@ public:
     int get_function_node_id(const StringName& p_name) const;
     Vector<Ref<OScriptFunction>> get_functions() const;
     //~ End Function Interface
+
+    //~ Begin Events Interface
+    bool has_event(const StringName& p_name) const;
+    Ref<OScriptFunction> create_event(const MethodInfo& p_method, int p_node_id, bool p_user_defined = false);
+    void remove_event(const StringName& p_name);
+    Ref<OScriptFunction> find_event(const StringName& p_name) const;
+    Ref<OScriptFunction> find_event(const Guid& p_guid) const;
+    bool rename_event(const StringName& p_old_name, const StringName& p_new_name);
+    PackedStringArray get_event_names() const;
+    int get_event_node_id(const StringName& p_name) const;
+    Vector<Ref<OScriptFunction>> get_events() const;
+    //~ End Events Interface
 
     //~ Begin Variable Interface
     bool has_variable(const StringName& p_name) const;

--- a/src/script/graph.h
+++ b/src/script/graph.h
@@ -66,6 +66,7 @@ private:
     BitField<GraphFlags> _flags{ 0 };              //! Flags
     RBSet<int> _nodes;                             //! Set of node ids that participate in this graph
     RBSet<int> _functions;                         //! Set of node ids that represent entry points or functions
+    RBSet<int> _events;                            //! Set of node ids that represent events
     HashMap<uint64_t, PackedVector2Array> _knots;  //! Knots for each graph connection
 
     //~ Begin Serialization
@@ -75,6 +76,8 @@ private:
     void _set_knots(const TypedArray<Dictionary>& p_knots);
     TypedArray<int> _get_functions() const;
     void _set_functions(const TypedArray<int>& p_functions);
+    TypedArray<int> _get_events() const;
+    void _set_events(const TypedArray<int>& p_functions);
     //~ End Serialization
 
     /// Initializes the node in this graph
@@ -204,6 +207,10 @@ public:
     /// Get an array of all functions that participate in this graph
     /// @return an array of functions
     Vector<Ref<OScriptFunction>> get_functions() const;
+
+    /// Get an array of all events that participate in this graph
+    /// @return an array of events
+    Vector<Ref<OScriptFunction>> get_events() const;
 
     /// Get an immutable map of knots for this graph's connections.
     /// @return knot map

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -54,6 +54,11 @@ void OScript::_bind_methods()
     ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "functions", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE),
                  "_set_functions", "_get_functions");
 
+    ClassDB::bind_method(D_METHOD("_set_events", "events"), &OScript::_set_events);
+    ClassDB::bind_method(D_METHOD("_get_events"), &OScript::_get_events);
+    ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "events", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE),
+                 "_set_events", "_get_events");
+
     ClassDB::bind_method(D_METHOD("_set_signals", "signals"), &OScript::_set_signals);
     ClassDB::bind_method(D_METHOD("_get_signals"), &OScript::_get_signals);
     ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "signals", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE),
@@ -76,6 +81,7 @@ void OScript::_bind_methods()
 
     ADD_SIGNAL(MethodInfo("connections_changed", PropertyInfo(Variant::STRING, "caller")));
     ADD_SIGNAL(MethodInfo("functions_changed"));
+    ADD_SIGNAL(MethodInfo("events_changed"));
     ADD_SIGNAL(MethodInfo("variables_changed"));
     ADD_SIGNAL(MethodInfo("signals_changed"));
 }
@@ -220,9 +226,11 @@ bool OScript::_has_static_method(const StringName& p_method) const
     return false;
 }
 
+
+// TODO: what and when calls this?
 bool OScript::_has_method(const StringName& p_method) const
 {
-    return _functions.has(p_method);
+    return _functions.has(p_method) || _events.has(p_method);
 }
 
 Dictionary OScript::_get_method_info(const StringName& p_method) const
@@ -233,7 +241,10 @@ Dictionary OScript::_get_method_info(const StringName& p_method) const
 TypedArray<Dictionary> OScript::_get_script_method_list() const
 {
     TypedArray<Dictionary> results;
-    for (const KeyValue<StringName, Ref<OScriptFunction>>& E : _functions)
+    for (const KeyValue<StringName, Ref<OScriptFunction>>& F : _functions)
+        results.push_back(F.value->to_dict());
+
+    for (const KeyValue<StringName, Ref<OScriptFunction>>& E : _events)
         results.push_back(E.value->to_dict());
 
     return results;

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -64,8 +64,16 @@ protected:
     void _set_connections(const TypedArray<int>& p_connections) { _set_connections_internal(p_connections); }
     TypedArray<OScriptGraph> _get_graphs() const { return _get_graphs_internal(); }
     void _set_graphs(const TypedArray<OScriptGraph>& p_graphs) { _set_graphs_internal(p_graphs); }
+
+
+    // TODO: What's going on here? What calls _get_functions()?
+    //      Is it correct to duplicate of does it need to handle the "events" too?
     TypedArray<OScriptFunction> _get_functions() const { return _get_functions_internal(); }
     void _set_functions(const TypedArray<OScriptFunction>& p_functions) { _set_functions_internal(p_functions); }
+    TypedArray<OScriptFunction> _get_events() const { return _get_events_internal(); }
+    void _set_events(const TypedArray<OScriptFunction>& p_functions) { _set_events_internal(p_functions); }
+
+
     TypedArray<OScriptVariable> _get_variables() const { return _get_variables_internal(); }
     void _set_variables(const TypedArray<OScriptVariable>& p_variables) { _set_variables_internal(p_variables); }
     TypedArray<OScriptSignal> _get_signals() const { return _get_signals_internal(); }


### PR DESCRIPTION
For now it does nothing, but it doesn't crash either :)

I decided to clean my working tree and start anew in my attempt to create a Goto block to enable execution at arbitrary points of an orchestration.

TODO:
- create a node for this panel to instantiate
- figure out how to integrate these "events" into method call registration so they can be called from GDScript
- cleanup

Many TODO notes to resolve so this is a work in progress, but working better than my first attempt.

This replaces #820 