### PR TITLE
GH-821 Introduce Orchestration built-in functions

### DIFF
--- a/doc_classes/OScript.xml
+++ b/doc_classes/OScript.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OScript" inherits="ScriptExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
     <brief_description>
-        A script implementating the Orchestration visual script language.
+        A script implemented in the Orchestration visual script language.
     </brief_description>
     <description>
-        An [OScript] represents an orchestration, a graph-based, visual script language that works similarly to [GDScript].
+        An [OScript] represents an orchestration, a graph-based, visual script language that works similarly to [GDScript]. Orchestrations are saved with the [code].torch[/code] extension. An orchestration extends the functionality of all objects that instantiate it.
     </description>
 </class>

--- a/src/common/varray.h
+++ b/src/common/varray.h
@@ -1,0 +1,41 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ORCHESTRATOR_VARRAY_H
+#define ORCHESTRATOR_VARRAY_H
+
+#include <godot_cpp/variant/variant.hpp>
+#include <vector>
+
+using namespace godot;
+
+template<typename... VarArgs>
+std::vector<Variant> varray(VarArgs... p_args)
+{
+    std::vector<Variant> v;
+    const Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() };
+    const uint32_t argc = sizeof...(p_args);
+    if (argc > 0)
+    {
+        v.resize(argc);
+        for (uint32_t i = 0; i < argc; i++)
+            v[i] = args[i];
+    }
+
+    return v;
+}
+
+#endif // ORCHESTRATOR_VARRAY_H

--- a/src/editor/graph/actions/default_action_registrar.cpp
+++ b/src/editor/graph/actions/default_action_registrar.cpp
@@ -306,6 +306,14 @@ void OrchestratorDefaultGraphActionRegistrar::_register_orchestration_nodes()
     _register_node<OScriptNodeEngineSingleton>("Utilities/engine_singleton");
     _register_node<OScriptNodePrintString>("Utilities/print_string");
 
+    // Register language utility functions
+    const TypedArray<Dictionary> language_functions = OScriptLanguage::get_singleton()->_get_public_functions();
+    for (int i = 0; i < language_functions.size(); i++)
+    {
+        const MethodInfo& mi = DictionaryUtils::to_method(language_functions[i]);
+        _register_node<OScriptNodeCallBuiltinFunction>("@OScript/" + mi.name, language_functions[i]);
+    }
+
     // Register each Engine singleton type
     for (const String& name : Engine::get_singleton()->get_singleton_list())
     {

--- a/src/script/language.cpp
+++ b/src/script/language.cpp
@@ -22,6 +22,7 @@
 #include "common/string_utils.h"
 #include "script/script.h"
 #include "script/vm/script_vm.h"
+#include "utility_functions.h"
 
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/engine_debugger.hpp>
@@ -264,9 +265,13 @@ bool OScriptLanguage::_can_make_function() const
 
 TypedArray<Dictionary> OScriptLanguage::_get_public_functions() const
 {
-    // Returns an array of MethodInfo for the language.
-    // In GDScript this includes things such as preload, assert, and its utility functions
-    return {};
+    TypedArray<Dictionary> results;
+    for (const StringName& function : OScriptUtilityFunctions::get_function_list())
+    {
+        const MethodInfo method = OScriptUtilityFunctions::get_function_info(function);
+        results.push_back(DictionaryUtils::from_method(method));
+    }
+    return results;
 }
 
 Dictionary OScriptLanguage::_get_public_constants() const

--- a/src/script/nodes/functions/call_builtin_function.cpp
+++ b/src/script/nodes/functions/call_builtin_function.cpp
@@ -19,6 +19,7 @@
 #include "common/dictionary_utils.h"
 #include "common/method_utils.h"
 #include "common/version.h"
+#include "script/utility_functions.h"
 
 OScriptNodeCallBuiltinFunction::OScriptNodeCallBuiltinFunction()
 {
@@ -47,6 +48,9 @@ String OScriptNodeCallBuiltinFunction::get_node_title() const
 String OScriptNodeCallBuiltinFunction::get_help_topic() const
 {
     #if GODOT_VERSION >= 0x040300
+    if (OScriptUtilityFunctions::function_exists(_reference.method.name))
+        return vformat("class_method:@OScript:%s", _reference.method.name);
+
     return vformat("class_method:@GlobalScope:%s", _reference.method.name);
     #else
     return super::get_help_topic();

--- a/src/script/register_script_types.cpp
+++ b/src/script/register_script_types.cpp
@@ -22,6 +22,7 @@
 #include "script/serialization/resource_cache.h"
 #include "script/serialization/serialization.h"
 #include "script/vm/script_state.h"
+#include "utility_functions.h"
 
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/resource_loader.hpp>
@@ -73,6 +74,8 @@ void register_script_types()
 
     // Create the ScriptExtension
     language = memnew(OScriptLanguage);
+
+    OScriptUtilityFunctions::register_functions();
 }
 
 void unregister_script_types()
@@ -84,6 +87,8 @@ void unregister_script_types()
         memdelete(language);
         language = nullptr;
     }
+
+    OScriptUtilityFunctions::unregister_functions();
 }
 
 void register_script_extension()

--- a/src/script/utility_functions.cpp
+++ b/src/script/utility_functions.cpp
@@ -1,0 +1,330 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "script/utility_functions.h"
+
+#include "common/varray.h"
+#include "script/language.h"
+
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/resource_loader.hpp>
+#include <godot_cpp/core/class_db.hpp>
+
+#ifdef DEBUG_ENABLED
+#define DEBUG_VALIDATE_ARG_COUNT(m_min_count, m_max_count)                          \
+    if (unlikely(p_arg_count < m_min_count))                                        \
+    {                                                                               \
+        *r_ret = Variant();                                                         \
+        r_error.error = GDEXTENSION_CALL_ERROR_TOO_FEW_ARGUMENTS;                   \
+        r_error.expected = m_min_count;                                             \
+        return;                                                                     \
+    }                                                                               \
+    if (unlikely(p_arg_count > m_max_count))                                        \
+    {                                                                               \
+        *r_ret = Variant();                                                         \
+        r_error.error = GDEXTENSION_CALL_ERROR_TOO_MANY_ARGUMENTS;                  \
+        r_error.expected = m_max_count;                                             \
+        return;                                                                     \
+    }
+
+#define DEBUG_VALIDATE_ARG_TYPE(m_arg, m_type)                                      \
+    if (unlikely(!Variant::can_convert_strict(p_args[m_arg]->get_type(), m_type)))  \
+    {                                                                               \
+        *r_ret = Variant();                                                         \
+        r_error.error = GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT;                    \
+        r_error.argument = m_arg;                                                   \
+        r_error.expected = m_type;                                                  \
+        return;                                                                     \
+    }
+#else
+#define DEBUG_VALIDATE_ARG_COUNT(m_min_count, m_max_count)
+#define DEBUG_VALIDATE_ARG_TYPE(m_arg, m_type)
+#endif // DEBUG_ENABLED
+
+struct OScriptUtilityFunctionsDefinitions
+{
+    static inline void type_exists(Variant* r_ret, const Variant** p_args, int p_arg_count, GDExtensionCallError& r_error)
+    {
+        DEBUG_VALIDATE_ARG_COUNT(1, 1);
+        DEBUG_VALIDATE_ARG_TYPE(0, Variant::STRING_NAME);
+        *r_ret = ClassDB::class_exists(*p_args[0]);
+    }
+
+    static inline void print_debug(Variant* r_ret, const Variant** p_args, int p_arg_count, GDExtensionCallError& r_error)
+    {
+        String s;
+        for (int i = 0; i < p_arg_count; i++)
+            s += p_args[i]->operator String();
+
+        const uint64_t caller_thread = OS::get_singleton()->get_thread_caller_id();
+        if (caller_thread == OS::get_singleton()->get_main_thread_id())
+        {
+            OScriptLanguage* script = OScriptLanguage::get_singleton();
+            if (script->_debug_get_stack_level_count() > 0)
+            {
+                s += "\n    At: "
+                    + script->_debug_get_stack_level_source(0)
+                    + ":"
+                    + itos(script->_debug_get_stack_level_line(0))
+                    + ":"
+                    + script->_debug_get_stack_level_function(0)
+                    + "()";
+            }
+        }
+        else
+        {
+            s += "\n   At: Cannot retrieve debug info outside the main thread. Thread ID: " + itos(caller_thread);
+        }
+
+        UtilityFunctions::print(s);
+        *r_ret = Variant();
+    }
+
+    static inline void print_stack(Variant* r_ret, const Variant** p_args, int p_arg_count, GDExtensionCallError& r_error)
+    {
+        DEBUG_VALIDATE_ARG_COUNT(0, 0);
+
+        const uint64_t caller_thread = OS::get_singleton()->get_thread_caller_id();
+        if (caller_thread != OS::get_singleton()->get_main_thread_id())
+        {
+            UtilityFunctions::print("Cannot retrieve debug info outside the main thread. Thread ID: " + itos(caller_thread));
+            return;
+        }
+
+        OScriptLanguage* script = OScriptLanguage::get_singleton();
+        for (int i = 0; i < script->_debug_get_stack_level_count(); i++)
+        {
+            UtilityFunctions::print(vformat("Frame %d - %s:%d in function '%s'",
+                i,
+                script->_debug_get_stack_level_source(i),
+                script->_debug_get_stack_level_line(i),
+                script->_debug_get_stack_level_function(i)));
+        }
+
+        *r_ret = Variant();
+    }
+
+    static inline void get_stack(Variant* r_ret, const Variant** p_args, int p_arg_count, GDExtensionCallError& r_error)
+    {
+        DEBUG_VALIDATE_ARG_COUNT(0, 0);
+
+        const uint64_t caller_thread = OS::get_singleton()->get_thread_caller_id();
+        if (caller_thread != OS::get_singleton()->get_main_thread_id())
+        {
+            *r_ret = TypedArray<Dictionary>();
+            return;
+        }
+
+        OScriptLanguage* script = OScriptLanguage::get_singleton();
+
+        TypedArray<Dictionary> ret;
+        for (int i = 0; i < script->_debug_get_stack_level_count(); i++)
+        {
+            Dictionary frame;
+            frame["source"] = script->_debug_get_stack_level_source(i);
+            frame["function"] = script->_debug_get_stack_level_function(i);
+            frame["line"] = script->_debug_get_stack_level_line(i);
+            ret.push_back(frame);
+        }
+
+        *r_ret = ret;
+    }
+
+    static inline void len(Variant* r_ret, const Variant** p_args, int p_arg_count, GDExtensionCallError& r_error)
+    {
+        DEBUG_VALIDATE_ARG_COUNT(1, 1);
+        switch (p_args[0]->get_type())
+        {
+            case Variant::STRING:
+            case Variant::STRING_NAME:
+            {
+                String d= *p_args[0];
+                *r_ret = d.length();
+                break;
+            }
+            case Variant::DICTIONARY:
+            {
+                Dictionary d= *p_args[0];
+                *r_ret = d.size();
+                break;
+            }
+            case Variant::ARRAY:
+            {
+                Array d = *p_args[0];
+                *r_ret = d.size();
+                break;
+            }
+            case Variant::PACKED_BYTE_ARRAY:
+            {
+                PackedByteArray d = *p_args[0];
+                *r_ret = d.size();
+                break;
+            }
+            case Variant::PACKED_INT32_ARRAY:
+            {
+                PackedInt32Array d = *p_args[0];
+                *r_ret = d.size();
+                break;
+            }
+            case Variant::PACKED_INT64_ARRAY:
+            {
+                PackedInt64Array d = *p_args[0];
+                *r_ret = d.size();
+                break;
+            }
+            case Variant::PACKED_FLOAT32_ARRAY:
+            {
+                PackedFloat32Array d = *p_args[0];
+                *r_ret = d.size();
+                break;
+            }
+            case Variant::PACKED_FLOAT64_ARRAY:
+            {
+                PackedFloat64Array d = *p_args[0];
+                *r_ret = d.size();
+                break;
+            }
+            case Variant::PACKED_STRING_ARRAY:
+            {
+                PackedStringArray d = *p_args[0];
+                *r_ret = d.size();
+                break;
+            }
+            case Variant::PACKED_VECTOR2_ARRAY:
+            {
+                PackedVector2Array d = *p_args[0];
+                *r_ret = d.size();
+                break;
+            }
+            case Variant::PACKED_VECTOR3_ARRAY:
+            {
+                PackedVector3Array d = *p_args[0];
+                *r_ret = d.size();
+                break;
+            }
+            case Variant::PACKED_VECTOR4_ARRAY:
+            {
+                PackedVector4Array d = *p_args[0];
+                *r_ret = d.size();
+                break;
+            }
+            default:
+            {
+                *r_ret = vformat("Value of type '%s' cannot provide a length", Variant::get_type_name(p_args[0]->get_type()));
+                r_error.error = GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT;
+                r_error.argument = 0;
+                r_error.expected = Variant::NIL;
+                break;
+            }
+        }
+    }
+};
+
+struct OScriptUtilityFunctionInfo
+{
+    OScriptUtilityFunctions::FunctionPtr function{ nullptr };
+    MethodInfo info;
+    bool is_const{ false };
+};
+
+static HashMap<StringName, OScriptUtilityFunctionInfo> utility_function_table;
+static List<StringName> utility_function_name_table;
+
+static void _register_function(const StringName& p_name, const MethodInfo& p_method, OScriptUtilityFunctions::FunctionPtr p_function, bool p_is_const)
+{
+    ERR_FAIL_COND(utility_function_table.has(p_name));
+
+    OScriptUtilityFunctionInfo function;
+    function.function = p_function;
+    function.info = p_method;
+    function.is_const = p_is_const;
+
+    utility_function_table.insert(p_name, function);
+    utility_function_name_table.push_back(p_name);
+}
+
+#define REGISTER_FUNC(m_func, m_is_const, m_return, m_args, m_is_vararg, m_default_args)        \
+    {                                                                                           \
+        String name(#m_func);                                                                   \
+        if (name.begins_with("_"))                                                              \
+            name = name.substr(1);                                                              \
+                                                                                                \
+        MethodInfo info = m_args;                                                               \
+        info.name = name;                                                                       \
+        info.return_val = m_return;                                                             \
+        info.default_arguments = m_default_args;                                                \
+        if (m_is_vararg)                                                                        \
+            info.flags |= METHOD_FLAG_VARARG;                                                   \
+                                                                                                \
+        _register_function(name, info, OScriptUtilityFunctionsDefinitions::m_func, m_is_const); \
+    }
+
+#define RET(m_type)             PropertyInfo(Variant::m_type, "")
+#define RETVAR                  PropertyInfo(Variant::NIL, "", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)
+#define RETCLS(m_class)         PropertyInfo(Variant::OBJECT, "", PROPERTY_HINT_RESOURCE_TYPE, m_class)
+
+#define NOARGS                  MethodInfo()
+#define ARGS(...)               MethodInfo("", __VA_ARGS__)
+#define ARG(m_name, m_type)     PropertyInfo(Variant::m_type, m_name)
+#define ARGVAR(m_name)          PropertyInfo(Variant::NIL, m_name, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)
+#define ARGTYPE(m_name)         PropertyInfo(Variant::INT, m_name, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CLASS_IS_ENUM, "Variant.Type")
+
+void OScriptUtilityFunctions::register_functions()
+{
+    REGISTER_FUNC(type_exists, true, RET(BOOL), ARGS(ARG("type", STRING_NAME)), false, varray());
+    REGISTER_FUNC(print_debug, false, RET(NIL), NOARGS, true, varray());
+    REGISTER_FUNC(print_stack, false, RET(NIL), NOARGS, false, varray());
+    REGISTER_FUNC(get_stack, false, RET(ARRAY), NOARGS, false, varray());
+    REGISTER_FUNC(len, true, RET(INT), ARGS(ARGVAR("var")), false, varray());
+}
+
+void OScriptUtilityFunctions::unregister_functions()
+{
+    utility_function_name_table.clear();
+    utility_function_table.clear();
+}
+
+OScriptUtilityFunctions::FunctionPtr OScriptUtilityFunctions::get_function(const StringName& p_function_name)
+{
+    OScriptUtilityFunctionInfo* info = utility_function_table.getptr(p_function_name);
+    ERR_FAIL_NULL_V(info, nullptr);
+
+    return info->function;
+}
+
+bool OScriptUtilityFunctions::function_exists(const StringName& p_function_name)
+{
+    return utility_function_table.has(p_function_name);
+}
+
+List<StringName> OScriptUtilityFunctions::get_function_list()
+{
+    List<StringName> result;
+    for (const StringName& E : utility_function_name_table)
+        result.push_back(E);
+
+    return result;
+}
+
+MethodInfo OScriptUtilityFunctions::get_function_info(const StringName& p_function_name)
+{
+    OScriptUtilityFunctionInfo* info = utility_function_table.getptr(p_function_name);
+    ERR_FAIL_NULL_V(info, MethodInfo());
+
+    return info->info;
+}
+
+

--- a/src/script/utility_functions.h
+++ b/src/script/utility_functions.h
@@ -1,0 +1,66 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ORCHESTRATOR_SCRIPT_UTILITY_FUNCTIONS_H
+#define ORCHESTRATOR_SCRIPT_UTILITY_FUNCTIONS_H
+
+#include <godot_cpp/core/object.hpp>
+#include <godot_cpp/templates/list.hpp>
+
+using namespace godot;
+
+/// Utility class that provides access to a variety of C++ pure functions that are accessible in
+/// an Orchestration, much like how certain functions like <code>load</code> are accessible in GDScript.
+class OScriptUtilityFunctions
+{
+public:
+    typedef void (*FunctionPtr)(Variant* r_ret, const Variant** p_args, int p_arg_count, GDExtensionCallError& r_error);
+
+    /**
+     * Get the function pointer
+     *
+     * @param p_function_name the function name
+     * @return the function pointer
+     */
+    static OScriptUtilityFunctions::FunctionPtr get_function(const StringName& p_function_name);
+
+    /**
+     * Check whether a language-specific utility function exists
+     *
+     * @param p_function_name the function name
+     * @return true if the function exists, false otherwise
+     */
+    static bool function_exists(const StringName& p_function_name);
+
+    /**
+     * Get a list of all registered utility functions
+     * @return list of function names
+     */
+    static List<StringName> get_function_list();
+
+    /**
+     * Get the method information about a function.
+     *
+     * @param p_function_name the function name
+     * @return the function's method information structure
+     */
+    static MethodInfo get_function_info(const StringName& p_function_name);
+
+    static void register_functions();
+    static void unregister_functions();
+};
+
+#endif // ORCHESTRATOR_SCRIPT_UTILITY_FUNCTIONS_H

--- a/src/script/vm/script_vm.cpp
+++ b/src/script/vm/script_vm.cpp
@@ -20,6 +20,7 @@
 #include "orchestration/orchestration.h"
 #include "script/instances/node_instance.h"
 #include "script/nodes/variables/local_variable.h"
+#include "script/utility_functions.h"
 #include "script/vm/script_state.h"
 
 #include <godot_cpp/classes/engine_debugger.hpp>
@@ -1038,6 +1039,15 @@ void OScriptVirtualMachine::call_method(OScriptInstance* p_instance, const Strin
     ERR_FAIL_COND_MSG(!r_err, "No error code argument provided.");
 
     r_err->error = GDEXTENSION_CALL_OK;
+
+    if (OScriptUtilityFunctions::function_exists(p_method))
+    {
+        if (OScriptUtilityFunctions::FunctionPtr func = OScriptUtilityFunctions::get_function(p_method))
+        {
+            func(r_return, const_cast<const Variant**>(p_args), p_arg_count, *r_err);
+            return;
+        }
+    }
 
     // Check whether the method is defined as part of the Orchestration.
     // This means that there will be a function defined in the function map.


### PR DESCRIPTION
Fixes #821 

This change introduces the following built-in functions:

* len
* print_debug
* print_stack
* get_stack
* type_exists

While many of these are mostly useful for debugging, things like `type_exists` and `len` bring GDScript built-in functions to the Orchestrator plug-in.  The `len` function specifically supports all variant types, without needing to call the specific size or equivalent method on the variant type directly.