### PR TITLE
Added default_scene to ProjectSettings (The Sequel)

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -152,7 +152,7 @@ void OrchestratorSettings::_register_settings()
     _settings.emplace_back(SENUM_SETTING("settings/storage_format", "Text,Binary", "Text"));
     _settings.emplace_back(SENUM_SETTING("settings/log_level", "FATAL,ERROR,WARN,INFO,DEBUG,TRACE", "INFO"));
     _settings.emplace_back(BOOL_SETTING("settings/notify_about_pre-releases", false));
-    _settings.emplace_back(FILE_SETTING("settings/dialogue_message_scene", "*.tscn,*.scn", "res://addons/orchestrator/scenes/dialogue_message.tscn"));
+    _settings.emplace_back(FILE_SETTING("settings/dialogue/default_message_scene", "*.tscn,*.scn", "res://addons/orchestrator/scenes/dialogue_message.tscn"));
 
     _settings.emplace_back(RANGE_SETTING("settings/runtime/max_call_stack", "256,1024,256", 1024));
     _settings.emplace_back(INT_SETTING("settings/runtime/max_loop_iterations", 1000000));

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -152,6 +152,7 @@ void OrchestratorSettings::_register_settings()
     _settings.emplace_back(SENUM_SETTING("settings/storage_format", "Text,Binary", "Text"));
     _settings.emplace_back(SENUM_SETTING("settings/log_level", "FATAL,ERROR,WARN,INFO,DEBUG,TRACE", "INFO"));
     _settings.emplace_back(BOOL_SETTING("settings/notify_about_pre-releases", false));
+    _settings.emplace_back(FILE_SETTING("settings/dialogue_message_scene", "*.tscn,*.scn", "res://addons/orchestrator/scenes/dialogue_message.tscn"));
 
     _settings.emplace_back(RANGE_SETTING("settings/runtime/max_call_stack", "256,1024,256", 1024));
     _settings.emplace_back(INT_SETTING("settings/runtime/max_loop_iterations", 1000000));

--- a/src/script/nodes/dialogue/dialogue_message.cpp
+++ b/src/script/nodes/dialogue/dialogue_message.cpp
@@ -17,6 +17,7 @@
 #include "dialogue_message.h"
 
 #include "common/property_utils.h"
+#include "common/settings.h"
 #include "script/nodes/dialogue/dialogue_choice.h"
 #include "script/vm/script_state.h"
 
@@ -29,10 +30,9 @@
 
 class OScriptNodeDialogueMessageInstance : public OScriptNodeInstance
 {
-    static inline const char* DEFAULT_SCENE = "res://addons/orchestrator/scenes/dialogue_message.tscn";
-
     DECLARE_SCRIPT_NODE_INSTANCE(OScriptNodeDialogueMessage)
     int _choices{ 0 };
+    String _default_scene;
     Node* _ui{ nullptr };
 
     bool _file_exists(const String& p_path) const
@@ -59,7 +59,7 @@ public:
 
         Variant scene_file = p_context.get_input(2);
         if (scene_file.get_type() == Variant::NIL || String(scene_file).is_empty())
-            scene_file = DEFAULT_SCENE;
+            scene_file = _default_scene;
 
         // Check if scene file exists
         if (!_file_exists(scene_file))
@@ -67,15 +67,15 @@ public:
             // Check if we checked the default scene and if not, re-check for it.
             // If default scene does not exist in either case, throw an exception
             // If default exists, use it and continue safely.
-            bool is_default = String(scene_file).match(DEFAULT_SCENE);
-            if (is_default || (!is_default && !_file_exists(DEFAULT_SCENE)))
+            bool is_default = String(scene_file).match(_default_scene);
+            if (is_default || (!is_default && !_file_exists(_default_scene)))
             {
-                p_context.set_error(vformat("Failed to find default scene: %s", DEFAULT_SCENE));
+                p_context.set_error(vformat("Failed to find default scene: %s", _default_scene));
                 return -1;
             }
 
             if (!is_default)
-                scene_file = DEFAULT_SCENE;
+                scene_file = _default_scene;
         }
 
         Ref<PackedScene> scene = ResourceLoader::get_singleton()->load(scene_file);
@@ -219,6 +219,7 @@ OScriptNodeInstance* OScriptNodeDialogueMessage::instantiate()
 {
     OScriptNodeDialogueMessageInstance* i = memnew(OScriptNodeDialogueMessageInstance);
     i->_node = this;
+    i->_default_scene = String(OrchestratorSettings::get_singleton()->get_setting("settings/dialogue_message_scene"));
     i->_choices = _choices;
     return i;
 }

--- a/src/script/nodes/dialogue/dialogue_message.cpp
+++ b/src/script/nodes/dialogue/dialogue_message.cpp
@@ -219,7 +219,7 @@ OScriptNodeInstance* OScriptNodeDialogueMessage::instantiate()
 {
     OScriptNodeDialogueMessageInstance* i = memnew(OScriptNodeDialogueMessageInstance);
     i->_node = this;
-    i->_default_scene = String(OrchestratorSettings::get_singleton()->get_setting("settings/dialogue_message_scene"));
+    i->_default_scene = OrchestratorSettings::get_singleton()->get_setting("settings/dialogue/default_message_scene");
     i->_choices = _choices;
     return i;
 }


### PR DESCRIPTION
Adds a setting in Project Settings for the user to set the PackedScene that is instanced by default when a Dialogue Message Node runs in an Orchestrator Script.

Aims to fix issue #838.

**Note**: This is a re-creation of the Branch in PR #840. A rebase was executed incorrectly and the commit history got all messed up. This PR aims to accomplish the exact same goal with none of the clutter created by the aforementioned blunder.