### PR TITLE
GH-535 Add string-based pin suggestion options

### DIFF
--- a/src/editor/graph/pins/graph_node_pin_factory.cpp
+++ b/src/editor/graph/pins/graph_node_pin_factory.cpp
@@ -47,6 +47,9 @@ OrchestratorGraphNodePin* OrchestratorGraphNodePinFactory::_resolve_string_based
         }
     }
 
+    if (p_pin->is_multiline_text())
+        return memnew(OrchestratorGraphNodePinText(p_node, p_pin));
+
     return memnew(OrchestratorGraphNodePinString(p_node, p_pin));
 }
 

--- a/src/editor/graph/pins/graph_node_pin_string.cpp
+++ b/src/editor/graph/pins/graph_node_pin_string.cpp
@@ -82,10 +82,10 @@ void OrchestratorGraphNodePinString::_focus_entered()
         _popup->connect("window_input", callable_mp(this, &OrchestratorGraphNodePinString::_window_input));
         _popup->connect("index_pressed", callable_mp(this, &OrchestratorGraphNodePinString::_suggestion_picked));
         _popup->connect("popup_hide", callable_mp(this, &OrchestratorGraphNodePinString::_popup_hide));
-        _popup->connect("tree_exiting", callable_mp_lambda(this, [=]{ _popup = nullptr; }));
+        _popup->connect("tree_exiting", callable_mp_lambda(this, [this]{ _popup = nullptr; }));
 
         _popup->clear();
-        for (const String suggestion : _suggestions)
+        for (const String& suggestion : _suggestions)
             _popup->add_item(suggestion);
 
         _editor->add_child(_popup);

--- a/src/editor/graph/pins/graph_node_pin_string.h
+++ b/src/editor/graph/pins/graph_node_pin_string.h
@@ -22,8 +22,39 @@
 namespace godot
 {
     class LineEdit;
+    class PopupMenu;
     class TextEdit;
 }
+
+/// An implementation of OrchestratorGraphNodePin for types that want to represent their default values
+/// using a multi-line text field for data entry.
+class OrchestratorGraphNodePinText : public OrchestratorGraphNodePin
+{
+    GDCLASS(OrchestratorGraphNodePinText, OrchestratorGraphNodePin);
+
+    TextEdit* _editor{ nullptr };
+
+protected:
+    //~ Begin Wrapped Interface
+    static void _bind_methods() {}
+    //~ End Wrapped Interface
+
+    //~ Begin OrchestratorGraphNodePin Interface
+    Control* _get_default_value_widget() override;
+    bool _render_default_value_below_label() const override { return true; }
+    //~ End OrchestratorGraphNodePin Interface
+
+    void _text_changed();
+
+    // Default constructor
+    OrchestratorGraphNodePinText() = default;
+
+public:
+    /// Constructs a multi-line text-based pin
+    /// @param p_node the graph node that owns the pin
+    /// @param p_pin the script pin
+    OrchestratorGraphNodePinText(OrchestratorGraphNode* p_node, const Ref<OScriptNodePin>& p_pin);
+};
 
 /// An implementation of OrchestratorGraphNodePin for types that want to represent their default values
 /// using a string-based text field for data entry.
@@ -31,36 +62,48 @@ class OrchestratorGraphNodePinString : public OrchestratorGraphNodePin
 {
     GDCLASS(OrchestratorGraphNodePinString, OrchestratorGraphNodePin);
 
-    static void _bind_methods();
+    LineEdit* _editor{ nullptr };       //! Single line input widget
+    PopupMenu* _popup{ nullptr };       //! Suggestions popup menu
+    PackedStringArray _suggestions;     //! Context suggestions
 
 protected:
-    OrchestratorGraphNodePinString() = default;
-
-    /// Sets the default value on the pin
-    /// @param p_value the default value to set
-    void _set_default_value(const String& p_value);
-
-    /// Called when the text edit's (multi-line text) text changes
-    /// @param p_text_edit the text edit widget
-    void _on_text_changed(TextEdit* p_text_edit);
-
-    /// Called when the line edit's text submitted handler.
-    /// @param p_value the text value submitted
-    /// @param p_line_edit the line edit widget
-    void _on_text_submitted(const String& p_value, LineEdit* p_line_edit);
-
-    /// Called when focus is lost on the line edit widget.
-    /// @param p_line_edit the line edit widget
-    void _on_focus_lost(LineEdit* p_line_edit);
+    //~ Begin Wrapped Interface
+    static void _bind_methods() {}
+    //~ End Wrapped Interface
 
     //~ Begin OrchestratorGraphNodePin Interface
     Control* _get_default_value_widget() override;
-    bool _render_default_value_below_label() const override;
     //~ End OrchestratorGraphNodePin Interface
 
-public:
-    OrchestratorGraphNodePinString(OrchestratorGraphNode* p_node, const Ref<OScriptNodePin>& p_pin);
+    /// Called when the line edit's text submitted handler.
+    /// @param p_value the text value submitted
+    void _text_submitted(const String& p_value);
 
+    /// Called when focus is gained for the line edit widget.
+    void _focus_entered();
+
+    /// Called when focus is lost on the line edit widget.
+    void _focus_exited();
+
+    /// Called when the popup suggestion menu is hidden
+    void _popup_hide();
+
+    /// Handles popup window input
+    /// @param p_event the input event
+    void _window_input(const Ref<InputEvent>& p_event);
+
+    /// Handles a suggestion pick
+    /// @param p_index the suggestion index
+    void _suggestion_picked(int p_index);
+
+    // Default constructor
+    OrchestratorGraphNodePinString() = default;
+
+public:
+    /// Constructs a string-based pin
+    /// @param p_node the graph node that owns the pin
+    /// @param p_pin the script pin
+    OrchestratorGraphNodePinString(OrchestratorGraphNode* p_node, const Ref<OScriptNodePin>& p_pin);
 };
 
 #endif  // ORCHESTRATOR_GRAPH_NODE_PIN_STRING_H

--- a/src/editor/register_editor_types.cpp
+++ b/src/editor/register_editor_types.cpp
@@ -153,6 +153,7 @@ void register_editor_types()
     GDREGISTER_INTERNAL_CLASS(OrchestratorGraphNodePinObject)
     GDREGISTER_INTERNAL_CLASS(OrchestratorGraphNodePinString)
     GDREGISTER_INTERNAL_CLASS(OrchestratorGraphNodePinStruct)
+    GDREGISTER_INTERNAL_CLASS(OrchestratorGraphNodePinText)
 
     // Add plugin to the editor
     EditorPlugins::add_by_type<OrchestratorPlugin>();

--- a/src/script/node.h
+++ b/src/script/node.h
@@ -395,6 +395,11 @@ public:
     /// Return whether the specified port is a loop-based port
     virtual bool is_loop_port(int p_port) const { return false; }
 
+    /// Get suggestion options for the specified pin.
+    /// @param p_pin the pin
+    /// @return a list of suggestion options as contextual choices
+    virtual PackedStringArray get_suggestions(const Ref<OScriptNodePin>& p_pin) { return PackedStringArray(); }
+
 protected:
     /// Notify that node pins have been changed.
     void _notify_pins_changed();

--- a/src/script/node_pin.h
+++ b/src/script/node_pin.h
@@ -333,6 +333,11 @@ public:
     /// Attempts to resolve the target object of this pin.
     /// @return the target object of the pin or {@code nullptr} if there is no target.
     Ref<OScriptTargetObject> resolve_target();
+
+    /// Resolves signal names for pin's connected object. Only applicable for input pins.
+    /// @param p_self_fallback whether to get signal names from script's node as a fallback
+    /// @return signal names list
+    PackedStringArray resolve_signal_names(bool p_self_fallback = false);
 };
 
 VARIANT_BITFIELD_CAST(OScriptNodePin::Flags)

--- a/src/script/nodes/functions/call_member_function.cpp
+++ b/src/script/nodes/functions/call_member_function.cpp
@@ -255,3 +255,27 @@ void OScriptNodeCallMemberFunction::validate_node_during_build(BuildLog& p_log) 
 
     super::validate_node_during_build(p_log);
 }
+
+PackedStringArray OScriptNodeCallMemberFunction::get_suggestions(const Ref<OScriptNodePin>& p_pin)
+{
+    if (p_pin.is_valid() && p_pin->is_input() && p_pin->get_pin_name().match("signal"))
+    {
+        const MethodInfo method = get_method_info();
+        const bool is_object = Object::get_class_static().match(get_target_class());
+
+        const bool object_connect = method.name.match("connect") && is_object;
+        const bool object_disconnect = method.name.match("disconnect") && is_object;
+        const bool object_is_connected = method.name.match("is_connected") && is_object;
+        const bool object_emit_signal = method.name.match("emit_signal") && is_object;
+
+        if (object_connect || object_disconnect || object_is_connected || object_emit_signal)
+        {
+            const Ref<OScriptNodePin> target_pin = find_pin("target", PD_Input);
+            if (target_pin.is_valid())
+                return target_pin->resolve_signal_names(true);
+        }
+    }
+
+    return super::get_suggestions(p_pin);
+}
+

--- a/src/script/nodes/functions/call_member_function.h
+++ b/src/script/nodes/functions/call_member_function.h
@@ -52,6 +52,7 @@ public:
     String get_help_topic() const override;
     void initialize(const OScriptNodeInitContext& p_context) override;
     void validate_node_during_build(BuildLog& p_log) const override;
+    PackedStringArray get_suggestions(const Ref<OScriptNodePin>& p_pin) override;
     //~ End OScriptNode Interface
 
     /// Get the target function class

--- a/src/script/nodes/signals/await_signal.cpp
+++ b/src/script/nodes/signals/await_signal.cpp
@@ -88,3 +88,24 @@ void OScriptNodeAwaitSignal::validate_node_during_build(BuildLog& p_log) const
 
     return super::validate_node_during_build(p_log);
 }
+
+void OScriptNodeAwaitSignal::on_pin_disconnected(const Ref<OScriptNodePin>& p_pin)
+{
+    // Makes sure that signal list pin changes to string renderer
+    if (p_pin.is_valid() && p_pin->get_pin_name().match("target"))
+        _notify_pins_changed();
+
+    super::on_pin_disconnected(p_pin);
+}
+
+PackedStringArray OScriptNodeAwaitSignal::get_suggestions(const Ref<OScriptNodePin>& p_pin)
+{
+    if (p_pin.is_valid() && p_pin->is_input() && p_pin->get_pin_name().match("signal_name"))
+    {
+        const Ref<OScriptNodePin> target_pin = find_pin("target", PD_Input);
+        if (target_pin.is_valid())
+            return target_pin->resolve_signal_names();
+    }
+
+    return super::get_suggestions(p_pin);
+}

--- a/src/script/nodes/signals/await_signal.h
+++ b/src/script/nodes/signals/await_signal.h
@@ -41,6 +41,8 @@ public:
     String get_node_title_color_name() const override { return "signals"; }
     OScriptNodeInstance* instantiate() override;
     void validate_node_during_build(BuildLog& p_log) const override;
+    void on_pin_disconnected(const Ref<OScriptNodePin>& p_pin) override;
+    PackedStringArray get_suggestions(const Ref<OScriptNodePin>& p_pin) override;
     //~ End OScriptNode Interface
 };
 


### PR DESCRIPTION
Fixes #535 

An `OScriptNode` can now override the `get_suggestions` function, which returns a `PackedStringArray` of suggestion options based on the supplied pin that will be shown in a `PopupMenu`. This is used only for `OrchestratorGraphNodePinString` pin types.