### PR TITLE
Fix README icon behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following screenshots only scratch the surface of what the plug-in offers ou
 
 ![screen-shot](https://static.cratercrash.space/orchestrator/images/screenshots/screenshot_d.png)
 
-## ![icon](https://static.cratercrash.space/orchestrator/images/icons/orchestrator_menu_image_500px.png?width=auto&height=30)  Godot Compatibility
+## ![icon](https://static.cratercrash.space/orchestrator/images/icons/orchestrator_menu_image_500px.png?width=auto&height=20)  Godot Compatibility
 
 Orchestrator is made using Godot GDExtension technology, which has certain ABI (application binary interface) requirements that must be followed to guarantee that the integration between extensions and the engine works as expected.
 The following table describes which Orchestrator version you should use based on your Godot editor version.
@@ -37,7 +37,7 @@ The following table describes which Orchestrator version you should use based on
 **Using the wrong version of Orchestrator with the Godot editor may result in unexpected behavior or crashes.**
 **Additionally, if your Godot version is not listed, it should be assumed the plug-in is not yet 100% compatible.**
 
-## ![icon](https://static.cratercrash.space/orchestrator/images/icons/orchestrator_menu_image_500px.png?width=auto&height=30) Features
+## ![icon](https://static.cratercrash.space/orchestrator/images/icons/orchestrator_menu_image_500px.png?width=auto&height=20) Features
 
 * A complete visual scripting solution for Godot.
 * Compatible with Godot 4.2+ using Godot GDExtension plug-in technology.
@@ -49,26 +49,26 @@ The following table describes which Orchestrator version you should use based on
 * Design complex dialogue conversations for NPCs for any game.
 * Work with any Godot engine data type, including complex types like Arrays or Dictionaries.
 
-## ![icon](https://static.cratercrash.space/orchestrator/images/icons/orchestrator_menu_image_500px.png?width=auto&height=30) Documentation
+## ![icon](https://static.cratercrash.space/orchestrator/images/icons/orchestrator_menu_image_500px.png?width=auto&height=20) Documentation
 
 For complete documentation, see https://docs.cratercrash.space/orchestrator.
 
-## ![icon](https://static.cratercrash.space/orchestrator/images/icons/orchestrator_menu_image_500px.png?width=auto&height=30) Changelog
+## ![icon](https://static.cratercrash.space/orchestrator/images/icons/orchestrator_menu_image_500px.png?width=auto&height=20) Changelog
 
 See [CHANGELOG](https://github.com/CraterCrash/godot-orchestrator/blob/main/CHANGELOG.md).
 
-## ![icon](https://static.cratercrash.space/orchestrator/images/icons/orchestrator_menu_image_500px.png?width=auto&height=30) Licenses
+## ![icon](https://static.cratercrash.space/orchestrator/images/icons/orchestrator_menu_image_500px.png?width=auto&height=20) Licenses
 
 - Source code: [Apache-2.0 License](/LICENSE)
 - Godot logo: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/)
 - Orchestrator logo: [&copy; 2023-present Crater Crash Studios, LLC. All Rights Reserved](https://www.cratercrash.com/legal/webcn)
 
-## ![icon](https://static.cratercrash.space/orchestrator/images/icons/orchestrator_menu_image_500px.png?width=auto&height=30) Community
+## ![icon](https://static.cratercrash.space/orchestrator/images/icons/orchestrator_menu_image_500px.png?width=auto&height=20) Community
 
 - [Discord](https://discord.gg/wYQpvuYDhT)
 - [Mastodon](https://cratercrash.social/@orchestrator)
 
-## ![icon](https://static.cratercrash.space/orchestrator/images/icons/orchestrator_menu_image_500px.png?width=auto&height=30) Contributors
+## ![icon](https://static.cratercrash.space/orchestrator/images/icons/orchestrator_menu_image_500px.png?width=auto&height=20) Contributors
 
 <a href="https://github.com/CraterCrash/godot-orchestrator/graphs/contributors">
   <img src="https://contributors-img.web.app/image?repo=CraterCrash/godot-orchestrator" />


### PR DESCRIPTION
Fix unexpected behavior of icon orchestrator_menu_image_500px.png appearing as way too big with height=30 and changed it to height=20 to work as (supposedly) expected

Happened when tested in Chromium (Brave) and WebKit (Safari) browsers so unexpected behavior from GitHub markdown preview because the height became too big and overflowed the height of the line I suppose

<img width="983" alt="image" src="https://github.com/user-attachments/assets/8d07cf74-b245-4eba-8832-479b0640b7f2" />
