### PR TITLE
Trim argument values for resolution

### DIFF
--- a/src/editor/script_editor_viewport.cpp
+++ b/src/editor/script_editor_viewport.cpp
@@ -506,6 +506,8 @@ void OrchestratorScriptEditorViewport::add_script_function(Object* p_object, con
     {
         PackedStringArray bits = argument.split(":");
 
+        bits[1] = bits[1].strip_edges();
+
         if (ClassDB::get_class_list().has(bits[1]))
         {
             // Type represents a registered class.


### PR DESCRIPTION
When parsing function parameter types, spaces before and after the type name were not properly handled, causing registered class types to fail to be correctly identified. Now, by using the strip_edges() method to clean up spaces before and after the type name, it ensures correct matching with types in the class database.