### PR TITLE
GH-1246 Rework Break for extra Variant properties

### DIFF
--- a/src/editor/actions/introspector.cpp
+++ b/src/editor/actions/introspector.cpp
@@ -854,12 +854,43 @@ Vector<Ref<OrchestratorEditorIntrospector::Action>> OrchestratorEditorIntrospect
                     .build());
             }
 
-            actions.push_back(
+            if (type.type == Variant::COLOR) {
+                actions.push_back(
+                _script_node_builder<OScriptNodeDecompose>(
+                    category,
+                    vformat("Break %s into RGBA", type_name),
+                    DictionaryUtils::of({ { "type", type.type }, { "sub_type", OScriptNodeDecompose::ST_COLOR_RGBA } }))
+                .no_capitalize(true)
+                .build());
+                actions.push_back(
+                    _script_node_builder<OScriptNodeDecompose>(
+                        category,
+                        vformat("Break %s into RGBA8", type_name),
+                        DictionaryUtils::of({ { "type", type.type }, { "sub_type", OScriptNodeDecompose::ST_COLOR_RGBA8 } }))
+                    .no_capitalize(true)
+                    .build());
+                actions.push_back(
+                    _script_node_builder<OScriptNodeDecompose>(
+                        category,
+                        vformat("Break %s into HSV", type_name),
+                        DictionaryUtils::of({ { "type", type.type }, { "sub_type", OScriptNodeDecompose::ST_COLOR_HSV } }))
+                    .no_capitalize(true)
+                    .build());
+                actions.push_back(
+                    _script_node_builder<OScriptNodeDecompose>(
+                        category,
+                        vformat("Break %s into OK HSL", type_name),
+                        DictionaryUtils::of({ { "type", type.type }, { "sub_type", OScriptNodeDecompose::ST_COLOR_OK_HSL } }))
+                    .no_capitalize(true)
+                    .build());
+            } else {
+                actions.push_back(
                 _script_node_builder<OScriptNodeDecompose>(
                     category,
                     vformat("Break %s", type_name),
                     type_dict)
                 .build());
+            }
         }
 
         if (!type.constructors.is_empty()) {

--- a/src/script/nodes/data/decompose.cpp
+++ b/src/script/nodes/data/decompose.cpp
@@ -24,6 +24,49 @@
 
 OScriptNodeDecompose::TypeMap OScriptNodeDecompose::_type_components;
 
+PackedStringArray OScriptNodeDecompose::_get_components() const {
+    PackedStringArray results;
+
+    const Array &components = _type_components[_type];
+    int64_t index_start = 0;
+    int64_t index_end = components.size();
+    if (_type == Variant::COLOR) {
+        switch (_sub_type) {
+            case ST_NONE:
+            case ST_COLOR_RGBA: {
+                index_start = 0;
+                index_end = 4;
+                break;
+            }
+            case ST_COLOR_RGBA8: {
+                index_start = 4;
+                index_end = 8;
+                break;
+            }
+            case ST_COLOR_HSV: {
+                index_start = 8;
+                index_end = 11;
+                break;
+            }
+            case ST_COLOR_OK_HSL: {
+                index_start = 11;
+                index_end = components.size();
+                break;
+            }
+            default: {
+                // no-op
+                break;
+            }
+        }
+    }
+
+    for (int64_t i = index_start; i < index_end; i++) {
+        results.push_back(components[i]);
+    }
+
+    return results;
+}
+
 void OScriptNodeDecompose::post_initialize() {
     // Clone this from the input pin
     _type = find_pin("value", PD_Input)->get_type();
@@ -35,17 +78,20 @@ void OScriptNodeDecompose::allocate_default_pins() {
     create_pin(PD_Input, PT_Data, PropertyUtils::make_typed("value", _type))->set_flag(OScriptNodePin::Flags::IGNORE_DEFAULT);
 
     Variant value = VariantUtils::make_default(_type);
-    const Array &components = _type_components[_type];
-    for (int i = 0; i < components.size(); i++) {
-        const Variant bit = value.get(components[i]);
-        create_pin(PD_Output, PT_Data, PropertyUtils::make_typed(components[i], bit.get_type()));
+
+    for (const String& component : _get_components()) {
+        const Variant bit = value.get(component);
+        const Ref<OScriptNodePin> pin = create_pin(PD_Output, PT_Data, PropertyUtils::make_typed(component, bit.get_type()));
+        if (_type == Variant::COLOR) {
+            pin->set_flag(OScriptNodePin::NO_CAPITALIZE);
+        }
     }
 }
 
 String OScriptNodeDecompose::get_tooltip_text() const {
     if (_type != Variant::NIL) {
         const String type_name = VariantUtils::get_friendly_type_name(_type);
-        const String components = StringUtils::join(", ", _type_components[_type]);
+        const String components = StringUtils::join(", ", _get_components());
         return vformat("Break a %s into %s", type_name, components);
     }
     return "Breaks a complex structure into its components";
@@ -78,6 +124,8 @@ void OScriptNodeDecompose::initialize(const OScriptNodeInitContext& p_context) {
     ERR_FAIL_COND_MSG(!data.has("type"), "Cannot properly initialize decompose node, no type specified.");
 
     _type = VariantUtils::to_type(data["type"]);
+    _sub_type = static_cast<SubType>(static_cast<int32_t>(data.get("sub_type", ST_NONE)));
+
     super::initialize(p_context);
 }
 
@@ -89,24 +137,11 @@ void OScriptNodeDecompose::_bind_methods() {
             for (const PropertyInfo& pi : type.properties) {
                 properties.push_back(pi.name);
             }
-
-            if (type.type == Variant::COLOR) {
-                // Color exposes a variety of additional properties, we only concern ourselves
-                // with the R,G,B,A properties and not R8,G8,B8,A8 nor H, S, or V.
-                properties.resize(4);
-            }
-            else if (type.type == Variant::PLANE) {
-                // Plane exposes not only the X,Y,Z and distance but also the normal.
-                // We want to express planes only via X, Y, Z, and distance.
-                properties.resize(4);
-            }
-            else if (type.type == Variant::AABB) {
-                // AABB exposes position, size, and end.
-                // We only want to express AABB via position and size only.
-                properties.resize(2);
-            }
-
             _type_components[type.type] = properties;
         }
     }
+
+    ClassDB::bind_method(D_METHOD("_set_sub_type", "type"), &OScriptNodeDecompose::_set_sub_type);
+    ClassDB::bind_method(D_METHOD("_get_sub_type"), &OScriptNodeDecompose::_get_sub_type);
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "sub_type", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "_set_sub_type", "_get_sub_type");
 }

--- a/src/script/nodes/data/decompose.h
+++ b/src/script/nodes/data/decompose.h
@@ -33,10 +33,27 @@
 class OScriptNodeDecompose : public OScriptNode {
     ORCHESTRATOR_NODE_CLASS(OScriptNodeDecompose, OScriptNode);
 
+public:
+    enum SubType : int32_t {
+        ST_NONE,
+        ST_COLOR_RGBA,
+        ST_COLOR_HSV,
+        ST_COLOR_RGBA8,
+        ST_COLOR_OK_HSL,
+        ST_MAX
+    };
+
+private:
     using TypeMap = HashMap<Variant::Type, Array>;
 
     static TypeMap _type_components;        //! Various types and respective components
     Variant::Type _type = Variant::NIL;     //! Transient type to pass from creation metadata
+    SubType _sub_type = ST_NONE;
+
+    int _get_sub_type() const { return _sub_type; }
+    void _set_sub_type(int p_sub_type) { _sub_type = static_cast<SubType>(p_sub_type); }
+
+    PackedStringArray _get_components() const;
 
 protected:
     static void _bind_methods();


### PR DESCRIPTION
Fixes #1246 

The break nodes were previously designed to only render specific Variant properties on Color, Plane, and AABB that matched the arguments in the variant type's constructor. This meant that for these types, only limited properties could be accessed.

In addition, the break node for AABB exposes end and for Plane the break node exposes normal.

<img width="725" height="426" alt="image" src="https://github.com/user-attachments/assets/ce40c51e-2158-4009-8514-ef28040fed18" />

The rework involves creating 4 specific break nodes for Color: RGBA, RGBA8, HSV, and OK_HSL

<img width="242" height="329" alt="image" src="https://github.com/user-attachments/assets/2345bf33-28d9-4b34-ad0c-1610d53f37d5" />
