### PR TITLE
GH-1263 Do not auto-init script language

### DIFF
--- a/src/api/extension_interface.cpp
+++ b/src/api/extension_interface.cpp
@@ -41,9 +41,6 @@ namespace orchestrator {
         if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
             register_script_scene_types();
             register_editor_types();
-
-            // See https://github.com/godotengine/godot/pull/114131
-            initialize_script_extension();
         }
     }
 

--- a/src/script/language.cpp
+++ b/src/script/language.cpp
@@ -39,7 +39,6 @@
 #include <godot_cpp/classes/expression.hpp>
 #include <godot_cpp/classes/file_access.hpp>
 #include <godot_cpp/classes/packed_scene.hpp>
-#include <godot_cpp/classes/reg_ex.hpp>
 #include <godot_cpp/classes/resource_loader.hpp>
 #include <godot_cpp/core/mutex_lock.hpp>
 
@@ -121,15 +120,6 @@ String OScriptLanguage::_get_name() const {
 }
 
 void OScriptLanguage::_init() {
-    // See https://github.com/godotengine/godot/pull/114131
-    // The issue is that when a GDExtension is added to a project, it is loaded after Godot's
-    // ScriptServer::init_languages method has been called. To work around this issue, the
-    // language's initialization is called directly. This variable prevents the main init call
-    // from the engine from double initializing the language.
-    if (initialized) {
-        return;
-    }
-
     _template_registry = memnew(OScriptTemplateRegistry);
 
     _debug_max_call_stack = ORCHESTRATOR_GET("settings/runtime/max_call_stack", 1024);

--- a/src/script/language.h
+++ b/src/script/language.h
@@ -205,6 +205,8 @@ public:
     _FORCE_INLINE_ const HashMap<StringName, int>& get_global_map() const { return globals; }
     _FORCE_INLINE_ const HashMap<StringName, Variant>& get_named_globals_map() const { return named_globals; }
 
+    bool is_initialized() const { return initialized; }
+
     void add_orphan_subclass(const String& p_qualified_name, const ObjectID& p_subclass);
     Ref<OScript> get_orphan_subclass(const String& p_qualified_name);
 

--- a/src/script/register_script_types.cpp
+++ b/src/script/register_script_types.cpp
@@ -134,10 +134,6 @@ void unregister_script_extension() {
     }
 }
 
-void initialize_script_extension() {
-    OScriptLanguage::get_singleton()->_init();
-}
-
 void register_script_node_types() {
     // Script Nodes (Abstracts first)
     ORCHESTRATOR_REGISTER_ABSTRACT_NODE_CLASS(OScriptEditablePinNode)

--- a/src/script/register_script_types.h
+++ b/src/script/register_script_types.h
@@ -23,8 +23,6 @@ void unregister_script_types();
 void register_script_extension();
 void unregister_script_extension();
 
-void initialize_script_extension();
-
 void register_script_node_types();
 void unregister_script_node_types();
 


### PR DESCRIPTION
Fixes #1263 

This forces the scripting language to rely on a forced editor restart when the language is enabled only.