### PR TITLE
GH-1235 Support file-based script inheritance

### DIFF
--- a/src/editor/inspector/orchestration_inspector_plugin.cpp
+++ b/src/editor/inspector/orchestration_inspector_plugin.cpp
@@ -1,0 +1,51 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editor/inspector/orchestration_inspector_plugin.h"
+
+#include "common/callable_lambda.h"
+#include "editor/inspector/properties/editor_property_extends.h"
+#include "orchestration/orchestration.h"
+
+bool OrchestratorEditorInspectorPluginOrchestration::_can_handle(Object* p_object) const {
+    return p_object && p_object->get_class() == Orchestration::get_class_static();
+}
+
+bool OrchestratorEditorInspectorPluginOrchestration::_parse_property(Object* p_object, Variant::Type p_type, const String& p_name,
+    PropertyHint p_hint_type, const String& p_hint_string, BitField<PropertyUsageFlags> p_usage_flags, bool p_wide) {
+
+    const Ref<Orchestration> orchestration = cast_to<Orchestration>(p_object);
+    if (orchestration.is_valid() && p_name == "base_type") {
+        OrchestratorEditorPropertyExtends* editor = memnew(OrchestratorEditorPropertyExtends);
+        editor->setup(orchestration->get_base_type(), true);
+        editor->connect("property_changed", callable_mp_lambda(
+            this,
+            [orchestration](const StringName& property, const Variant& value, const StringName& field, bool changing) {
+                if (orchestration.is_valid()) {
+                    orchestration->set_edited(true);
+                }
+            }));
+
+        #if GODOT_VERSION >= 0x040300
+        add_property_editor(p_name, editor, true, "Extends");
+        #else
+        add_property_editor(p_name, editor, true);
+        #endif
+        //return true;
+    }
+
+    return false;
+}

--- a/src/editor/inspector/orchestration_inspector_plugin.h
+++ b/src/editor/inspector/orchestration_inspector_plugin.h
@@ -1,0 +1,38 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ORCHESTRATOR_EDITOR_INSPECTOR_PLUGIN_ORCHESTRATION_H
+#define ORCHESTRATOR_EDITOR_INSPECTOR_PLUGIN_ORCHESTRATION_H
+
+#include <godot_cpp/classes/editor_inspector_plugin.hpp>
+
+using namespace godot;
+
+/// An EditorInspectorPlugin that handles Orchestration object selection
+class OrchestratorEditorInspectorPluginOrchestration : public EditorInspectorPlugin {
+    GDCLASS(OrchestratorEditorInspectorPluginOrchestration, EditorInspectorPlugin);
+
+protected:
+    static void _bind_methods() { }
+
+public:
+    //~ Begin EditorInspectorPlugin Interface
+    bool _can_handle(Object* p_object) const override;
+    bool _parse_property(Object* p_object, Variant::Type p_type, const String& p_name, PropertyHint p_hint_type, const String& p_hint_string, BitField<PropertyUsageFlags> p_usage_flags, bool p_wide) override;
+    //~ End EditorInspectorPlugin Interface
+};
+
+#endif // ORCHESTRATOR_EDITOR_INSPECTOR_PLUGIN_ORCHESTRATION_H

--- a/src/editor/inspector/properties/editor_property_extends.cpp
+++ b/src/editor/inspector/properties/editor_property_extends.cpp
@@ -1,0 +1,130 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editor/inspector/properties/editor_property_extends.h"
+
+#include "common/callable_lambda.h"
+#include "common/macros.h"
+#include "common/scene_utils.h"
+#include "common/version.h"
+#include "core/godot/core_string_names.h"
+#include "core/godot/scene_string_names.h"
+#include "editor/gui/dialogs_helper.h"
+#include "editor/gui/file_dialog.h"
+
+#include <godot_cpp/classes/editor_file_dialog.hpp>
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/h_box_container.hpp>
+
+void OrchestratorEditorPropertyExtends::_select_extends_class() {
+    if (_editor_property_class) {
+        Control* button = cast_to<Button>(_editor_property_class->find_child("*Button*", true, false));
+        if (button) {
+            button->emit_signal("pressed");
+        }
+    }
+}
+
+void OrchestratorEditorPropertyExtends::_select_extends_path() {
+    OrchestratorFileDialog* dialog = memnew(OrchestratorFileDialog);
+    dialog->set_file_mode(FileDialog::FILE_MODE_OPEN_FILE);
+    dialog->set_access(FileDialog::ACCESS_RESOURCES);
+    dialog->set_hide_on_ok(true);
+    dialog->clear_filters();
+    dialog->add_filter("*.os,*.torch", "Orchestrations");
+    dialog->set_customization_flag_enabled(FileDialog::CUSTOMIZATION_FILE_FILTER, false);
+    dialog->connect("canceled", callable_mp_lambda(this, [dialog] { dialog->queue_free(); }));
+    dialog->connect("file_selected", callable_mp_this(_extends_path_selected));
+    add_child(dialog);
+
+    dialog->popup_file_dialog();
+    dialog->set_title("Select Orchestration To Extend");
+}
+
+void OrchestratorEditorPropertyExtends::_extends_path_selected(const String& p_path) {
+    const String extension = p_path.get_extension();
+    if (!Array::make("os", "torch").has(extension)) {
+        ORCHESTRATOR_ERROR("The selected file is not an orchestration.");
+    }
+
+    emit_changed("base_type", p_path);
+}
+
+void OrchestratorEditorPropertyExtends::_update_property() {
+    if (get_edited_object()) {
+        _selected_value = get_edited_object()->get(get_edited_property());
+        _extends->set_text(_selected_value);
+    }
+}
+
+void OrchestratorEditorPropertyExtends::setup(const String& p_base_type, bool p_allow_path) {
+    _base_type = p_base_type;
+    _allow_path = p_allow_path;
+}
+
+void OrchestratorEditorPropertyExtends::_notification(int p_what) {
+    #if GODOT_VERSION <= 0x040202
+    EditorProperty::_notification(p_what);
+    #endif
+
+    switch (p_what) {
+        case NOTIFICATION_READY: {
+            HBoxContainer* container = memnew(HBoxContainer);
+            container->set_h_size_flags(SIZE_EXPAND_FILL);
+
+            _extends = memnew(LineEdit);
+            _extends->set_h_size_flags(SIZE_EXPAND_FILL);
+            _extends->set_text(_base_type);
+            _extends->connect(SceneStringName(focus_exited), callable_mp_lambda(this, [this] {
+                emit_changed(get_edited_property(), _extends->get_text());
+            }));
+            _extends->connect(SceneStringName(text_submitted), callable_mp_lambda(this, [this] (const String& p_value) {
+                emit_changed(get_edited_property(), p_value);
+            }));
+            container->add_child(_extends);
+
+            _select_class_button = memnew(Button);
+            _select_class_button->set_button_icon(SceneUtils::get_editor_icon("ClassList"));
+            _select_class_button->set_tooltip_text("Extend from a native or Orchestration-defined class");
+            _select_class_button->connect(SceneStringName(pressed), callable_mp_this(_select_extends_class));
+            container->add_child(_select_class_button);
+
+            if (_allow_path) {
+                _select_path_button = memnew(Button);
+                _select_path_button->set_button_icon(SceneUtils::get_editor_icon("Folder"));
+                _select_path_button->set_tooltip_text("Extend from another Orchestration that is not a class");
+                _select_path_button->connect(SceneStringName(pressed), callable_mp_this(_select_extends_path));
+                container->add_child(_select_path_button);
+            }
+
+            add_child(container);
+            add_focusable(_extends);
+
+            int node_index = get_index();
+            if (node_index >= 1) {
+                // Allows us to reuse the same class selection behavior
+                _editor_property_class = cast_to<Control>(get_parent()->get_child(node_index - 1));
+                _editor_property_class->set_visible(false);
+            }
+
+            break;
+        }
+    }
+}
+
+void OrchestratorEditorPropertyExtends::_bind_methods() {
+
+}

--- a/src/editor/inspector/properties/editor_property_extends.h
+++ b/src/editor/inspector/properties/editor_property_extends.h
@@ -1,0 +1,63 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef ORCHESTRATOR_EDITOR_PROPERTY_EXTENDS_H
+#define ORCHESTRATOR_EDITOR_PROPERTY_EXTENDS_H
+
+#include <godot_cpp/classes/button.hpp>
+#include <godot_cpp/classes/editor_property.hpp>
+#include <godot_cpp/classes/line_edit.hpp>
+
+using namespace godot;
+
+class OrchestratorEditorPropertyExtends : public EditorProperty {
+    GDCLASS(OrchestratorEditorPropertyExtends, EditorProperty);
+
+    Button* _select_class_button = nullptr;
+    Button* _select_path_button = nullptr;
+    LineEdit* _extends = nullptr;
+    String _base_type;
+    String _selected_value;
+    bool _allow_path = false;
+    Control* _editor_property_class = nullptr;
+
+protected:
+    static void _bind_methods();
+
+    //~ Begin Wrapped Interface
+    void _notification(int p_what);
+    //~ End Wrapped Interface
+
+    //~ Begin Signal Handlers
+    void _select_extends_class();
+    void _select_extends_path();
+    void _extends_path_selected(const String& p_path);
+    //~ End Signal Handlers
+
+public:
+    //~ Begin EditorProperty Interface
+    void _update_property() override;
+    //~ End EditorProperty Interface
+
+    String get_selected_value() const { return _selected_value; }
+
+    /// Setup the editor property
+    /// @param p_base_type the base type
+    /// @param p_allow_path whether the path option is selectable
+    void setup(const String& p_base_type, bool p_allow_path = true);
+};
+
+#endif

--- a/src/editor/plugins/orchestrator_editor_plugin.cpp
+++ b/src/editor/plugins/orchestrator_editor_plugin.cpp
@@ -24,6 +24,7 @@
 #include "editor/export/orchestration_export_plugin.h"
 #include "editor/gui/window_wrapper.h"
 #include "editor/inspector/function_inspector_plugin.h"
+#include "editor/inspector/orchestration_inspector_plugin.h"
 #include "editor/inspector/signal_inspector_plugin.h"
 #include "editor/inspector/type_cast_inspector_plugin.h"
 #include "editor/inspector/variable_inspector_plugin.h"
@@ -71,6 +72,7 @@ void OrchestratorPlugin::_register_plugins() {
     _register_inspector_plugin<OrchestratorEditorInspectorPluginSignal>();
     _register_inspector_plugin<OrchestratorEditorInspectorPluginVariable>();
     _register_inspector_plugin<OrchestratorEditorInspectorPluginTypeCast>();
+    _register_inspector_plugin<OrchestratorEditorInspectorPluginOrchestration>();
 
     // Export Plugins
     _register_export_plugin<OrchestratorEditorExportPlugin>();

--- a/src/editor/register_editor_types.cpp
+++ b/src/editor/register_editor_types.cpp
@@ -40,7 +40,9 @@
 #include "editor/gui/select_type_dialog.h"
 #include "editor/gui/window_wrapper.h"
 #include "editor/inspector/function_inspector_plugin.h"
+#include "editor/inspector/orchestration_inspector_plugin.h"
 #include "editor/inspector/properties/editor_property_class_name.h"
+#include "editor/inspector/properties/editor_property_extends.h"
 #include "editor/inspector/properties/editor_property_pin_properties.h"
 #include "editor/inspector/properties/editor_property_variable_classification.h"
 #include "editor/inspector/signal_inspector_plugin.h"
@@ -66,6 +68,7 @@ void register_editor_types() {
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorInspectorPluginSignal)
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorInspectorPluginVariable)
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorInspectorPluginTypeCast)
+    GDREGISTER_INTERNAL_CLASS(OrchestratorEditorInspectorPluginOrchestration)
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorGraphNodeThemeCache)
 
     // Editor bits
@@ -73,6 +76,7 @@ void register_editor_types() {
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorPropertyClassName)
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorPropertyPinProperties)
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorPropertyVariableClassification)
+    GDREGISTER_INTERNAL_CLASS(OrchestratorEditorPropertyExtends)
     GDREGISTER_INTERNAL_CLASS(OrchestratorFileDialog)
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorSearchDialogItem)
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorSearchDialog)

--- a/src/editor/script_editor_view.cpp
+++ b/src/editor/script_editor_view.cpp
@@ -243,6 +243,9 @@ void OrchestratorScriptGraphEditorView::_update_editor_script_buttons() {
         if (!global_name.is_empty()) {
             button->set_text(vformat("%s Extends %s", global_name, script_type));
             button->set_button_icon(SceneUtils::get_class_icon(global_name));
+        } else if (script_type.begins_with("res://")) {
+            button->set_text(vformat("Extends %s", script_type));
+            button->set_button_icon(SceneUtils::get_class_icon(_script->get_native()->get_name()));
         } else {
             button->set_text(vformat("Extends %s", script_type));
             button->set_button_icon(SceneUtils::get_class_icon(script_type));
@@ -731,6 +734,7 @@ void OrchestratorScriptGraphEditorView::set_edited_resource(const Ref<Resource>&
 
     // Makes sure that when Orchestration changes, any editor tab panels are updated
     _script->get_orchestration()->connect(CoreStringName(changed), callable_mp_this(_update_editor_script_buttons));
+    _script->get_orchestration()->connect(CoreStringName(changed), callable_mp_this(_queue_validate_script));
     _script->get_orchestration()->connect("reloaded", callable_mp_this(_update_editor_post_reload));
     _script->connect(CoreStringName(changed), callable_mp_this(_update_editor_script_buttons));
 

--- a/src/script/parser/parser.cpp
+++ b/src/script/parser/parser.cpp
@@ -2866,10 +2866,14 @@ OScriptParser::ClassNode* OScriptParser::build_class(Orchestration* p_orchestrat
     clazz->fqcn = OScript::canonicalize_path(script_path);
     current_class = clazz;
 
-    // todo: can this extends logic be improved or cleaned up?
-    IdentifierNode* base = build_identifier(p_orchestration->get_base_type());
-    clazz->extends.push_back(base);
-    clazz->extends_used = true;
+    if (p_orchestration->get_base_type().begins_with("res://")) {
+        clazz->extends_path = p_orchestration->get_base_type();
+        clazz->extends_used = true;
+    } else {
+        IdentifierNode* base = build_identifier(p_orchestration->get_base_type());
+        clazz->extends.push_back(base);
+        clazz->extends_used = true;
+    }
 
     if (!p_orchestration->get_global_name().is_empty()) {
          clazz->identifier = build_identifier(p_orchestration->get_global_name());


### PR DESCRIPTION
Fixes #1235 

The base type field is now called _Extends_ and is rendered using a `LineEdit` control rather than a single button. This allows for placing the extended value in one of three ways:

* Pasting the class name or file path manually into the `LineEdit`
* Clicking the `ClassList` button to select from the class list dialog window
* Clicking the `Folder` button to select a `.os` or `.torch` file as the base script type

The new control in the inspector looks like this:
<img width="490" height="48" alt="image" src="https://github.com/user-attachments/assets/ebb0335f-aa7f-4990-a33d-0a128f68bef6" />
