### PR TITLE
GH-1283 Remove support for Godot 4.2 and 4.3

### DIFF
--- a/src/common/macros.h
+++ b/src/common/macros.h
@@ -30,12 +30,6 @@
             obj->disconnect(signal, method);        \
         }
 
-#if GODOT_VERSION < 0x040202
-#define GDE_NOTIFICATION(p, x) p::_notification(x);
-#else
-#define GDE_NOTIFICATION(p, x)
-#endif
-
 #define BEGIN_NOTIFICATION_HANDLER(x)               \
     switch(x) {
 

--- a/src/common/property_utils.cpp
+++ b/src/common/property_utils.cpp
@@ -103,9 +103,7 @@ namespace PropertyUtils {
             case Variant::PACKED_STRING_ARRAY:
             case Variant::PACKED_VECTOR2_ARRAY:
             case Variant::PACKED_VECTOR3_ARRAY:
-            #if GODOT_VERSION >= 0x040300
             case Variant::PACKED_VECTOR4_ARRAY:
-            #endif
             case Variant::ARRAY:
             case Variant::DICTIONARY: {
                 return true;

--- a/src/common/resource_utils.cpp
+++ b/src/common/resource_utils.cpp
@@ -44,69 +44,24 @@ namespace ResourceUtils {
     }
 
     String generate_scene_unique_id() {
-        #if GODOT_VERSION >= 0x040300
         return Resource::generate_scene_unique_id();
-        #else
-        const Dictionary dt = Time::get_singleton()->get_datetime_dict_from_system();
-
-        uint32_t hash = hash_murmur3_one_32(Time::get_singleton()->get_ticks_usec());
-        hash = hash_murmur3_one_32(dt["year"], hash);
-        hash = hash_murmur3_one_32(dt["month"], hash);
-        hash = hash_murmur3_one_32(dt["day"], hash);
-        hash = hash_murmur3_one_32(dt["hour"], hash);
-        hash = hash_murmur3_one_32(dt["minute"], hash);
-        hash = hash_murmur3_one_32(dt["second"], hash);
-        hash = hash_murmur3_one_32(UtilityFunctions::randi(), hash);
-
-        static constexpr uint32_t characters = 5;
-        static constexpr uint32_t char_count = ('z' - 'a');
-        static constexpr uint32_t base = char_count + ('9' - '0');
-
-        String id;
-        for (uint32_t i = 0; i < characters; i++) {
-            const uint32_t c = hash % base;
-            if (c < char_count) {
-                id += String::chr('a' + c);
-            } else {
-                id += String::chr('0' + (c - char_count));
-            }
-            hash /= base;
-        }
-
-        return id;
-        #endif
     }
 
     String get_scene_unique_id(const Ref<Resource>& p_resource, const String& p_path) {
         ERR_FAIL_COND_V_MSG(!p_resource.is_valid(), "", "Cannot get scene unique id on an invalid resource");
-
-        #if GODOT_VERSION >= 0x040300
         return p_resource->get_scene_unique_id();
-        #else
-        return ResourceCache::get_singleton()->get_scene_unique_id(p_path, p_resource);
-        #endif
     }
 
     void set_scene_unique_id(const Ref<Resource>& p_resource, const String& p_path, const String& p_id) {
         ERR_FAIL_COND_MSG(!p_resource.is_valid(), "Cannot set id on an invalid resource");
-
-        #if GODOT_VERSION >= 0x040300
         p_resource->set_scene_unique_id(p_id);
-        #else
-        ResourceCache::get_singleton()->set_scene_unique_id(p_path, p_resource, p_id);
-        #endif
     }
 
     void set_id_for_path(const Ref<Resource>& p_resource, const String& p_path, const String& p_id) {
-        #if GODOT_VERSION >= 0x040400
         p_resource->set_id_for_path(p_path, p_id);
-        #else
-        ResourceCache::get_singleton()->set_id_for_path(p_path, p_resource->get_path(), p_id);
-        #endif
     }
 
     int64_t get_resource_id_for_path(const String& p_path, bool p_generate) {
-        #if GODOT_VERSION >= 0x040300
         const int64_t fallback = ResourceLoader::get_singleton()->get_resource_uid(p_path);
         if (fallback != ResourceUID::INVALID_ID) {
             return fallback;
@@ -115,10 +70,6 @@ namespace ResourceUtils {
             return ResourceUID::get_singleton()->create_id();
         }
         return ResourceUID::INVALID_ID;
-        #else
-        // In orchestrations, we did not serialize the UID in this context
-        return ResourceUID::INVALID_ID;
-        #endif
     }
 
     bool is_builtin(const Ref<Resource>& p_resource) {

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -17,7 +17,6 @@
 #include "common/settings.h"
 
 #include "common/dictionary_utils.h"
-#include "common/version.h"
 #include "script/script_warning.h"
 
 #include <godot_cpp/classes/project_settings.hpp>
@@ -91,9 +90,7 @@ void OrchestratorSettings::_register_settings() {
     _settings.emplace_back(BOOL_SETTING("ui/graph/disconnect_control_flow_when_dragged", true));
     _settings.emplace_back(BOOL_SETTING("ui/graph/grid_enabled", true));
     _settings.emplace_back(BOOL_SETTING("ui/graph/grid_snapping_enabled", true));
-    #if GODOT_VERSION >= 0x040300
     _settings.emplace_back(SENUM_SETTING("ui/graph/grid_pattern", "Dots,Lines", "Lines"));
-    #endif
     _settings.emplace_back(BOOL_SETTING("ui/graph/show_advanced_tooltips", false));
     _settings.emplace_back(BOOL_SETTING("ui/graph/show_autowire_selection_dialog", true));
     _settings.emplace_back(BOOL_SETTING("ui/graph/show_minimap", false));
@@ -172,9 +169,7 @@ void OrchestratorSettings::_register_settings() {
     _settings.emplace_back(COLOR_NO_ALPHA_SETTING("ui/connection_colors/packed float64 array", Color(0.38, 0.85, 0.96)));
     _settings.emplace_back(COLOR_NO_ALPHA_SETTING("ui/connection_colors/packed vector2 array", Color(0.74, 0.57, 0.95)));
     _settings.emplace_back(COLOR_NO_ALPHA_SETTING("ui/connection_colors/packed vector3 array", Color(0.84, 0.49, 0.93)));
-    #if GODOT_VERSION >= 0x040300
     _settings.emplace_back(COLOR_NO_ALPHA_SETTING("ui/connection_colors/packed vector4 array", Color(0.84, 0.49, 0.94)));
-    #endif
     _settings.emplace_back(COLOR_NO_ALPHA_SETTING("ui/connection_colors/packed color array", Color(0.62, 1.00, 0.44)));
 }
 

--- a/src/core/godot/object/class_db.cpp
+++ b/src/core/godot/object/class_db.cpp
@@ -18,7 +18,6 @@
 
 #include "api/extension_db.h"
 #include "common/dictionary_utils.h"
-#include "common/version.h"
 
 #include <godot_cpp/classes/resource.hpp>
 #include <godot_cpp/core/class_db.hpp>
@@ -93,35 +92,8 @@ StringName GDE::ClassDB::get_property_getter(const StringName& p_class_name, con
 }
 
 Variant GDE::ClassDB::get_property_default_value(const StringName& p_class_name, const StringName& p_property_name) {
-    #if GODOT_VERSION >= 0x040300
     // See https://github.com/godotengine/godot/pull/90916
     return GClassDB::class_get_property_default_value(p_class_name, p_property_name);
-    #else
-    static HashMap<String, HashMap<String, Variant>> default_value_cache;
-    if (!default_value_cache.has(p_class_name)) {
-        if (GClassDB::can_instantiate(p_class_name)) {
-            Variant instance =  GClassDB::instantiate(p_class_name);
-            const Ref<Resource> resource = instance;
-            if (resource.is_valid()) {
-                const TypedArray<Dictionary> properties = resource->get_property_list();
-                for (uint32_t index = 0; index < properties.size(); index++) {
-                    const PropertyInfo& property = DictionaryUtils::to_property(properties[index]);
-                    if (property.usage & (PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR)) {
-                        default_value_cache[p_class_name][property.name] = resource->get(property.name);
-                    }
-                }
-            } else {
-                // An object
-                memdelete(Object::cast_to<Object>(instance));
-            }
-        }
-    }
-
-    if (default_value_cache.has(p_class_name))
-        return default_value_cache[p_class_name][p_property_name];
-
-    return {};
-    #endif
 }
 
 bool GDE::ClassDB::has_signal(const StringName& p_class_name, const StringName& p_signal_name, bool p_no_inheritance) {

--- a/src/editor/actions/introspector.cpp
+++ b/src/editor/actions/introspector.cpp
@@ -24,7 +24,6 @@
 #include "common/settings.h"
 #include "common/string_utils.h"
 #include "common/variant_utils.h"
-#include "common/version.h"
 #include "core/godot/config/project_settings_cache.h"
 #include "core/godot/core_string_names.h"
 #include "script/nodes/script_nodes.h"
@@ -243,13 +242,8 @@ Vector<Ref<OrchestratorEditorIntrospector::Action>> OrchestratorEditorIntrospect
             }
 
             if (property.usage & PROPERTY_USAGE_INTERNAL) {
-                #if GODOT_VERSION >= 0x040400
                 String getter = StringUtils::default_if_empty(ClassDB::class_get_property_getter(p_class_name, property.name), getter_name);
                 String setter = StringUtils::default_if_empty(ClassDB::class_get_property_setter(p_class_name, property.name), setter_name);
-                #else
-                String getter = getter_name;
-                String setter = setter_name;
-                #endif
                 if (!getter.is_empty()) {
                     internal_method_names.push_back(getter);
                 }

--- a/src/editor/actions/menu.cpp
+++ b/src/editor/actions/menu.cpp
@@ -712,9 +712,7 @@ OrchestratorEditorActionMenu::OrchestratorEditorActionMenu()
     _results = memnew(Tree);
     _results->set_hide_root(true);
     _results->add_theme_constant_override("icon_max_width", SceneUtils::get_editor_class_icon_size());
-    #if GODOT_VERSION >= 0x040300
     _results->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-    #endif
     _results->connect(SceneStringName(item_activated), callable_mp_this(_confirmed));
     _results->connect("cell_selected", callable_mp_this(_item_selected));
     _results->connect("nothing_selected", callable_mp_this(_nothing_selected));

--- a/src/editor/debugger/script_debugger_plugin.cpp
+++ b/src/editor/debugger/script_debugger_plugin.cpp
@@ -18,7 +18,6 @@
 
 #include "common/macros.h"
 
-#if GODOT_VERSION >= 0x040300
 OrchestratorEditorDebuggerPlugin* OrchestratorEditorDebuggerPlugin::_singleton = nullptr;
 
 void OrchestratorEditorDebuggerPlugin::_session_started(int32_t p_session_id) {
@@ -138,4 +137,3 @@ OrchestratorEditorDebuggerPlugin::OrchestratorEditorDebuggerPlugin() {
 OrchestratorEditorDebuggerPlugin::~OrchestratorEditorDebuggerPlugin() {
     _singleton = nullptr;
 }
-#endif

--- a/src/editor/debugger/script_debugger_plugin.h
+++ b/src/editor/debugger/script_debugger_plugin.h
@@ -16,9 +16,6 @@
 //
 #pragma once
 
-#include "common/version.h"
-
-#if GODOT_VERSION >= 0x040300
 #include <godot_cpp/classes/editor_debugger_plugin.hpp>
 #include <godot_cpp/classes/editor_debugger_session.hpp>
 #include <godot_cpp/classes/script.hpp>
@@ -68,4 +65,3 @@ public:
     OrchestratorEditorDebuggerPlugin();
     ~OrchestratorEditorDebuggerPlugin() override;
 };
-#endif

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -507,12 +507,11 @@ void OrchestratorEditor::_copy_script_uid() {
 void OrchestratorEditor::_live_auto_reload_running_scripts() {
     _pending_auto_reload = false;
 
-    #if GODOT_VERSION >= 0x040300
-    if (_reload_all_scripts)
+    if (_reload_all_scripts) {
         OrchestratorEditorDebuggerPlugin::get_singleton()->reload_all_scripts();
-    else
+    } else {
         OrchestratorEditorDebuggerPlugin::get_singleton()->reload_scripts(_script_paths_to_reload);
-    #endif
+    }
 
     _reload_all_scripts = false;
     _script_paths_to_reload.clear();
@@ -539,11 +538,7 @@ struct OrchestratorEditorItemData {
             if (sort_key == other.sort_key) {
                 return index < other.index;
             }
-            #if GODOT_VERSION >= 0x040300
             return sort_key.filenocasecmp_to(other.sort_key) < 0;
-            #else
-            return sort_key.to_lower().casecmp_to(other.sort_key.to_lower()) < 0;
-            #endif
         }
         return category < other.category;
     }
@@ -850,12 +845,10 @@ void OrchestratorEditor::_add_callback(Object* p_object, const String& p_functio
     const Ref<ScriptExtension> script = p_object->get_script();
     ERR_FAIL_COND(script.is_null());
 
-    #if GODOT_VERSION >= 0x040300
     const ScriptLanguageExtension* language = cast_to<ScriptLanguageExtension>(script->_get_language());
     if (!language || !language->_can_make_function()) {
         return;
     }
-    #endif
 
     cache_and_push_item(script.ptr());
 
@@ -945,11 +938,7 @@ void OrchestratorEditor::_reload_scripts(bool p_refresh_only) {
             script->reload_from_file();
 
             // When reloaded, make sure the inspector is cleared as to avoid showing stale state.
-            #if GODOT_VERSION >= 0x040400
             EI->get_inspector()->edit(nullptr);
-            #else
-            EI->inspect_object(nullptr);
-            #endif
 
             update_docs_from_script(script);
         }
@@ -1283,11 +1272,9 @@ void OrchestratorEditor::_set_breakpoint(const Ref<RefCounted>& p_script, int p_
         state["breakpoints"] = breakpoints;
         _editor_cache->set_value(script->get_path(), "state", state);
 
-        #if GODOT_VERSION >= 0x040300
         if (OrchestratorEditorDebuggerPlugin* debugger = OrchestratorEditorDebuggerPlugin::get_singleton()) {
             debugger->set_breakpoint(script->get_path(), p_node, p_enabled);
         }
-        #endif
     }
 }
 
@@ -1302,11 +1289,9 @@ void OrchestratorEditor::_clear_breakpoints() {
     for (const String& section : cached_editors) {
         Array breakpoints = _get_cached_breakpoints_for_script(section);
 
-        #if GODOT_VERSION >= 0x040300
         for (int i = 0; i < breakpoints.size(); i++) {
             OrchestratorEditorDebuggerPlugin::get_singleton()->set_breakpoint(section, breakpoints[i], false);
         }
-        #endif
 
         if (breakpoints.size() > 0) {
             Dictionary state = _editor_cache->get_value(section, "state");
@@ -1376,13 +1361,10 @@ void OrchestratorEditor::_file_removed(const String& p_file) {
 
     // Check closed
     if (_editor_cache->has_section(p_file)) {
-        #if GODOT_VERSION >= 0x040300
         Array breakpoints = _get_cached_breakpoints_for_script(p_file);
         for (int i = 0; i < breakpoints.size(); i++) {
             OrchestratorEditorDebuggerPlugin::get_singleton()->set_breakpoint(p_file, breakpoints[i], false);
         }
-
-        #endif
 
         _editor_cache->erase_section(p_file);
     }
@@ -1405,7 +1387,6 @@ void OrchestratorEditor::_files_moved(const String& p_old_file, const String& p_
     _editor_cache->erase_section(p_old_file);
     _editor_cache->set_value(p_new_file, "state", state);
 
-    #if GODOT_VERSION >= 0x040300
     Array breakpoints = _get_cached_breakpoints_for_script(p_new_file);
     for (int i = 0; i < breakpoints.size(); i++) {
         OrchestratorEditorDebuggerPlugin::get_singleton()->set_breakpoint(p_old_file, breakpoints[i], false);
@@ -1413,7 +1394,6 @@ void OrchestratorEditor::_files_moved(const String& p_old_file, const String& p_
             OrchestratorEditorDebuggerPlugin::get_singleton()->set_breakpoint(p_new_file, breakpoints[i], true);
         }
     }
-    #endif
 }
 
 OrchestratorEditorView* OrchestratorEditor::_get_current_editor() const {
@@ -1618,9 +1598,7 @@ void OrchestratorEditor::update_script_times() {
 }
 
 void OrchestratorEditor::update_docs_from_script(const Ref<Script>& p_script) { // NOLINT
-    #if GODOT_VERSION >= 0x040400
     EI->get_script_editor()->update_docs_from_script(p_script);
-    #endif
 }
 
 void OrchestratorEditor::clear_docs_from_script(const Ref<Script>& p_script) {
@@ -1976,9 +1954,8 @@ Variant OrchestratorEditor::get_drag_data_fw(const Point2& p_point, Control* p_f
 
     Label* label = memnew(Label);
     label->set_text(preview_name);
-    #if GODOT_VERSION >= 0x040300
     label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-    #endif
+
     drag_preview->add_child(label);
 
     set_drag_preview(drag_preview);
@@ -2152,21 +2129,11 @@ void OrchestratorEditor::save_editor_layout_delayed() {
     // As of Godot 4.4.1, the first Timer child of EditorNode should be started.
     if (Node* editor_node = EditorNode) {
         const TypedArray<Node> timers = editor_node->find_children("*", "Timer", true, false);
-        #if GODOT_VERSION >= 0x040400
         if (!timers.is_empty()) {
             if (Timer* timer = cast_to<Timer>(timers.get(0))) {
                 timer->start();
             }
         }
-        #else
-        for (int i = 0; i < timers.size(); i++) {
-            Timer* timer = cast_to<Timer>(timers[0]);
-            if (timer) {
-                timer->start();
-            }
-            break;
-        }
-        #endif
     }
 }
 
@@ -2442,9 +2409,7 @@ OrchestratorEditor::OrchestratorEditor(OrchestratorWindowWrapper* p_window_wrapp
     _scripts_vbox->add_child(_filter_scripts);
 
     _script_list = memnew(ItemList);
-    #if GODOT_VERSION >= 0x040300
     _script_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-    #endif
     _script_list->set_custom_minimum_size(Size2(100, 60) * EDSCALE);
     _script_list->set_v_size_flags(SIZE_EXPAND_FILL);
     _script_list->set_theme_type_variation("ItemListSecondary");
@@ -2491,12 +2456,7 @@ OrchestratorEditor::OrchestratorEditor(OrchestratorWindowWrapper* p_window_wrapp
     _file_menu->get_popup()->add_item("New Orchestration...", FILE_NEW, OACCEL_KEY(KEY_MASK_CTRL, KEY_N));
     _file_menu->get_popup()->add_item("Open...", FILE_OPEN);
     _file_menu->get_popup()->add_item("Reopen Closed Orchestration", FILE_REOPEN_CLOSED, OACCEL_KEY(KEY_MASK_CTRL | KEY_MASK_SHIFT, KEY_T));
-    #if GODOT_VERSION >= 0x040300
     _file_menu->get_popup()->add_submenu_node_item("Open Recent", _recent_history, FILE_OPEN_RECENT);
-    #else
-    _file_menu->add_child(_recent_history);
-    _file_menu->get_popup()->add_submenu_item("Open Recent", _recent_history->get_name(), FILE_OPEN_RECENT);
-    #endif
     _file_menu->get_popup()->add_separator();
     _file_menu->get_popup()->add_item("Save", FILE_SAVE, OACCEL_KEY(KEY_MASK_CTRL | KEY_MASK_ALT, KEY_S));
     _file_menu->get_popup()->add_item("Save As...", FILE_SAVE_AS);
@@ -2521,13 +2481,11 @@ OrchestratorEditor::OrchestratorEditor(OrchestratorWindowWrapper* p_window_wrapp
     _menu_hb->add_child(debug_menu_btn);
     debug_menu_btn->hide();
 
-    #if GODOT_VERSION >= 0x040300
     OrchestratorEditorDebuggerPlugin* debugger = OrchestratorEditorDebuggerPlugin::get_singleton();
     debugger->connect("goto_script_line", callable_mp_this(_goto_script_line));
     debugger->connect("breaked", callable_mp_this(_breaked));
     debugger->connect("breakpoints_cleared_in_tree", callable_mp_this(_clear_breakpoints));
     debugger->connect("breakpoint_set_in_tree", callable_mp_this(_set_breakpoint));
-    #endif
 
     _help_menu = memnew(MenuButton);
     _help_menu->set_text("Help");
@@ -2633,9 +2591,7 @@ OrchestratorEditor::OrchestratorEditor(OrchestratorWindowWrapper* p_window_wrapp
 
     _disk_changed_list = memnew(Tree);
     _disk_changed_list->set_hide_root(true);
-    #if GODOT_VERSION >= 0x040300
     _disk_changed_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-    #endif
     _disk_changed_list->set_v_size_flags(SIZE_EXPAND_FILL);
     vbc->add_child(_disk_changed_list);
 

--- a/src/editor/graph/graph_node.cpp
+++ b/src/editor/graph/graph_node.cpp
@@ -240,7 +240,6 @@ void OrchestratorEditorGraphNode::_create_indicators() {
         _add_indicator("NodeWarning", "Node is experimental and behavior may change without notice");
     }
 
-    #if GODOT_VERSION >= 0x040300
     if (get_graph()->is_breakpoint(this)) {
         const bool breakpoint_enabled = get_graph()->get_breakpoint(this);
         const String suffix = !breakpoint_enabled ? "On" : "Off";
@@ -250,7 +249,6 @@ void OrchestratorEditorGraphNode::_create_indicators() {
 
         _add_indicator("DebugSkipBreakpoints" + suffix, tooltip_text);
     }
-    #endif
 }
 
 void OrchestratorEditorGraphNode::_add_indicator(const String& p_icon_name, const String& p_tooltip_text) {

--- a/src/editor/graph/graph_panel.cpp
+++ b/src/editor/graph/graph_panel.cpp
@@ -679,11 +679,7 @@ void OrchestratorEditorGraphPanel::_show_node_context_menu(OrchestratorEditorGra
 
     menu->add_separator("Documentation");
 
-    #if GODOT_VERSION >= 0x040300
     const String view_doc_topic = script_node->get_help_topic();
-    #else
-    const String view_doc_topic = script_node->get_class();
-    #endif
     menu->add_icon_item("Help", "View Documentation", callable_mp_this(_view_documentation).bind(view_doc_topic));
 
     const Ref<OScriptNodeVariableGet> variable_get = script_node;
@@ -825,11 +821,7 @@ void OrchestratorEditorGraphPanel::_show_pin_context_menu(OrchestratorEditorGrap
 
     menu->add_separator("Documentation");
 
-    #if GODOT_VERSION >= 0x040300
     const String view_doc_topic = script_node->get_help_topic();
-    #else
-    const String view_doc_topic = script_node->get_class();
-    #endif
     menu->add_icon_item("Help", "View Documentation", callable_mp_this(_view_documentation).bind(view_doc_topic));
 
     menu->set_position(p_pin->get_screen_position() + p_position * get_zoom());
@@ -1435,17 +1427,12 @@ void OrchestratorEditorGraphPanel::_toggle_node_bookmark(OrchestratorEditorGraph
 }
 
 bool OrchestratorEditorGraphPanel::_has_breakpoint_support() const {
-    #if GODOT_VERSION >= 0x040300
     return true;
-    #else
-    return false;
-    #endif
 }
 
 void OrchestratorEditorGraphPanel::_toggle_node_breakpoint(OrchestratorEditorGraphNode* p_node) {
     ERR_FAIL_NULL_MSG(p_node, "Cannot toggle node breakpoint on an invalid node reference");
 
-    #if GODOT_VERSION >= 0x040300
     const int id = p_node->get_id();
     if (!_breakpoint_state.has(id)) {
         _breakpoint_state[id] = true;
@@ -1466,14 +1453,11 @@ void OrchestratorEditorGraphPanel::_toggle_node_breakpoint(OrchestratorEditorGra
     }
 
     p_node->notify_breakpoints_changed();
-
-    #endif
 }
 
 void OrchestratorEditorGraphPanel::_set_node_breakpoint(OrchestratorEditorGraphNode* p_node, bool p_breaks) {
     ERR_FAIL_NULL_MSG(p_node, "Cannot set node breakpoint on an invalid node reference");
 
-    #if GODOT_VERSION >= 0x040300
     const int id = p_node->get_id();
     if (p_breaks) {
         _breakpoint_state[id] = true;
@@ -1499,13 +1483,11 @@ void OrchestratorEditorGraphPanel::_set_node_breakpoint(OrchestratorEditorGraphN
     }
 
     p_node->notify_breakpoints_changed();
-    #endif
 }
 
 void OrchestratorEditorGraphPanel::_set_node_breakpoint_enabled(OrchestratorEditorGraphNode* p_node, bool p_enabled) {
     ERR_FAIL_NULL_MSG(p_node, "Cannot set node breakpoint status on an invalid node reference");
 
-    #if GODOT_VERSION >= 0x040300
     const int id = p_node->get_id();
     _breakpoint_state[id] = p_enabled;
     emit_signal("breakpoint_changed", id, p_enabled);
@@ -1519,7 +1501,6 @@ void OrchestratorEditorGraphPanel::_set_node_breakpoint_enabled(OrchestratorEdit
     }
 
     p_node->notify_breakpoints_changed();
-    #endif
 }
 
 void OrchestratorEditorGraphPanel::_set_variable_node_validation(OrchestratorEditorGraphNode* p_node, bool p_validated) {
@@ -1673,12 +1654,7 @@ void OrchestratorEditorGraphPanel::_reset_pin_to_generated_default_value(Orchest
 
 void OrchestratorEditorGraphPanel::_view_documentation(const String& p_topic) {
     EI->set_main_screen_editor("Script");
-
-    #if GODOT_VERSION >= 0x040300
     EI->get_script_editor()->goto_help(p_topic);
-    #else
-    EI->get_script_editor()->call("_help_class_open", p_topic);
-    #endif
 }
 
 void OrchestratorEditorGraphPanel::_connect_graph_node_signals(OrchestratorEditorGraphNode* p_node) {
@@ -1693,11 +1669,7 @@ void OrchestratorEditorGraphPanel::_connect_graph_node_signals(OrchestratorEdito
     // Godot 4.3 introduced a new resize_end callback that we will use now to handle triggering the
     // final size of a node. This helps to avoid issues with editor scale changes being problematic
     // by leaving nodes too large after scale up.
-    #if GODOT_VERSION < 0x040300
-    p_node->connect(SceneStringName(resized), callable_mp_this(_node_resized).bind(p_node));
-    #else
     p_node->connect("resize_end", callable_mp_this(_node_resize_end).bind(p_node));
-    #endif
 
     _connect_graph_node_pin_signals(p_node);
 }
@@ -1714,11 +1686,7 @@ void OrchestratorEditorGraphPanel::_disconnect_graph_node_signals(OrchestratorEd
     // Godot 4.3 introduced a new resize_end callback that we will use now to handle triggering the
     // final size of a node. This helps to avoid issues with editor scale changes being problematic
     // by leaving nodes too large after scale up.
-    #if GODOT_VERSION < 0x040300
-    p_node->disconnect(SceneStringName(resized), callable_mp_this(_node_resized).bind(p_node));
-    #else
     p_node->disconnect("resize_end", callable_mp_this(_node_resize_end).bind(p_node));
-    #endif
 
     _disconnect_graph_node_pin_signals(p_node);
 }
@@ -1997,9 +1965,7 @@ void OrchestratorEditorGraphPanel::_action_menu_canceled() {
 }
 
 void OrchestratorEditorGraphPanel::_grid_pattern_changed(int p_index) {
-    #if GODOT_VERSION >= 0x040300
     set_grid_pattern(CAST_INT_TO_ENUM(GridPattern, _grid_pattern->get_item_metadata(p_index)));
-    #endif
 }
 
 void OrchestratorEditorGraphPanel::_settings_changed() {
@@ -2947,105 +2913,6 @@ bool OrchestratorEditorGraphPanel::_is_in_output_hotzone(Object* p_in_node, int3
     return _is_in_port_hotzone(pos / zoom, p_mouse_position, port_size, false);
 }
 
-#if GODOT_VERSION < 0x040300
-static Vector2 get_closest_point_to_segment(const Vector2& p_point, const Vector2* p_segment) {
-    Vector2 p = p_point - p_segment[0];
-    Vector2 n = p_segment[1] - p_segment[0];
-    real_t l2 = n.length_squared();
-
-    if (l2 < 1e-20f) {
-        return p_segment[0]; // Both points are the same, just give any.
-    }
-
-    real_t d = n.dot(p) / l2;
-
-    if (d <= 0.0f) {
-        return p_segment[0]; // Before first point.
-    }
-
-    if (d >= 1.0f) {
-        return p_segment[1]; // After first point.
-    }
-
-    return p_segment[0] + n * d; // Inside.
-}
-
-static float get_distance_to_segment(const Vector2& p_point, const Vector2* p_segment) {
-    return p_point.distance_to(get_closest_point_to_segment(p_point, p_segment));
-}
-
-Dictionary OrchestratorEditorGraphPanel::get_closest_connection_at_point(const Vector2& p_position, float p_max_distance) {
-    Vector2 transformed_point = p_position + get_scroll_offset();
-
-    Dictionary closest_connection;
-    float closest_distance = p_max_distance;
-
-    TypedArray<Dictionary> connections = get_connection_list();
-    for (int i = 0; i < connections.size(); i++) {
-        const Dictionary& connection = connections[i];
-
-        const String source_name = connection["from_node"];
-        const int32_t source_port = connection["from_port"];
-        OrchestratorEditorGraphNode* source = find_node(source_name);
-        if (!source) {
-            continue;
-        }
-
-        const String target_name = connection["to_node"];
-        const int32_t target_port = connection["to_port"];
-        OrchestratorEditorGraphNode* target = find_node(target_name);
-        if (!target) {
-            continue;
-        }
-
-        // What is cached
-        Vector2 from_pos = source->get_output_port_position(source_port) + source->get_position_offset();
-        Vector2 to_pos = target->get_input_port_position(target_port) + target->get_position_offset();
-
-        if (_godot_version.at_least(4, 3)) {
-            from_pos *= get_zoom();
-            to_pos *= get_zoom();
-        }
-
-        // This function is called during both draw and this logic, and so the results need to be handled
-        // differently based on the context of the call in Godot 4.2.
-        PackedVector2Array points = get_connection_line(from_pos, to_pos);
-        if (points.is_empty()) {
-            continue;
-        }
-
-        if (!_godot_version.at_least(4, 3)) {
-            for (int j = 0; j < points.size(); j++) {
-                points[j] *= get_zoom();
-            }
-        }
-
-        const real_t line_thickness = get_connection_lines_thickness();
-
-        Rect2 aabb(points[0], Vector2());
-        for (int j = 0; j < points.size(); j++) {
-            aabb = aabb.expand(points[j]);
-        }
-
-        aabb.grow_by(line_thickness * static_cast<real_t>(0.5));
-
-        if (aabb.distance_to(transformed_point) > p_max_distance) {
-            continue;
-        }
-
-        for (int j = 0; j < points.size(); j++) {
-            float distance = get_distance_to_segment(transformed_point, &points[j]);
-            if (distance <= line_thickness * 0.5 + p_max_distance && distance < closest_distance) {
-                closest_distance = distance;
-                closest_connection = connection;
-            }
-        }
-    }
-
-    return closest_connection;
-}
-#endif
-
 void OrchestratorEditorGraphPanel::set_graph(const Ref<OrchestrationGraph>& p_graph) {
     ERR_FAIL_COND_MSG(!p_graph.is_valid(), "The provided graph panel model is invalid");
 
@@ -3228,11 +3095,9 @@ void OrchestratorEditorGraphPanel::clear_breakpoints() {
     while (!_breakpoints.is_empty()) {
         int node_id = _breakpoints[_breakpoints.size() - 1];
 
-        #if GODOT_VERSION >= 0x040300
         if (OrchestratorEditorDebuggerPlugin* debugger = OrchestratorEditorDebuggerPlugin::get_singleton()) {
             debugger->set_breakpoint(_graph->get_orchestration()->as_script()->get_path(), node_id, false);
         }
-        #endif
 
         _breakpoints.remove_at(_breakpoints.size() - 1);
         _breakpoint_state.erase(node_id);
@@ -3607,11 +3472,8 @@ Variant OrchestratorEditorGraphPanel::get_edit_state() const {
     panel_state["breakpoints"] = breakpoints;
     panel_state["minimap"] = is_minimap_enabled();
     panel_state["snapping"] = is_snapping_enabled();
-
-    #if GODOT_VERSION >= 0x040300
     panel_state["grid"] = is_showing_grid();
     panel_state["grid_pattern"] = get_grid_pattern();
-    #endif
 
     return panel_state;
 }
@@ -3657,13 +3519,11 @@ void OrchestratorEditorGraphPanel::set_edit_state(const Variant& p_state, const 
         }).call_deferred();
     }
 
-    #if GODOT_VERSION >= 0x040300
     set_show_grid(state.get("grid", true));
 
     const int grid_pattern = state.get("grid_pattern", 0);
     set_grid_pattern(CAST_INT_TO_ENUM(GridPattern, grid_pattern));
     _grid_pattern->select(grid_pattern);
-    #endif
 }
 
 void OrchestratorEditorGraphPanel::_notification(int p_what) {
@@ -3747,7 +3607,6 @@ OrchestratorEditorGraphPanel::OrchestratorEditorGraphPanel() {
 
     // New dots-based grid style was introduced in Godot 4.3.
     // Introduces a new drop-down option for selecting the specific grid pattern
-    #if GODOT_VERSION >= 0x040300
     const String grid_pattern = ORCHESTRATOR_GET("ui/graph/grid_pattern", "Lines");
     const int selected = grid_pattern == "Lines" ? 0 : 1;
     _grid_pattern = memnew(OptionButton);
@@ -3765,7 +3624,6 @@ OrchestratorEditorGraphPanel::OrchestratorEditorGraphPanel() {
     VSeparator* sep = memnew(VSeparator());
     get_menu_hbox()->add_child(sep);
     get_menu_hbox()->move_child(sep, 6);
-    #endif
 
     set_minimap_enabled(ORCHESTRATOR_GET("ui/graph/show_minimap", false));
     set_show_arrange_button(ORCHESTRATOR_GET("ui/graph/show_arrange_button", false));

--- a/src/editor/graph/graph_panel.h
+++ b/src/editor/graph/graph_panel.h
@@ -302,10 +302,6 @@ public:
     bool _is_in_output_hotzone(Object* p_in_node, int32_t p_in_port, const Vector2& p_mouse_position) override;
     //~ End GraphEdit Interface
 
-    #if GODOT_VERSION < 0x040300
-    Dictionary get_closest_connection_at_point(const Vector2& p_position, float p_max_distance = 4.0f);
-    #endif
-
     void set_graph(const Ref<OrchestrationGraph>& p_graph);
     void reloaded_from_file();
 

--- a/src/editor/inspector/orchestration_inspector_plugin.cpp
+++ b/src/editor/inspector/orchestration_inspector_plugin.cpp
@@ -39,12 +39,7 @@ bool OrchestratorEditorInspectorPluginOrchestration::_parse_property(Object* p_o
                 }
             }));
 
-        #if GODOT_VERSION >= 0x040300
         add_property_editor(p_name, editor, true, "Extends");
-        #else
-        add_property_editor(p_name, editor, true);
-        #endif
-        //return true;
     }
 
     return false;

--- a/src/editor/inspector/properties/editor_property_extends.cpp
+++ b/src/editor/inspector/properties/editor_property_extends.cpp
@@ -78,10 +78,6 @@ void OrchestratorEditorPropertyExtends::setup(const String& p_base_type, bool p_
 }
 
 void OrchestratorEditorPropertyExtends::_notification(int p_what) {
-    #if GODOT_VERSION <= 0x040202
-    EditorProperty::_notification(p_what);
-    #endif
-
     switch (p_what) {
         case NOTIFICATION_READY: {
             HBoxContainer* container = memnew(HBoxContainer);

--- a/src/editor/inspector/properties/editor_property_pin_properties.cpp
+++ b/src/editor/inspector/properties/editor_property_pin_properties.cpp
@@ -16,15 +16,14 @@
 //
 #include "editor/inspector/properties/editor_property_pin_properties.h"
 
-#include "../../gui/select_type_dialog.h"
 #include "common/dictionary_utils.h"
 #include "common/macros.h"
 #include "common/name_utils.h"
 #include "common/property_utils.h"
 #include "common/scene_utils.h"
 #include "common/variant_utils.h"
-#include "common/version.h"
 #include "core/godot/scene_string_names.h"
+#include "editor/gui/select_type_dialog.h"
 
 #include <godot_cpp/classes/v_box_container.hpp>
 
@@ -287,12 +286,7 @@ void OrchestratorEditorPropertyPinProperties::setup(bool p_inputs, int p_max_ent
     _max_entries = p_max_entries;
 }
 
-void OrchestratorEditorPropertyPinProperties::_notification(int p_what)
-{
-    #if GODOT_VERSION < 0x040202
-    EditorProperty::_notification(p_what);
-    #endif
-
+void OrchestratorEditorPropertyPinProperties::_notification(int p_what) {
     switch (p_what) {
         case NOTIFICATION_READY: {
             _margin = memnew(MarginContainer);

--- a/src/editor/inspector/variable_inspector_plugin.cpp
+++ b/src/editor/inspector/variable_inspector_plugin.cpp
@@ -37,11 +37,7 @@ bool OrchestratorEditorInspectorPluginVariable::_parse_property(Object* p_object
     if (p_name.match("classification")) {
         OrchestratorEditorPropertyVariableClassification* editor = memnew(OrchestratorEditorPropertyVariableClassification);
         _classification = editor;
-        #if GODOT_VERSION >= 0x040300
         add_property_editor(p_name, editor, true, "Variable Type");
-        #else
-        add_property_editor(p_name, editor, true);
-        #endif
         return true;
     }
 

--- a/src/editor/plugins/orchestrator_editor_plugin.cpp
+++ b/src/editor/plugins/orchestrator_editor_plugin.cpp
@@ -78,9 +78,7 @@ void OrchestratorPlugin::_register_plugins() {
     _register_export_plugin<OrchestratorEditorExportPlugin>();
 
     // Debugger Plugins
-    #if GODOT_VERSION >= 0x040300
     _register_debugger_plugin<OrchestratorEditorDebuggerPlugin>();
-    #endif
 }
 
 bool OrchestratorPlugin::_is_plugin_just_installed() const {

--- a/src/editor/property_selector.cpp
+++ b/src/editor/property_selector.cpp
@@ -21,7 +21,6 @@
 #include "common/property_utils.h"
 #include "common/scene_utils.h"
 #include "common/variant_utils.h"
-#include "common/version.h"
 #include "core/godot/scene_string_names.h"
 
 #include <godot_cpp/classes/button.hpp>
@@ -84,11 +83,7 @@ void OrchestratorPropertySelector::_item_selected() {
 }
 
 bool OrchestratorPropertySelector::_contains_ignore_case(const String& p_text, const String& p_what) const {
-    #if GODOT_VERSION >= 0x040300
     return p_text.containsn(p_what);
-    #else
-    return p_text.to_lower().contains(p_what.to_lower());
-    #endif
 }
 
 void OrchestratorPropertySelector::_update_search() {
@@ -207,11 +202,7 @@ OrchestratorPropertySelector::OrchestratorPropertySelector() : _type(Variant::NI
     SceneUtils::add_margin_child(vbox, "Search:", _search_box);
 
     _search_options = memnew(Tree);
-    #if GODOT_VERSION >= 0x040300
     _search_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-    #else
-    _search_options->set_auto_translate(false);
-    #endif
     _search_options->set_hide_root(true);
     _search_options->set_hide_folding(true);
     SceneUtils::add_margin_child(vbox, "Matches:", _search_options, true);

--- a/src/editor/register_editor_types.cpp
+++ b/src/editor/register_editor_types.cpp
@@ -61,9 +61,7 @@
 void register_editor_types() {
     // Plugin bits
     GDREGISTER_INTERNAL_CLASS(OrchestratorPlugin)
-    #if GODOT_VERSION >= 0x040300
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorDebuggerPlugin)
-    #endif
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorExportPlugin)
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorInspectorPluginFunction)
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorInspectorPluginSignal)

--- a/src/editor/scene_node_selector.cpp
+++ b/src/editor/scene_node_selector.cpp
@@ -18,7 +18,6 @@
 
 #include "common/macros.h"
 #include "common/scene_utils.h"
-#include "common/version.h"
 #include "core/godot/scene_string_names.h"
 
 #include <godot_cpp/classes/button.hpp>
@@ -255,11 +254,7 @@ OrchestratorSceneNodeSelector::OrchestratorSceneNodeSelector() {
 
     _tree = memnew(Tree);
     _tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-    #if GODOT_VERSION >= 0x040300
     _tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-    #else
-    _tree->set_auto_translate(false);
-    #endif
     _tree->set_anchor(SIDE_RIGHT, Control::ANCHOR_END);
     _tree->set_anchor(SIDE_BOTTOM, Control::ANCHOR_END);
     _tree->set_begin(Point2(0, 0));

--- a/src/editor/script_editor_view.cpp
+++ b/src/editor/script_editor_view.cpp
@@ -575,22 +575,15 @@ void OrchestratorScriptGraphEditorView::_enable_editor() {
     _goto_menu->get_popup()->add_item("Goto Node", SEARCH_LOCATE_NODE, OACCEL_KEY(KEY_MASK_CMD_OR_CTRL, KEY_L));
 
     _goto_menu->get_popup()->add_separator();
-    #if GODOT_VERSION >= 0x040300
     _goto_menu->get_popup()->add_submenu_node_item("Bookmarks", _bookmarks_menu);
-    #else
-    _goto_menu->add_child(_bookmarks_menu);
-    _goto_menu->get_popup()->add_submenu_item("Bookmarks", _bookmarks_menu->get_name());
-    #endif
     _update_bookmarks_list();
     _bookmarks_menu->connect("about_to_popup", callable_mp_this(_update_bookmarks_list));
     _bookmarks_menu->connect("index_pressed", callable_mp_this(_bookmarks_menu_option));
 
-    #if GODOT_VERSION >= 0x040300
     _goto_menu->get_popup()->add_submenu_node_item("Breakpoints", _breakpoints_menu);
     _update_breakpoints_list();
     _breakpoints_menu->connect("about_to_popup", callable_mp_this(_update_breakpoints_list));
     _breakpoints_menu->connect("index_pressed", callable_mp_this(_breakpoints_menu_option));
-    #endif
 
     _edit_hb->add_child(_debug_menu);
     _debug_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp_this(_menu_option));
@@ -1057,8 +1050,6 @@ void OrchestratorScriptGraphEditorView::register_editor() {
 }
 
 void OrchestratorScriptGraphEditorView::_notification(int p_what) {
-    GDE_NOTIFICATION(OrchestratorEditorView, p_what);
-
     // We maintain a private group of objects under the "_orchestrator_script_graph_views" group, which
     // is used by the plugin to identify all script graph views. This group is used to coordinate when
     // the component panel visibility and width changes across the views.

--- a/src/editor/updater/updater.cpp
+++ b/src/editor/updater/updater.cpp
@@ -22,7 +22,6 @@
 #include "common/scene_utils.h"
 #include "common/settings.h"
 #include "common/string_utils.h"
-#include "common/version.h"
 #include "core/godot/scene_string_names.h"
 #include "editor/plugins/orchestrator_editor_plugin.h"
 
@@ -197,9 +196,7 @@ void OrchestratorUpdaterVersionPicker::_request_download() {
 
         const String download_url = selected->get_meta("download_url");
         if (_download->request(download_url) == OK) {
-            #if GODOT_VERSION >= 0x040300
             _progress->set_indeterminate(true);
-            #endif
             set_process(true);
         }
     }
@@ -218,9 +215,7 @@ void OrchestratorUpdaterVersionPicker::_handle_custom_action(const StringName& p
 
 void OrchestratorUpdaterVersionPicker::_download_completed(int p_status, int p_code, const PackedStringArray& p_headers, const PackedByteArray& p_data) {
     _progress->set_visible(false);
-    #if GODOT_VERSION >= 0x040300
     _progress->set_indeterminate(false);
-    #endif
 
     set_process(false);
 
@@ -295,11 +290,9 @@ void OrchestratorUpdaterVersionPicker::_cancel_and_close() {
 
             _download->cancel_request();
 
-            #if GODOT_VERSION >= 0x040300
             _progress->set_indeterminate(false);
-            #endif
-
             _progress->set_visible(false);
+
             _status->set_visible(false);
         }
     }
@@ -412,16 +405,12 @@ void OrchestratorUpdaterVersionPicker::_notification(int p_what) {
             int client_status = _download->get_http_client_status();
             if (client_status == HTTPClient::STATUS_BODY) {
                 if (_download->get_body_size() > 0) {
-                    #if GODOT_VERSION >= 0x040300
                     _progress->set_indeterminate(false);
-                    #endif
                     _status->set_text(vformat("Downloading (%s / %s)...",
                         String::humanize_size(_download->get_downloaded_bytes()),
                         String::humanize_size(_download->get_body_size())));
                 } else {
-                    #if GODOT_VERSION >= 0x040300
                     _progress->set_indeterminate(true);
-                    #endif
                     _status->set_text(vformat("Downloading... (%s)",
                         String::humanize_size(_download->get_downloaded_bytes())));
                 }

--- a/src/orchestration/serialization/binary/binary_parser.cpp
+++ b/src/orchestration/serialization/binary/binary_parser.cpp
@@ -31,11 +31,7 @@ bool OrchestrationBinaryParser::_is_cached(const String& p_path) {
 }
 
 Ref<Resource> OrchestrationBinaryParser::_get_cache_ref(const String& p_path) {
-    #if GODOT_VERSION >= 0x040400
     return ResourceLoader::get_singleton()->get_cached_ref(p_path);
-    #else
-    return nullptr;
-    #endif
 }
 
 String OrchestrationBinaryParser::_read_unicode_string() {
@@ -728,7 +724,6 @@ Error OrchestrationBinaryParser::_load() {
                 _internal_resources.write[i].path = path;
             }
 
-            #if GODOT_VERSION >= 0x040300
             if (ResourceFormatLoader::CACHE_MODE_REUSE == _cache_mode && _is_cached(path)) {
                 const Ref<Resource> cached = _get_cache_ref(path);
                 if (cached.is_valid()) {
@@ -736,7 +731,6 @@ Error OrchestrationBinaryParser::_load() {
                     continue;
                 }
             }
-            #endif
         } else {
             if (ResourceFormatLoader::CACHE_MODE_IGNORE == _cache_mode && !_is_cached(_path)) {
                 path = _path;
@@ -749,7 +743,6 @@ Error OrchestrationBinaryParser::_load() {
         String resource_type = _read_unicode_string();
 
         Ref<Resource> resource;
-        #if GODOT_VERSION >= 0x040300
         if (ResourceFormatLoader::CACHE_MODE_REPLACE == _cache_mode && _is_cached(path)) {
             const Ref<Resource> cached = _get_cache_ref(path);
             if (cached->get_class() == resource_type) {
@@ -757,7 +750,6 @@ Error OrchestrationBinaryParser::_load() {
                 _resource = cached;
             }
         }
-        #endif
 
         MissingResource* missing_resource = nullptr;
         if (resource.is_null()) {
@@ -787,9 +779,7 @@ Error OrchestrationBinaryParser::_load() {
                 // resource->set_path(path);
             }
 
-            #if GODOT_VERSION >= 0x040300
             resource->set_scene_unique_id(id);
-            #endif
         }
 
         if (!is_main) {

--- a/src/orchestration/serialization/binary/binary_serializer.cpp
+++ b/src/orchestration/serialization/binary/binary_serializer.cpp
@@ -811,7 +811,6 @@ Error OrchestrationBinarySerializer::save(const Ref<Resource>& p_resource, const
     // Iterate all internal resources and collect used unique scene ids.
     // For resources that have collisions, first one visited wins; others reassigned.
     HashSet<String> used_unique_ids;
-    #if GODOT_VERSION >= 0x040300
     for (const Ref<Resource>& E : _saved_resources) {
         if (_is_resource_built_in(E)) {
             if (!E->get_scene_unique_id().is_empty()) {
@@ -823,7 +822,6 @@ Error OrchestrationBinarySerializer::save(const Ref<Resource>& p_resource, const
             }
         }
     }
-    #endif
 
     // Store the number of internal resources
     _file->store_32(_saved_resources.size());
@@ -833,7 +831,6 @@ Error OrchestrationBinarySerializer::save(const Ref<Resource>& p_resource, const
     HashMap<Ref<Resource>, uint32_t> resource_map;
     Vector<uint64_t> offsets;
     for (const Ref<Resource>& E: _saved_resources) {
-        #if GODOT_VERSION >= 0x040300
         if (_is_resource_built_in(E)) {
             bool generated;
             String uid_text = _create_resource_uid(E, used_unique_ids, generated);
@@ -849,12 +846,6 @@ Error OrchestrationBinarySerializer::save(const Ref<Resource>& p_resource, const
         } else {
             _save_unicode_string(E->get_path());
         }
-        #else
-        // All internal resources are written as "local://[index]"
-        // This allows renaming and moving of files without impacting the data
-        // When the file is loaded the "local://" prefix is replaced with the resource path
-        _save_unique_string("local://" + itos(resource_index));
-        #endif
 
         // Temporarily store an empty offset "0", and track it in the map
         // These will be serialized later

--- a/src/orchestration/serialization/serializer.cpp
+++ b/src/orchestration/serialization/serializer.cpp
@@ -71,50 +71,12 @@ String OrchestrationSerializer::_resource_get_class(const Ref<Resource>& p_resou
     return p_resource->get_class();
 }
 
-#if GODOT_VERSION >= 0x040300
 String OrchestrationSerializer::_generate_scene_unique_id() {
     return Resource::generate_scene_unique_id();
 }
-#else
-#include <godot_cpp/classes/time.hpp>
-#include <godot_cpp/variant/utility_functions.hpp>
-String OrchestrationSerializer::_generate_scene_unique_id() {
-    const Dictionary dict = Time::get_singleton()->get_datetime_dict_from_system();
-
-    uint32_t hash = hash_murmur3_one_32(Time::get_singleton()->get_ticks_usec());
-    hash = hash_murmur3_one_32(dict["year"], hash);
-    hash = hash_murmur3_one_32(dict["month"], hash);
-    hash = hash_murmur3_one_32(dict["day"], hash);
-    hash = hash_murmur3_one_32(dict["hour"], hash);
-    hash = hash_murmur3_one_32(dict["minute"], hash);
-    hash = hash_murmur3_one_32(dict["second"], hash);
-    hash = hash_murmur3_one_32(UtilityFunctions::randi(), hash);
-
-    static constexpr uint32_t characters = 5;
-    static constexpr uint32_t char_count = ('z' - 'a');
-    static constexpr uint32_t base = char_count + ('9' - '0');
-
-    String id;
-    for (uint32_t i = 0; i < characters; i++) {
-        uint32_t c = hash % base;
-        if (c < char_count) {
-            id += String::chr('a' + c);
-        } else {
-            id += String::chr('0' + (c - char_count));
-        }
-        hash /= base;
-    }
-
-    return id;
-}
-#endif
 
 String OrchestrationSerializer::_create_resource_uid(const Ref<Resource>& p_resource, const HashSet<String>& p_used_ids, bool& r_generated) {
-    #if GODOT_VERSION >= 0x40300
     String uid = p_resource->get_scene_unique_id();
-    #else
-    String uid = ResourceCache::get_singleton()->get_scene_unique_id(_path, p_resource);
-    #endif
 
     if (!uid.is_empty()) {
         r_generated = false;

--- a/src/orchestration/serialization/text/text_format.cpp
+++ b/src/orchestration/serialization/text/text_format.cpp
@@ -16,12 +16,9 @@
 //
 #include "orchestration/serialization/text/text_format.h"
 
-#include "common/version.h"
-
 #include <godot_cpp/classes/resource_uid.hpp>
 
 int64_t OrchestrationTextFormat::get_resource_id_for_path(const String& p_path, bool p_generate) {
-    #if GODOT_VERSION >= 0x040300
     int64_t fallback = ResourceLoader::get_singleton()->get_resource_uid(p_path);
     if (fallback != ResourceUID::INVALID_ID) {
         return fallback;
@@ -29,7 +26,6 @@ int64_t OrchestrationTextFormat::get_resource_id_for_path(const String& p_path, 
     if (p_generate) {
         return ResourceUID::get_singleton()->create_id();
     }
-    #endif
 
     return ResourceUID::INVALID_ID;
 }

--- a/src/orchestration/serialization/text/text_parser.cpp
+++ b/src/orchestration/serialization/text/text_parser.cpp
@@ -161,11 +161,7 @@ Error OrchestrationTextParser::_parse_ext_resource(OScriptVariantParser::Stream*
                 WARN_PRINT("External resource failed to load at: " + path);
             } else {
                 #ifdef TOOLS_ENABLED
-                    #if GODOT_VERSION >= 0x040400
                     res->set_id_for_path(_path, id);
-                    #else
-                    ResourceCache::get_singleton()->set_id_for_path(_path, res->get_path(), id);
-                    #endif
                 #endif
                 r_res = res;
             }
@@ -370,9 +366,7 @@ Error OrchestrationTextParser::_load() {
             Ref<Resource> cache = ResourceCache::get_singleton()->get_ref(path);
             if (cache.is_valid() && cache->get_class() == type) {
                 res = cache;
-                #if GODOT_VERSION >= 0x040400
                 res->reset_state();
-                #endif
                 do_assign = true;
             }
         }
@@ -427,16 +421,10 @@ Error OrchestrationTextParser::_load() {
                     // res->set_path(path);
                 }
             } else {
-                #if GODOT_VERSION >= 0x040400
                 res->set_path_cache(path);
-                #endif
             }
 
-            #if GODOT_VERSION >= 0x040300
             res->set_scene_unique_id(id);
-            #else
-            ResourceCache::get_singleton()->set_scene_unique_id(_path, res, id);
-            #endif
         }
 
         Dictionary missing_properties;
@@ -484,9 +472,7 @@ Error OrchestrationTextParser::_load() {
 
         Ref<Resource> cache = ResourceCache::get_singleton()->get_ref(_path);
 		if (_cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE && cache.is_valid() && cache->get_class() == _type) {
-		    #if GODOT_VERSION >= 0x040400
 		    cache->reset_state();
-		    #endif
 			_resource = cache;
 		}
 
@@ -535,9 +521,7 @@ Error OrchestrationTextParser::_load() {
 					    // todo: requires Godot change to support this
 						// _resource->set_as_translation_remapped(_translation_remapped);
 					} else {
-			            #if GODOT_VERSION >= 0x040400
 			            _resource->set_path_cache(_path);
-			            #endif
 					}
 				}
 				return err;

--- a/src/orchestration/serialization/text/text_serializer.cpp
+++ b/src/orchestration/serialization/text/text_serializer.cpp
@@ -238,7 +238,6 @@ Error OrchestrationTextSerializer::save(const Ref<Resource>& p_resource, const S
     for (List<Ref<Resource>>::Element* E = _saved_resources.front(); E ; E = E->next()) {
         const Ref<Resource> res = E->get();
         if (E->next() && _is_resource_built_in(res)) {
-            #if GODOT_VERSION >= 0x040300
             if (!res->get_scene_unique_id().is_empty()) {
                 if (used_unique_ids.has(res->get_scene_unique_id())) {
                     res->set_scene_unique_id(""); // Repeated
@@ -246,16 +245,6 @@ Error OrchestrationTextSerializer::save(const Ref<Resource>& p_resource, const S
                     used_unique_ids.insert(res->get_scene_unique_id());
                 }
             }
-            #else
-            const String id = ResourceCache::get_singleton()->get_scene_unique_id(_path, res);
-            if (!id.is_empty()) {
-                if (used_unique_ids.has(id)) {
-                    ResourceCache::get_singleton()->set_scene_unique_id(_path, res, "");
-                } else {
-                    used_unique_ids.insert(id);
-                }
-            }
-            #endif
         }
     }
 
@@ -271,11 +260,7 @@ Error OrchestrationTextSerializer::save(const Ref<Resource>& p_resource, const S
             const String uid = _create_resource_uid(res, used_unique_ids, generated);
 
             if (generated) {
-                #if GODOT_VERSION >= 0x040300
                 res->set_scene_unique_id(uid);
-                #else
-                ResourceCache::get_singleton()->set_scene_unique_id(_path, res, uid);
-                #endif
                 used_unique_ids.insert(uid);
             }
 

--- a/src/orchestration/serialization/text/text_serializer.h
+++ b/src/orchestration/serialization/text/text_serializer.h
@@ -16,7 +16,6 @@
 //
 #pragma once
 
-#include "common/version.h"
 #include "orchestration/serialization/serializer.h"
 
 // Forward declarations
@@ -37,10 +36,6 @@ class OrchestrationTextSerializer : public OrchestrationSerializer {
 
     HashMap<Ref<Resource>, String> _external_resources;
     HashMap<Ref<Resource>, String> _internal_resources;
-
-    #if GODOT_VERSION < 0x040300
-    String _generate_scene_unique_id();
-    #endif
 
     static String _write_resources(void* p_userdata, const Ref<Resource>& p_resource);
     String _write_resource(const Ref<Resource>& p_resource);

--- a/src/script/language.cpp
+++ b/src/script/language.cpp
@@ -38,13 +38,10 @@
 #include <godot_cpp/classes/engine_debugger.hpp>
 #include <godot_cpp/classes/expression.hpp>
 #include <godot_cpp/classes/file_access.hpp>
+#include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/packed_scene.hpp>
 #include <godot_cpp/classes/resource_loader.hpp>
 #include <godot_cpp/core/mutex_lock.hpp>
-
-#if GODOT_VERSION >= 0x040300
-  #include <godot_cpp/classes/os.hpp>
-#endif
 
 OScriptLanguage* OScriptLanguage::_singleton = nullptr;
 
@@ -362,30 +359,22 @@ String OScriptLanguage::_debug_get_error() const {
 }
 
 int32_t OScriptLanguage::_debug_get_stack_level_count() const {
-    #if GODOT_VERSION >= 0x040300
-    if (_debug_parse_err_line >= 0)
+    if (_debug_parse_err_line >= 0) {
         return 1;
+    }
     return _call_stack_size;
-    #else
-    return 0;
-    #endif
 }
 
 int32_t OScriptLanguage::_debug_get_stack_level_line(int32_t p_level) const {
-    #if GODOT_VERSION >= 0x040300
     if (_debug_parse_err_line >= 0) {
         return _debug_parse_err_line;
     }
 
     ERR_FAIL_INDEX_V(p_level, _call_stack_size, -1);
     return *(_get_stack_level(p_level)->node);
-    #else
-    return -1;
-    #endif
 }
 
 String OScriptLanguage::_debug_get_stack_level_function(int32_t p_level) const {
-    #if GODOT_VERSION >= 0x040300
     if (_debug_parse_err_line >= 0) {
         return {};
     }
@@ -393,26 +382,18 @@ String OScriptLanguage::_debug_get_stack_level_function(int32_t p_level) const {
     ERR_FAIL_INDEX_V(p_level, _call_stack_size, {});
     OScriptCompiledFunction* func = _get_stack_level(p_level)->function;
     return func ? String(func->get_name()) : "";
-    #else
-    return {};
-    #endif
 }
 
 String OScriptLanguage::_debug_get_stack_level_source(int32_t p_level) const {
-    #if GODOT_VERSION >= 0x040300
     if (_debug_parse_err_line >= 0) {
         return _debug_parse_err_file.get();
     }
 
     ERR_FAIL_INDEX_V(p_level, _call_stack_size, {});
     return _get_stack_level(p_level)->function->get_source();
-    #else
-    return {};
-    #endif
 }
 
 Dictionary OScriptLanguage::_debug_get_stack_level_locals(int32_t p_level, int32_t p_max_subitems, int32_t p_max_depth) {
-    #if GODOT_VERSION >= 0x040300
     if (_debug_parse_err_line >= 0) {
         return {};
     }
@@ -440,13 +421,9 @@ Dictionary OScriptLanguage::_debug_get_stack_level_locals(int32_t p_level, int32
     result["locals"] = local_names;
     result["values"] = local_values;
     return result;
-    #else
-    return {};
-    #endif
 }
 
 Dictionary OScriptLanguage::_debug_get_stack_level_members(int32_t p_level, int32_t p_max_subitems, int32_t p_max_depth) {
-    #if GODOT_VERSION >= 0x040300
     if (_debug_parse_err_line >= 0) {
         return {};
     }
@@ -476,26 +453,18 @@ Dictionary OScriptLanguage::_debug_get_stack_level_members(int32_t p_level, int3
     members["values"] = member_values;
 
     return members;
-    #else
-    return {};
-    #endif
 }
 
 void* OScriptLanguage::_debug_get_stack_level_instance(int32_t p_level) {
-    #if GODOT_VERSION >= 0x040300
     if (_debug_parse_err_line >= 0) {
         return nullptr;
     }
 
     ERR_FAIL_INDEX_V(p_level, _call_stack_size, nullptr);
     return _get_stack_level(p_level)->instance->_script_instance;
-    #else
-    return nullptr;
-    #endif
 }
 
 Dictionary OScriptLanguage::_debug_get_globals(int32_t p_max_subitems, int32_t p_max_depth) {
-    #if GODOT_VERSION >= 0x040300
     const HashMap<StringName, int>& name_index = get_global_map();
     const Variant* gl_array = get_global_array();
 
@@ -541,9 +510,6 @@ Dictionary OScriptLanguage::_debug_get_globals(int32_t p_max_subitems, int32_t p
     results["globals"] = global_names;
     results["values"] = global_values;
     return results;
-    #else
-    return {};
-    #endif
 }
 
 String OScriptLanguage::_debug_parse_stack_level_expression(int32_t p_level, const String& p_expression, int32_t p_max_subitems, int32_t p_max_depth) {
@@ -570,7 +536,6 @@ String OScriptLanguage::_debug_parse_stack_level_expression(int32_t p_level, con
 
 TypedArray<Dictionary> OScriptLanguage::_debug_get_current_stack_info() {
     TypedArray<Dictionary> array;
-    #if GODOT_VERSION >= 0x040300
     CallLevel* cl = _call_stack;
     while (cl) {
         Dictionary data;
@@ -580,7 +545,6 @@ TypedArray<Dictionary> OScriptLanguage::_debug_get_current_stack_info() {
         array.append(data);
         cl = cl->prev;
     }
-    #endif
     return array;
 }
 
@@ -1105,7 +1069,6 @@ PackedStringArray OScriptLanguage::get_global_named_constant_names() const {
 }
 
 bool OScriptLanguage::debug_break(const String& p_error, bool p_allow_continue) {
-    #if GODOT_VERSION >= 0x040300
     if (EngineDebugger::get_singleton()->is_active()) {
         _debug_parse_err_line = -1;
         _debug_parse_err_file = "";
@@ -1119,12 +1082,10 @@ bool OScriptLanguage::debug_break(const String& p_error, bool p_allow_continue) 
         _debug_error = String();
         return true;
     }
-    #endif
     return false;
 }
 
 bool OScriptLanguage::debug_break_parse(const String& p_file, int p_node, const String& p_error) {
-    #if GODOT_VERSION >= 0x040300
     if (EngineDebugger::get_singleton()->is_active())
     {
         if (OS::get_singleton()->get_thread_caller_id() == OS::get_singleton()->get_main_thread_id())
@@ -1142,7 +1103,6 @@ bool OScriptLanguage::debug_break_parse(const String& p_file, int p_node, const 
             return true;
         }
     }
-    #endif
     return false;
 }
 

--- a/src/script/language.h
+++ b/src/script/language.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include "core/godot/string/string.h"
-#include "common/version.h"
 #include "script/compiler/compiled_function.h"
 #include "script/serialization/format_defs.h"
 
@@ -66,7 +65,6 @@ class OScriptLanguage : public ScriptLanguageExtension {
     HashMap<StringName, Variant> named_globals;
     Vector<int> global_array_empty_indexes;
 
-    #if GODOT_VERSION >= 0x040300
     struct CallLevel {
         Variant* stack{ nullptr };
         OScriptCompiledFunction* function{ nullptr };
@@ -75,7 +73,6 @@ class OScriptLanguage : public ScriptLanguageExtension {
         int* node{ nullptr };
         CallLevel* prev{ nullptr };
     };
-    #endif
 
     static thread_local int _debug_parse_err_line;
     static thread_local StringPtr _debug_parse_err_file;
@@ -146,9 +143,7 @@ public:
     bool _can_inherit_from_file() const override { return true; }
     int32_t _find_function(const String& p_function_name, const String& p_code) const override;
     String _make_function(const String& p_class_name, const String& p_function_name, const PackedStringArray& p_function_args) const override;
-    #if GODOT_VERSION >= 0x040300
     bool _can_make_function() const override { return true; }
-    #endif
     Error _open_in_external_editor(const Ref<Script>& p_script, int32_t p_line, int32_t p_column) override { return OK; }
     bool _overrides_external_editor() override { return true; }
     void _add_global_constant(const StringName& p_name, const Variant& p_value) override;

--- a/src/script/node.cpp
+++ b/src/script/node.cpp
@@ -18,7 +18,6 @@
 
 #include "common/macros.h"
 #include "common/variant_utils.h"
-#include "common/version.h"
 #include "script/script.h"
 
 #include <godot_cpp/classes/os.hpp>
@@ -73,14 +72,12 @@ void OScriptNode::set_position(const Vector2& p_position) {
     }
 }
 
-#if GODOT_VERSION >= 0x040300
 void OScriptNode::set_breakpoint_flag(BreakpointFlags p_flag) {
     if (_breakpoint_flag != p_flag) {
         _breakpoint_flag = p_flag;
         emit_changed();
     }
 }
-#endif
 
 void OScriptNode::set_flags(BitField<ScriptNodeFlags> p_flags) {
     _flags = p_flags;
@@ -179,11 +176,7 @@ void OScriptNode::initialize(const OScriptNodeInitContext& p_context) {
 }
 
 String OScriptNode::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     return vformat("class:%s", get_class());
-    #else
-    return get_class();
-    #endif
 }
 
 Ref<OScriptNodePin> OScriptNode::create_pin(EPinDirection p_direction, EPinType p_pin_type, const PropertyInfo& p_property, const Variant& p_default_value) {
@@ -342,10 +335,7 @@ void OScriptNode::_cache_pin_indices() {
 
 OScriptNode::OScriptNode()
     : _flags(CATALOGABLE)
-    #if GODOT_VERSION >= 0x040300
-    , _breakpoint_flag(BREAKPOINT_NONE)
-    #endif
-{
+    , _breakpoint_flag(BREAKPOINT_NONE) {
 }
 
 void OScriptNode::_bind_methods() {

--- a/src/script/node.h
+++ b/src/script/node.h
@@ -75,13 +75,11 @@ public:
         EXPERIMENTAL     = 1 << 3       //! Node is experimental and may change
     };
 
-    #if GODOT_VERSION >= 0x040300
     enum BreakpointFlags {
         BREAKPOINT_NONE,
         BREAKPOINT_ENABLED,
         BREAKPOINT_DISABLED
     };
-    #endif
 
 protected:
     Orchestration* _orchestration = nullptr;   //! Owning orchestration
@@ -93,9 +91,7 @@ protected:
     Vector<Ref<OScriptNodePin>> _pins;         //! Pins
     bool _reconstruction_queued = false;       //! Tracks if node reconstruction has been queued
     bool _reconstructing = false;              //! Tracks if the node is in reconstruction
-    #if GODOT_VERSION >= 0x040300
     BreakpointFlags _breakpoint_flag;          //! Transient state for breakpoints
-    #endif
 
 private:
     // Serialization for pins
@@ -151,7 +147,6 @@ public:
     /// @param p_position the node's position coordinates
     void set_position(const Vector2& p_position);
 
-    #if GODOT_VERSION >= 0x040300
     /// Returns whether this node has a breakpoint, regardless if breakpoint is disabled.
     /// @return if this node has a breakpoint
     bool has_breakpoint() const { return _breakpoint_flag != BREAKPOINT_NONE; }
@@ -163,7 +158,6 @@ public:
     /// Sets the node's breakpoint flag
     /// @param p_flag the breakpoint flag state
     void set_breakpoint_flag(BreakpointFlags p_flag);
-    #endif
 
     /// Get the node's flags.
     /// @return flags, defaults to none.

--- a/src/script/node_pin.cpp
+++ b/src/script/node_pin.cpp
@@ -32,12 +32,6 @@ Ref<OScriptNodePin> OScriptNodePin::create(OScriptNode* p_owning_node, const Pro
     pin->_owning_node = p_owning_node;
     pin->_property = p_property;
 
-    #if GODOT_VERSION < 0x040202
-    if (pin->_property.usage == 7) {
-        pin->_property.usage = PROPERTY_USAGE_DEFAULT;
-    }
-    #endif
-
     if (PropertyUtils::is_enum(p_property)) {
         pin->_flags.set_flag(ENUM);
         if (p_property.usage & PROPERTY_USAGE_CLASS_IS_ENUM) {
@@ -127,12 +121,6 @@ bool OScriptNodePin::_load(const Dictionary& p_data) {
         _property.usage = p_data["usage"];
     }
 
-    #if GODOT_VERSION < 0x040202
-    if (_property.usage == 7) {
-        _property.usage = PROPERTY_USAGE_DEFAULT;
-    }
-    #endif
-
     return true;
 }
 
@@ -182,12 +170,6 @@ Dictionary OScriptNodePin::_save() {
     if (!_property.hint_string.is_empty()) {
         data["hint_string"] = _property.hint_string;
     }
-
-    #if GODOT_VERSION < 0x040202
-    if (_property.usage == 7) {
-        _property.usage = PROPERTY_USAGE_DEFAULT;
-    }
-    #endif
 
     if (_property.usage != PROPERTY_USAGE_DEFAULT) {
         data["usage"] = _property.usage;

--- a/src/script/nodes/constants/constants.cpp
+++ b/src/script/nodes/constants/constants.cpp
@@ -20,7 +20,6 @@
 #include "common/property_utils.h"
 #include "common/string_utils.h"
 #include "common/variant_utils.h"
-#include "common/version.h"
 #include "script/script_server.h"
 
 #include <godot_cpp/classes/engine.hpp>
@@ -124,11 +123,7 @@ String OScriptNodeGlobalConstant::get_node_title() const {
 }
 
 String OScriptNodeGlobalConstant::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     return vformat("class_constant:@GlobalScope:%s", _constant_name);
-    #else
-    return super::get_help_topic();
-    #endif
 }
 
 String OScriptNodeGlobalConstant::get_icon() const {
@@ -184,13 +179,9 @@ String OScriptNodeMathConstant::get_node_title() const {
 }
 
 String OScriptNodeMathConstant::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     // todo: some math constants are not exposed to the documentation, i.e. "One"
     //       check if these can be exposed via OScriptLanguage instead?
     return vformat("class_constant:@GDScript:%s", _constant_name);
-    #else
-    return super::get_help_topic();
-    #endif
 }
 
 String OScriptNodeMathConstant::get_icon() const {
@@ -330,11 +321,7 @@ String OScriptNodeTypeConstant::get_node_title() const {
 }
 
 String OScriptNodeTypeConstant::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     return vformat("class_constant:%s:%s", Variant::get_type_name(_type), _constant_name);
-    #else
-    return super::get_help_topic();
-    #endif
 }
 
 String OScriptNodeTypeConstant::get_icon() const {
@@ -448,7 +435,6 @@ String OScriptNodeClassConstantBase::get_node_title() const {
 }
 
 String OScriptNodeClassConstantBase::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     String class_name = _class_name;
     while (!class_name.is_empty()) {
         PackedStringArray values = ClassDB::class_get_integer_constant_list(class_name, true);
@@ -457,7 +443,6 @@ String OScriptNodeClassConstantBase::get_help_topic() const {
         }
         class_name = ClassDB::get_parent_class(class_name);
     }
-    #endif
     return super::get_help_topic();
 }
 

--- a/src/script/nodes/data/compose.cpp
+++ b/src/script/nodes/data/compose.cpp
@@ -183,11 +183,7 @@ String OScriptNodeComposeFrom::get_icon() const {
 }
 
 String OScriptNodeComposeFrom::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     return vformat("class:%s", Variant::get_type_name(_type));
-    #else
-    return vformat("%s", Variant::get_type_name(_type));
-    #endif
 }
 
 PackedStringArray OScriptNodeComposeFrom::get_keywords() const {

--- a/src/script/nodes/data/decompose.cpp
+++ b/src/script/nodes/data/decompose.cpp
@@ -106,11 +106,7 @@ String OScriptNodeDecompose::get_icon() const {
 }
 
 String OScriptNodeDecompose::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     return vformat("class:%s", Variant::get_type_name(_type));
-    #else
-    return vformat("%s", Variant::get_type_name(_type));
-    #endif
 }
 
 PackedStringArray OScriptNodeDecompose::get_keywords() const {

--- a/src/script/nodes/functions/call_builtin_function.cpp
+++ b/src/script/nodes/functions/call_builtin_function.cpp
@@ -18,7 +18,6 @@
 
 #include "common/dictionary_utils.h"
 #include "common/method_utils.h"
-#include "common/version.h"
 #include "script/utility_functions.h"
 
 bool OScriptNodeCallBuiltinFunction::_has_execution_pins(const MethodInfo& p_method) const {
@@ -37,14 +36,10 @@ String OScriptNodeCallBuiltinFunction::get_node_title() const {
 }
 
 String OScriptNodeCallBuiltinFunction::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     if (OScriptUtilityFunctions::function_exists(_reference.method.name)) {
         return vformat("class_method:@OScript:%s", _reference.method.name);
     }
     return vformat("class_method:@GlobalScope:%s", _reference.method.name);
-    #else
-    return super::get_help_topic();
-    #endif
 }
 
 void OScriptNodeCallBuiltinFunction::initialize(const OScriptNodeInitContext& p_context) {

--- a/src/script/nodes/functions/call_member_function.cpp
+++ b/src/script/nodes/functions/call_member_function.cpp
@@ -21,7 +21,6 @@
 #include "common/method_utils.h"
 #include "common/property_utils.h"
 #include "common/variant_utils.h"
-#include "common/version.h"
 #include "script/nodes/variables/variable_get.h"
 #include "script/script_server.h"
 
@@ -159,7 +158,6 @@ String OScriptNodeCallMemberFunction::get_node_title_color_name() const {
 }
 
 String OScriptNodeCallMemberFunction::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     if (_reference.target_type != Variant::OBJECT) {
         BuiltInType type = ExtensionDB::get_builtin_type(_reference.target_type);
         return vformat("class_method:%s:%s", type.name, _reference.method.name);
@@ -169,7 +167,6 @@ String OScriptNodeCallMemberFunction::get_help_topic() const {
             return vformat("class_method:%s:%s", class_name, _reference.method.name);
         }
     }
-    #endif
     return super::get_help_topic();
 }
 

--- a/src/script/nodes/functions/call_static_function.cpp
+++ b/src/script/nodes/functions/call_static_function.cpp
@@ -20,7 +20,6 @@
 #include "common/dictionary_utils.h"
 #include "common/method_utils.h"
 #include "common/property_utils.h"
-#include "common/version.h"
 #include "core/godot/gdextension_compat.h"
 #include "script/script_server.h"
 
@@ -135,12 +134,10 @@ String OScriptNodeCallStaticFunction::get_node_title() const {
 }
 
 String OScriptNodeCallStaticFunction::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     const String class_name = MethodUtils::get_method_class(_class_name, _method_name);
     if (!class_name.is_empty()) {
         return vformat("class_method:%s:%s", class_name, _method_name);
     }
-    #endif
     return super::get_help_topic();
 }
 

--- a/src/script/nodes/functions/event.cpp
+++ b/src/script/nodes/functions/event.cpp
@@ -18,7 +18,6 @@
 
 #include "common/method_utils.h"
 #include "common/variant_utils.h"
-#include "common/version.h"
 #include "script/script.h"
 
 String OScriptNodeEvent::get_tooltip_text() const {
@@ -37,14 +36,12 @@ String OScriptNodeEvent::get_node_title() const {
 }
 
 String OScriptNodeEvent::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     if (_function.is_valid()) {
         String class_name = MethodUtils::get_method_class(_orchestration->get_base_type(), _function->get_function_name());
         if (!class_name.is_empty()) {
             return vformat("class_method:%s:%s", class_name, _function->get_function_name());
         }
     }
-    #endif
     return super::get_help_topic();
 }
 

--- a/src/script/nodes/memory/memory.cpp
+++ b/src/script/nodes/memory/memory.cpp
@@ -17,7 +17,6 @@
 #include "script/nodes/memory/memory.h"
 
 #include "common/property_utils.h"
-#include "common/version.h"
 #include "script/script_server.h"
 
 #include <godot_cpp/classes/engine.hpp>
@@ -83,11 +82,7 @@ String OScriptNodeNew::get_node_title() const {
 }
 
 String OScriptNodeNew::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     return vformat("class:%s", _class_name);
-    #else
-    return super::get_help_topic();
-    #endif
 }
 
 String OScriptNodeNew::get_icon() const {

--- a/src/script/nodes/properties/property.cpp
+++ b/src/script/nodes/properties/property.cpp
@@ -191,7 +191,6 @@ String OScriptNodeProperty::get_icon() const {
 }
 
 String OScriptNodeProperty::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     switch (_call_mode) {
         case CALL_INSTANCE:
             return vformat("class_property:%s:%s", _base_type, _property.name);
@@ -209,7 +208,6 @@ String OScriptNodeProperty::get_help_topic() const {
         default:
             break;
     }
-    #endif
     return super::get_help_topic();
 }
 

--- a/src/script/nodes/scene/scene_node.cpp
+++ b/src/script/nodes/scene/scene_node.cpp
@@ -120,11 +120,7 @@ String OScriptNodeSceneNode::get_icon() const {
 }
 
 String OScriptNodeSceneNode::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     return vformat("class:%s", _class_name);
-    #else
-    return _class_name;
-    #endif
 }
 
 Ref<OScriptTargetObject> OScriptNodeSceneNode::resolve_target(const Ref<OScriptNodePin>& p_pin) const {

--- a/src/script/nodes/scene/scene_tree.cpp
+++ b/src/script/nodes/scene/scene_tree.cpp
@@ -50,9 +50,5 @@ String OScriptNodeSceneTree::get_icon() const {
 }
 
 String OScriptNodeSceneTree::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     return vformat("class:%s", SceneTree::get_class_static());
-    #else
-    return SceneTree::get_class_static();
-    #endif
 }

--- a/src/script/nodes/signals/emit_member_signal.cpp
+++ b/src/script/nodes/signals/emit_member_signal.cpp
@@ -93,11 +93,7 @@ String OScriptNodeEmitMemberSignal::get_node_title() const {
 }
 
 String OScriptNodeEmitMemberSignal::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     return vformat("class_signal:%s:%s", _target_class, _method.name);
-    #else
-    return vformat("%s:%s", _target_class, _method.name);
-    #endif
 }
 
 void OScriptNodeEmitMemberSignal::initialize(const OScriptNodeInitContext& p_context) {

--- a/src/script/nodes/utilities/engine_singleton.cpp
+++ b/src/script/nodes/utilities/engine_singleton.cpp
@@ -18,7 +18,6 @@
 
 #include "common/property_utils.h"
 #include "common/string_utils.h"
-#include "common/version.h"
 
 #include <godot_cpp/classes/engine.hpp>
 
@@ -73,11 +72,7 @@ String OScriptNodeEngineSingleton::get_node_title() const {
 }
 
 String OScriptNodeEngineSingleton::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     return vformat("class:%s", _singleton);
-    #else
-    return super::get_help_topic();
-    #endif
 }
 
 String OScriptNodeEngineSingleton::get_icon() const {

--- a/src/script/nodes/utilities/self.cpp
+++ b/src/script/nodes/utilities/self.cpp
@@ -19,7 +19,6 @@
 #include "common/macros.h"
 #include "common/property_utils.h"
 #include "common/scene_utils.h"
-#include "common/version.h"
 
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/scene_tree.hpp>
@@ -63,11 +62,7 @@ String OScriptNodeSelf::get_node_title() const {
 }
 
 String OScriptNodeSelf::get_help_topic() const {
-    #if GODOT_VERSION >= 0x040300
     return vformat("class:%s", _orchestration->get_base_type());
-    #else
-    return super::get_help_topic();
-    #endif
 }
 
 String OScriptNodeSelf::get_icon() const {

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -974,19 +974,15 @@ Error OScript::_reload(bool p_keep_state) {
 }
 
 #ifdef TOOLS_ENABLED
-#if GODOT_VERSION >= 0x040400
 StringName OScript::_get_doc_class_name() const {
     return doc_class_name;
 }
-#endif
 
 TypedArray<Dictionary> OScript::_get_documentation() const {
     TypedArray<Dictionary> result;
-    #ifdef TOOLS_ENABLED
     for (const DocData::ClassDoc& class_doc : docs) {
         result.push_back(DocData::ClassDoc::to_dict(class_doc));
     }
-    #endif
     return result;
 }
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -216,11 +216,9 @@ public:
     void _set_source_code(const String& p_code) override;
     Error _reload(bool p_keep_state) override;
     #ifdef TOOLS_ENABLED
-    #if GODOT_VERSION >= 0x040400
     StringName _get_doc_class_name() const override;
     TypedArray<Dictionary> _get_documentation() const override;
     String _get_class_icon_path() const override;
-    #endif
     #endif
     bool _has_method(const StringName& p_method) const override;
     bool _has_static_method(const StringName& p_method) const override;

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -143,15 +143,9 @@ struct OScriptInstanceCallbacks {
         return INSTANCE->get_property_list(r_size);
     }
 
-    #if GODOT_VERSION >= 0x040300
     static void free_property_list_func(GDExtensionScriptInstanceDataPtr p_instance, const GDExtensionPropertyInfo* p_list, uint32_t p_count) {
         INSTANCE->free_property_list(p_list, p_count);
     }
-    #else
-    static void free_property_list_func(GDExtensionScriptInstanceDataPtr p_instance, const GDExtensionPropertyInfo* p_list) {
-        INSTANCE->free_property_list(p_list);
-    }
-    #endif
 
     static GDExtensionBool property_can_revert_func(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name) {
         return INSTANCE->property_can_revert(CAST_STRINGNAME(p_name));
@@ -173,15 +167,9 @@ struct OScriptInstanceCallbacks {
         return INSTANCE->get_method_list(r_size);
     }
 
-    #if GODOT_VERSION >= 0x040300
     static void free_method_list_func(GDExtensionScriptInstanceDataPtr p_instance, const GDExtensionMethodInfo* p_list, uint32_t p_count) {
         INSTANCE->free_method_list(p_list, p_count);
     }
-    #else
-    static void free_method_list_func(GDExtensionScriptInstanceDataPtr p_instance, const GDExtensionMethodInfo* p_list) {
-        INSTANCE->free_method_list(p_list);
-    }
-    #endif
 
     static GDExtensionVariantType get_property_type_func(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionConstStringNamePtr p_name, GDExtensionBool* r_valid) {
         return static_cast<GDExtensionVariantType>(INSTANCE->get_property_type(CAST_STRINGNAME(p_name), CAST_BOOL(r_valid)));

--- a/src/script/script_instance.h
+++ b/src/script/script_instance.h
@@ -28,13 +28,8 @@
 
 using namespace godot;
 
-#if GODOT_VERSION >= 0x040300
 typedef GDExtensionScriptInstanceInfo3 OScriptInstanceInfo;
 #define GDEXTENSION_SCRIPT_INSTANCE_CREATE GDE_INTERFACE(script_instance_create3)
-#else
-typedef GDExtensionScriptInstanceInfo2 OScriptInstanceInfo;
-#define GDEXTENSION_SCRIPT_INSTANCE_CREATE GDE_INTERFACE(script_instance_create2)
-#endif
 
 /// Abstract base class for all OScript-based script instance objects.
 class OScriptInstanceBase {

--- a/src/script/script_server.cpp
+++ b/src/script/script_server.cpp
@@ -16,8 +16,6 @@
 //
 #include "script/script_server.h"
 
-#include "common/version.h"
-
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/node.hpp>
 #include <godot_cpp/classes/project_settings.hpp>
@@ -266,16 +264,7 @@ PackedStringArray ScriptServer::get_class_hierarchy(const StringName& p_class_na
 
 String ScriptServer::get_global_name(const Ref<Script>& p_script) {
     if (p_script.is_valid()) {
-        #if GODOT_VERSION >= 0x040300
         return p_script->get_global_name();
-        #else
-        for (const Variant& global_class : _get_global_class_list()) {
-            const Dictionary& entry = global_class;
-            if (entry.has("path") && p_script->get_path().match(entry["path"]) && entry.has("class")) {
-                return entry["class"];
-            }
-        }
-        #endif
     }
     return "";
 }

--- a/src/script/serialization/resource_cache.cpp
+++ b/src/script/serialization/resource_cache.cpp
@@ -109,44 +109,6 @@ void ResourceCache::set_id_for_path(const String& p_path, const String& p_res_pa
         add_path_cache(p_path, p_res_path, p_id);
 }
 
-#if GODOT_VERSION < 0x040400
-String ResourceCache::get_scene_unique_id(const String& p_path, const Ref<Resource>& p_resource) {
-    ERR_FAIL_COND_V_MSG(!p_resource.is_valid(), String(), "No resource path was supplied to get_scene_unique_id");
-
-    if (_resource_scene_unique_ids.has(p_path)) {
-        for (const CacheEntry& entry : _resource_scene_unique_ids[p_path]) {
-            if (entry.is_resource(p_resource)) {
-                return entry.id;
-            }
-        }
-    }
-    return {};
-}
-
-void ResourceCache::set_scene_unique_id(const String& p_path, const Ref<Resource>& p_resource, const String& p_id) {
-    ERR_FAIL_COND_MSG(!p_resource.is_valid(), "Cannot set scene unique id on invalid resource.");
-
-    Variant weak_ref = UtilityFunctions::weakref(p_resource);
-    ERR_FAIL_COND_MSG(!weak_ref, "Cannot set scene unique id on an invalid weak reference.");
-
-    if (p_id.is_empty()) {
-        const List<CacheEntry>& list = _resource_scene_unique_ids[p_path];
-        for (const CacheEntry& entry : list) {
-            if (entry.is_resource(p_resource)) {
-                _resource_scene_unique_ids[p_path].erase(entry);
-                break;
-            }
-        }
-    } else {
-        CacheEntry entry;
-        entry.reference = weak_ref;
-        entry.id = p_id;
-
-        _resource_scene_unique_ids[p_path].push_back(entry);
-    }
-}
-#endif
-
 ResourceCache::ResourceCache() {
     _singleton = this;
     _mutex.instantiate();

--- a/src/script/serialization/resource_cache.h
+++ b/src/script/serialization/resource_cache.h
@@ -16,8 +16,6 @@
 //
 #pragma once
 
-#include "common/version.h"
-
 #include <godot_cpp/classes/resource.hpp>
 #include <godot_cpp/core/mutex_lock.hpp>
 #include <godot_cpp/templates/hash_map.hpp>
@@ -45,9 +43,6 @@ protected:
     Ref<Mutex> _path_cache_lock;                                    //! Mutex for the resource path cache
     HashMap<String, Resource*> _resources;                          //! Map of resources
     HashMap<String, HashMap<String, String>> _resource_path_cache;  //! Map of resource path to resource IDs
-    #if GODOT_VERSION < 0x040400
-    HashMap<String, List<CacheEntry>> _resource_scene_unique_ids;   //! Map of scene unique IDs for resources
-    #endif
 
     /// Clears the cache
     void _clear();
@@ -96,11 +91,6 @@ public:
 
     /// Helper method for Resource::set_id_for_path
     void set_id_for_path(const String& p_path, const String& p_res_path, const String& p_id);
-
-    #if GODOT_VERSION < 0x040400
-    String get_scene_unique_id(const String& p_path, const Ref<Resource>& p_resource);
-    void set_scene_unique_id(const String& p_path, const Ref<Resource>& p_resource, const String& p_id);
-    #endif
 
     ResourceCache();
     ~ResourceCache();

--- a/src/script/utility_functions.cpp
+++ b/src/script/utility_functions.cpp
@@ -17,7 +17,6 @@
 #include "script/utility_functions.h"
 
 #include "common/settings.h"
-#include "common/version.h"
 #include "core/godot/variant/variant.h"
 #include "script/language.h"
 #include "script/nodes/utilities/print_string.h"
@@ -121,7 +120,6 @@ struct OScriptUtilityFunctionsDefinitions
         *r_ret = ClassDB::class_exists(*p_args[0]);
     }
 
-    #if GODOT_VERSION >= 0x040300
     static void print_debug(Variant* r_ret, const Variant** p_args, int p_arg_count, GDExtensionCallError& r_error) {
         String s;
         for (int i = 0; i < p_arg_count; i++) {
@@ -191,7 +189,6 @@ struct OScriptUtilityFunctionsDefinitions
 
         *r_ret = ret;
     }
-    #endif
 
     /// Returns the length of the specified Variant input argument.
     static void len(Variant* r_ret, const Variant** p_args, int p_arg_count, GDExtensionCallError& r_error) {
@@ -253,13 +250,11 @@ struct OScriptUtilityFunctionsDefinitions
                 *r_ret = d.size();
                 break;
             }
-            #if GODOT_VERSION >= 0x040300
             case Variant::PACKED_VECTOR4_ARRAY: {
                 PackedVector4Array d = *p_args[0];
                 *r_ret = d.size();
                 break;
             }
-            #endif
             default: {
                 *r_ret = vformat("Value of type '%s' cannot provide a length", Variant::get_type_name(p_args[0]->get_type()));
                 r_error.error = GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT;
@@ -568,11 +563,9 @@ static void _register_function(const StringName& p_name, const MethodInfo& p_met
 
 void OScriptUtilityFunctions::register_functions() {
 
-    #if GODOT_VERSION >= 0x040300
     REGISTER_FUNC(print_debug, false, RET(NIL), NOARGS, true, varray(), false);
     REGISTER_FUNC(print_stack, false, RET(NIL), NOARGS, false, varray(), false);
     REGISTER_FUNC(get_stack, false, RET(ARRAY), NOARGS, false, varray(), false);
-    #endif
 
     REGISTER_FUNC(type_exists, true, RET(BOOL), ARGS(ARG("type", STRING_NAME)), false, varray(), false);
     REGISTER_FUNC(len, true, RET(INT), ARGS(ARGVAR("var")), false, varray(), false);


### PR DESCRIPTION
Fixes #1283

With the fact that we're dropping support for Orchestrator 2.0 and 2.1, there is no need to continue to support Godot 4.2 and 4.3, which have a considerable amount of conditionalized logic that this PR was able to remove.