### PR TITLE
GH-709 Support connection straightening

### DIFF
--- a/src/editor/graph/graph_panel.cpp
+++ b/src/editor/graph/graph_panel.cpp
@@ -789,13 +789,29 @@ void OrchestratorEditorGraphPanel::_show_pin_context_menu(OrchestratorEditorGrap
     }
 
     if (!pin_connections.is_empty()) {
-        OrchestratorEditorContextMenu* submenu = menu->add_submenu("Jump to connected node...");
-        for (OrchestratorEditorGraphPin* connection : pin_connections) {
-            const int node_id = connection->get_graph_node()->get_id();
-            const String node_name = connection->get_graph_node()->get_title();
+        {
+            OrchestratorEditorContextMenu* submenu = menu->add_submenu("Jump to connected node...");
+            for (OrchestratorEditorGraphPin* connection : pin_connections) {
+                const int node_id = connection->get_graph_node()->get_id();
+                const String node_name = connection->get_graph_node()->get_title();
 
-            const String label = vformat("Jump to %d - %s", node_id, node_name);
-            submenu->add_item(label, callable_mp_this(center_node).bind(connection->get_graph_node()));
+                const String label = vformat("Jump to %d - %s", node_id, node_name);
+                submenu->add_item(label, callable_mp_this(center_node).bind(connection->get_graph_node()));
+            }
+        }
+        {
+            OrchestratorEditorContextMenu* submenu = menu->add_submenu("Straighten Connection...");
+            if (pin_connections.size() > 1) {
+                submenu->add_item("Straighten All Pin Connections", callable_mp_this(straighten_all_connections).bind(p_pin));
+            }
+
+            for (OrchestratorEditorGraphPin* connection : pin_connections) {
+                const String node_name = connection->get_graph_node()->get_title();
+                const String pin_name = connection->get_pin_name();
+
+                const String label = vformat("Straighten Connection to %s (%s)", node_name, pin_name);
+                submenu->add_item(label, callable_mp_this(straighten_connection).bind(p_pin, connection));
+            }
         }
     }
 
@@ -3474,6 +3490,55 @@ void OrchestratorEditorGraphPanel::center_node(OrchestratorEditorGraphNode* p_no
     p_node->set_selected(true);
 
     scroll_to_position(p_node->get_graph_rect().get_center());
+}
+
+void OrchestratorEditorGraphPanel::straighten_all_connections(OrchestratorEditorGraphPin* p_pin) {
+    for (OrchestratorEditorGraphPin* connection : get_connected_pins(p_pin)) {
+        if (p_pin->get_direction() == PD_Output) {
+            straighten_connection(p_pin, connection);
+        } else {
+            straighten_connection(connection, p_pin);
+        }
+    }
+}
+
+void OrchestratorEditorGraphPanel::straighten_connection(OrchestratorEditorGraphPin* p_source, OrchestratorEditorGraphPin* p_target) {
+    GUARD_NULL(p_source);
+    GUARD_NULL(p_target);
+
+    OrchestratorEditorGraphNode* source_node = p_source->get_graph_node();
+    const Vector2 source_node_position = source_node->get_position_offset();
+    const Vector2 source_pin_position = source_node_position + source_node->get_port_position_for_pin(p_source);
+
+    OrchestratorEditorGraphNode* target_node = p_target->get_graph_node();
+    Vector2 target_node_position = target_node->get_position_offset();
+    const Vector2 target_pin_position = target_node_position + target_node->get_port_position_for_pin(p_target);
+
+    Connection connection;
+    connection.from_node = source_node->get_id();
+    connection.from_port = source_node->get_pin_port(p_source);
+    connection.to_node = target_node->get_id();
+    connection.to_port = target_node->get_pin_port(p_target);
+
+    if (_knot_editor) {
+        const Guid knot_guid = _knot_editor->get_knot_guid(connection.id, 0);
+        if (knot_guid.is_valid()) {
+            // If the connection has a knot, the first knot will be aligned instead of the target node.
+            const Vector<OrchestratorEditorGraphNodeKnot*> knots = get_all<OrchestratorEditorGraphNodeKnot>(false);
+            for (OrchestratorEditorGraphNodeKnot* knot : knots) {
+                if (knot->get_guid() == knot_guid) {
+                    Vector2 offset = knot->get_position_offset();
+                    offset.y = source_pin_position.y;
+                    knot->set_position_offset(offset);
+                    break;
+                }
+            }
+            return;
+        }
+    }
+
+    target_node_position.y += source_pin_position.y - target_pin_position.y;
+    target_node->_node->set_position(target_node_position);
 }
 
 OrchestratorEditorGraphNode* OrchestratorEditorGraphPanel::spawn_node(const NodeSpawnOptions& p_options) {

--- a/src/editor/graph/graph_panel.h
+++ b/src/editor/graph/graph_panel.h
@@ -359,6 +359,9 @@ public:
     void center_node_id(int p_id);
     void center_node(OrchestratorEditorGraphNode* p_node);
 
+    void straighten_all_connections(OrchestratorEditorGraphPin* p_pin);
+    void straighten_connection(OrchestratorEditorGraphPin* p_source, OrchestratorEditorGraphPin* p_target);
+
     template <typename T, typename P> Vector<T*> predicate_find(P&& p_predicate);
     template <typename T, typename F> void for_each(F&& p_function, bool p_selected = false);
     template <typename T> Vector<T*> get_selected();

--- a/src/editor/graph/knot_editor.cpp
+++ b/src/editor/graph/knot_editor.cpp
@@ -218,6 +218,15 @@ bool OrchestratorEditorGraphPanelKnotEditor::is_remove_knot_keybind(const Ref<In
     return is_create_knot_keybind(p_event);
 }
 
+Guid OrchestratorEditorGraphPanelKnotEditor::get_knot_guid(uint64_t p_connection_id, uint32_t p_knot_index) const {
+    const Vector<KnotInfo>* info = _knots.getptr(p_connection_id);
+    if (!info || p_knot_index >= info->size()) {
+        return {};
+    }
+
+    return info->get(p_knot_index).guid;
+}
+
 PackedVector2Array OrchestratorEditorGraphPanelKnotEditor::get_knots_for_connection(uint64_t p_connection_id) const {
     PackedVector2Array results;
     if (_knots.has(p_connection_id)) {

--- a/src/editor/graph/knot_editor.h
+++ b/src/editor/graph/knot_editor.h
@@ -92,6 +92,8 @@ public:
     bool is_create_knot_keybind(const Ref<InputEvent>& p_event) const;
     bool is_remove_knot_keybind(const Ref<InputEvent>& p_event) const;
 
+    Guid get_knot_guid(uint64_t p_connection_id, uint32_t p_knot_index) const;
+
     PointArray get_knots_for_connection(uint64_t p_connection_id) const;
     Vector<Ref<Curve2D>> get_curves_for_points(const PointArray& p_points, float p_curvature) const;
 

--- a/src/script/node.cpp
+++ b/src/script/node.cpp
@@ -67,7 +67,10 @@ void OScriptNode::set_size(const Vector2& p_size) {
 }
 
 void OScriptNode::set_position(const Vector2& p_position) {
-    _position = p_position;
+    if (!_position.is_equal_approx(p_position)) {
+        _position = p_position;
+        emit_changed();
+    }
 }
 
 #if GODOT_VERSION >= 0x040300


### PR DESCRIPTION
Fixes #709 

Given this graph
<img width="606" height="428" alt="image" src="https://github.com/user-attachments/assets/4401dc53-4475-40d8-b01e-0f01cc212d12" />


The pin context menu offers these options:
<img width="595" height="290" alt="image" src="https://github.com/user-attachments/assets/31e6d057-575e-4236-ba67-e73d734a7a01" />


When selecting straighten all connections, the result is:
<img width="595" height="211" alt="image" src="https://github.com/user-attachments/assets/8ab9fd82-b2d1-4f6c-a442-ad5624de5ec0" />

In addition, of a connection has a knot, rather than the target node pin being aligned with the source pin, the first knot is aligned to the source pin only, which mirrors the behavior observed in UE.
<img width="595" height="336" alt="image" src="https://github.com/user-attachments/assets/621f5c28-e825-45fe-b9bd-0cbded75b2a3" />
