### PR TITLE
GH-1357 Fix stylebox setup for macOS

### DIFF
--- a/src/core/godot/core_string_names.cpp
+++ b/src/core/godot/core_string_names.cpp
@@ -1,0 +1,19 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "core/godot/core_string_names.h"
+
+CoreStringNames* CoreStringNames::singleton = nullptr;

--- a/src/core/godot/core_string_names.h
+++ b/src/core/godot/core_string_names.h
@@ -21,13 +21,15 @@
 using namespace godot;
 
 class CoreStringNames {
-    inline static CoreStringNames* singleton = nullptr;
+    static CoreStringNames* singleton;
 
 public:
     static void create() { singleton = memnew(CoreStringNames); }
     static void free() {
-        memdelete(singleton);
-        singleton = nullptr;
+        if (singleton) {
+            memdelete(singleton);
+            singleton = nullptr;
+        }
     }
 
     _FORCE_INLINE_ static CoreStringNames* get_singleton() { return singleton; }

--- a/src/core/godot/scene_string_names.cpp
+++ b/src/core/godot/scene_string_names.cpp
@@ -1,0 +1,19 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "core/godot/scene_string_names.h"
+
+SceneStringNames* SceneStringNames::singleton = nullptr;

--- a/src/core/godot/scene_string_names.h
+++ b/src/core/godot/scene_string_names.h
@@ -21,13 +21,15 @@
 using namespace godot;
 
 class SceneStringNames {
-    inline static SceneStringNames* singleton = nullptr;
+    static SceneStringNames* singleton;
 
 public:
     static void create() { singleton = memnew(SceneStringNames); }
     static void free() {
-        memdelete(singleton);
-        singleton = nullptr;
+        if (singleton) {
+            memdelete(singleton);
+            singleton = nullptr;
+        }
     }
 
     _FORCE_INLINE_ static SceneStringNames* get_singleton() { return singleton; }


### PR DESCRIPTION
Fixes #1357

The main issue here is that Apple does not like a header-based inline static initializer. This apparently led to the fact that controls were being populated with a null `normal` StyleBox, while also causing the editor to crash when the plugin was being unloaded.

The solution was to move the static initializer to the `cpp` file.
