### PR TITLE
GH-1387 Raise warnings for shadowed global types

### DIFF
--- a/src/script/compiler/analyzer.cpp
+++ b/src/script/compiler/analyzer.cpp
@@ -6018,6 +6018,14 @@ void OScriptAnalyzer::is_shadowing(OScriptParser::IdentifierNode* p_identifier, 
 		} else if (OScriptParser::get_builtin_type(name) < Variant::VARIANT_MAX) {
 			parser->push_warning(p_identifier, OScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, "built-in type");
 			return;
+		} else if (name == StringName("PI") || name == StringName("TAU") || name == StringName("INF") || name == StringName("NAN")) {
+		    parser->push_warning(p_identifier, OScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, "global constant");
+		    return;
+		} else if (GDE::CoreConstants::is_global_constant(name)) {
+		    parser->push_warning(p_identifier, OScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, "global constant");
+		}
+        else if (GDE::CoreConstants::is_global_enum(name)) {
+		    parser->push_warning(p_identifier, OScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, "global enum");
 		}
 	}
 

--- a/src/script/script_warning.h
+++ b/src/script/script_warning.h
@@ -43,7 +43,7 @@ public:
 		UNUSED_SIGNAL, // Signal is defined but never explicitly used in the class.
 		SHADOWED_VARIABLE, // A local variable/constant shadows a current class member.
 		SHADOWED_VARIABLE_BASE_CLASS, // A local variable/constant shadows a base class member.
-		SHADOWED_GLOBAL_IDENTIFIER, // A global class or function has the same name as variable.
+		SHADOWED_GLOBAL_IDENTIFIER, // A local variable/constant/enum/function shadows a global type, class, function, enum, or constant.
 		UNREACHABLE_CODE, // Code after a return statement.
 		UNREACHABLE_PATTERN, // Pattern in a match statement after a catch all pattern (wildcard or bind).
 		STANDALONE_EXPRESSION, // Expression not assigned to a variable.


### PR DESCRIPTION
Fixes GH-1387

This is in reguards to an upstream PR `106984` in Godot, where GDScript is discussing the same changes.