### PR TITLE
GH-1403 Fix connecting signals with bind values

### DIFF
--- a/src/core/godot/object/script_language.cpp
+++ b/src/core/godot/object/script_language.cpp
@@ -61,3 +61,18 @@ bool GDE::Script::is_valid(const Ref<godot::Script>& p_script) {
     }
     return false;
 }
+
+bool GDE::Script::has_method(const Ref<godot::Script>& p_script, const StringName& p_name) {
+    if (p_script.is_valid()) {
+        // todo:
+        //  a bug in Godot prevents calling Ref<Script>::has_method, because this will delegate
+        //  to Object::has_method and never calls the underlying ScriptExtension::has_method.
+        //  To avoid this issue, we directly cast to OScript.
+        Ref<ScriptExtension> script_extension = p_script;
+        if (script_extension.is_valid()) {
+            return script_extension->_has_method(p_name);
+        }
+        return p_script->has_method(p_name);
+    }
+    return false;
+}

--- a/src/core/godot/object/script_language.h
+++ b/src/core/godot/object/script_language.h
@@ -27,5 +27,6 @@ namespace GDE {
         static MethodInfo get_method_info(const Ref<godot::Script>& p_script, const StringName& p_function);
         static bool inherits_script(const Ref<godot::Script>& p_script, const Ref<godot::Script>& p_parent_script);
         static bool is_valid(const Ref<godot::Script>& p_script);
+        static bool has_method(const Ref<godot::Script>& p_script, const StringName& p_name);
     };
 }

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -843,7 +843,11 @@ void OrchestratorEditor::_add_callback(Object* p_object, const String& p_functio
     ERR_FAIL_NULL(p_object);
 
     const Ref<ScriptExtension> script = p_object->get_script();
-    ERR_FAIL_COND(script.is_null());
+    if (script.is_null()) {
+        // This can be called by Editor for any script language, and we shouldn't report an error if the
+        // user is linked a signal to a GDScript script.
+        return;
+    }
 
     const ScriptLanguageExtension* language = cast_to<ScriptLanguageExtension>(script->_get_language());
     if (!language || !language->_can_make_function()) {

--- a/src/editor/script_editor_view.cpp
+++ b/src/editor/script_editor_view.cpp
@@ -939,6 +939,13 @@ void OrchestratorScriptGraphEditorView::add_callback(const String& p_function, c
 
     OrchestratorEditorGraphPanel* editor = _get_active_graph_tab();
     if (editor) {
+        const Ref<OrchestrationGraph> graph = _script->get_orchestration()->find_graph(editor->get_name());
+        if (graph.is_valid() && graph->get_flags().has_flag(OScriptGraph::GF_FUNCTION)) {
+            // Fallback to the default EventGraph, cannot add signal callbacks to function graphs
+            editor = _get_graph_tab("EventGraph");
+            _focus_graph_tab(editor);
+        }
+
         NodeSpawnOptions options;
         options.context.method = method;
         options.position = editor->get_scroll_offset() + (editor->get_size() / 2.0);

--- a/src/script/compiler/analyzer.cpp
+++ b/src/script/compiler/analyzer.cpp
@@ -1167,7 +1167,7 @@ bool OScriptAnalyzer::get_function_signature(OScriptParser::Node* p_source, bool
 	}
 
 	Ref<Script> base_script = p_base_type.script_type;
-	while (base_script.is_valid() && base_script->has_method(function_name)) {
+	while (base_script.is_valid() && GDE::Script::has_method(base_script, function_name)) {
 		MethodInfo info = GDE::Script::get_method_info(base_script, function_name);
 		if (!(info == MethodInfo())) {
 			return function_signature_from_info(info, r_return_type, r_par_types, r_default_arg_count, r_method_flags);
@@ -2566,11 +2566,11 @@ void OScriptAnalyzer::resolve_function_body(OScriptParser::FunctionNode* p_funct
         // Non-abstract functions must have a body.
         if (p_function->source_lambda != nullptr) {
             push_error(R"(A lambda function must have a ":" followed by a body.)", p_function);
+            return;
         } else if (!p_function->is_abstract) {
-            push_error(vformat(R"(The function "%s" is defined without a body.)", p_function->identifier->name), p_function);
+            // push_error(vformat(R"(The function "%s" is defined without a body.)", p_function->identifier->name), p_function);
             // push_error(vformat(R"(A function "%s" must either have a body, or be marked as "@abstract".)", p_function->identifier->name), p_function);
         }
-        return;
     } else {
         // Abstract functions must not have a body.
         if (p_function->is_abstract) {

--- a/src/script/compiler/compiler.cpp
+++ b/src/script/compiler/compiler.cpp
@@ -21,6 +21,7 @@
 #include "core/godot/config/project_settings_cache.h"
 #include "core/godot/core_string_names.h"
 #include "core/godot/object/class_db.h"
+#include "core/godot/object/script_language.h"
 #include "core/godot/variant/variant.h"
 #include "script/compiler/analyzer.h"
 #include "script/compiler/bytecode_generator.h"
@@ -707,7 +708,7 @@ OScriptCompiledFunction* OScriptCompiler::make_static_initializer(Error& r_error
         }
     }
 
-    if (p_script->has_method(OScriptLanguage::get_singleton()->strings._static_init)) {
+    if (GDE::Script::has_method(p_script, OScriptLanguage::get_singleton()->strings._static_init)) {
         context.generator->write_newline(p_class->script_node_id);
         context.generator->write_call(OScriptCodeGenerator::Address(), class_addr, OScriptLanguage::get_singleton()->strings._static_init, Vector<OScriptCodeGenerator::Address>());
     }

--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -18,6 +18,7 @@
 
 #include "common/dictionary_utils.h"
 #include "core/godot/gdextension_compat.h"
+#include "core/godot/object/script_language.h"
 #include "core/godot/scene_string_names.h"
 #include "core/godot/variant/variant.h"
 #include "script/script.h"
@@ -1148,7 +1149,7 @@ bool OScriptPlaceHolderInstance::has_method(const StringName& p_name) const {
 
     Ref<Script> scr = _script;
     while (scr.is_valid()) {
-        if (scr->has_method(p_name)) {
+        if (GDE::Script::has_method(scr, p_name)) {
             return true;
         }
         scr = scr->get_base_script();


### PR DESCRIPTION
Fixes GH-1403

This was an interesting issue and relates to a recent fix I addressed in the upstream Godot code base, which is associated with https://github.com/godotengine/godot/pull/115192. 

The main issue is that `Script::has_method` is considered virtual, overriding the behavior of `Object::has_method`.  On the engine side, things work as expected; calls to the `Script` implementation invoke its virtual method. However, for scripts implemented in GDExtension via the `ScriptExtension` contract, the `Script::has_method` method never delegates to `ScriptExtension::_has_method`, resulting in unexpected results in GDExtension-based languages.

The PR introduces a new `has_script_method` that will be exposed on scripts starting with Godot 4.7, but for earlier versions, we must explicitly check whether the script is a `ScriptExtension` and handle it differently.