### PR TITLE
GH-1362 Resolve NodePath relative to attached script node

### DIFF
--- a/src/editor/graph/graph_panel.cpp
+++ b/src/editor/graph/graph_panel.cpp
@@ -2673,9 +2673,18 @@ void OrchestratorEditorGraphPanel::_drop_data(const Vector2& p_at_position, cons
                 continue;
             }
 
-            const NodePath path = dropped_node->is_unique_name_in_owner()
-                ? NodePath("%" + dropped_node->get_name())
-                : edited_scene_root->get_path_to(dropped_node);
+            NodePath path;
+            if (dropped_node->is_unique_name_in_owner()) {
+                path = NodePath("%" + dropped_node->get_name());
+            } else {
+                Vector<Node*> attached_nodes;
+                SceneUtils::find_all_nodes_for_script(edited_scene_root, edited_scene_root, _graph->get_orchestration()->as_script(), attached_nodes);
+                if (attached_nodes.is_empty()) {
+                    ORCHESTRATOR_ERROR("Cannot drop a node in a script that is not attached to a node in this scene.");
+                }
+
+                path = attached_nodes[0]->get_path_to(dropped_node);
+            }
 
             String global_name;
             const Ref<Script> dropped_node_script = dropped_node->get_script();

--- a/src/script/nodes/scene/scene_node.cpp
+++ b/src/script/nodes/scene/scene_node.cpp
@@ -88,15 +88,26 @@ void OScriptNodeSceneNode::_upgrade(uint32_t p_version, uint32_t p_current_versi
     super::_upgrade(p_version, p_current_version);
 }
 
-Node* OScriptNodeSceneNode::_get_referenced_node() const {
+Node* OScriptNodeSceneNode::_get_scene_base_node() const {
     if (_is_in_editor() && !_node_path.is_empty()) {
-        if (SceneTree* st = Object::cast_to<SceneTree>(Engine::get_singleton()->get_main_loop())) {
+        if (SceneTree* st = cast_to<SceneTree>(Engine::get_singleton()->get_main_loop())) {
             if (st->get_edited_scene_root()) {
                 if (Node* root = st->get_edited_scene_root()) {
-                    return root->get_node_or_null(_node_path);
+                    Vector<Node*> nodes;
+                    SceneUtils::find_all_nodes_for_script(root, root, get_orchestration()->as_script(), nodes);
+                    if (!nodes.is_empty()) {
+                        return nodes[0];
+                    }
                 }
             }
         }
+    }
+    return nullptr;
+}
+
+Node* OScriptNodeSceneNode::_get_referenced_node() const {
+    if (Node* base_node = _get_scene_base_node()) {
+        return base_node->get_node_or_null(_node_path);
     }
     return nullptr;
 }
@@ -121,6 +132,15 @@ String OScriptNodeSceneNode::get_icon() const {
 
 String OScriptNodeSceneNode::get_help_topic() const {
     return vformat("class:%s", _class_name);
+}
+
+Ref<Resource> OScriptNodeSceneNode::get_inspect_object() {
+    if (_is_in_editor()) {
+        if (Node* base_node = _get_scene_base_node()) {
+            set_meta("__base_node_relative", base_node);
+        }
+    }
+    return super::get_inspect_object();
 }
 
 Ref<OScriptTargetObject> OScriptNodeSceneNode::resolve_target(const Ref<OScriptNodePin>& p_pin) const {

--- a/src/script/nodes/scene/scene_node.h
+++ b/src/script/nodes/scene/scene_node.h
@@ -43,6 +43,9 @@ protected:
     void _upgrade(uint32_t p_version, uint32_t p_current_version) override;
     //~ End OScriptNode Interface
 
+    /// Get the node from scene that has this script, if possible.
+    Node* _get_scene_base_node() const;
+
     /// Get the referenced node from the scene, if possible.
     Node* _get_referenced_node() const;
 
@@ -55,6 +58,7 @@ public:
     String get_node_title_color_name() const override { return "scene"; }
     String get_icon() const override;
     String get_help_topic() const override;
+    Ref<Resource> get_inspect_object() override;
     Ref<OScriptTargetObject> resolve_target(const Ref<OScriptNodePin>& p_pin) const override;
     void initialize(const OScriptNodeInitContext& p_context) override;
     bool is_pure() const override;


### PR DESCRIPTION
Fixes GH-1362

This changes the logic to match that of GDScript, where it is always relative to the first node in the scene where the script is attached. If the script is not attached to a node in the scene and scene nodes are dragged onto the canvas, the editor will report an error that the dragged operation failed because the script is not attached to any scene nodes.