### PR TITLE
GH-1441 Deprecate `type_exists` OScript utility function

### DIFF
--- a/doc_classes/@OScript.xml
+++ b/doc_classes/@OScript.xml
@@ -56,7 +56,7 @@
                 [b]Note:[/b] By default, backtraces are only available in editor builds and debug builds. To enable them for release builds as well, you need to enable [member ProjectSettings.debug/settings/gdscript/always_track_call_stacks].
             </description>
         </method>
-        <method name="type_exists">
+        <method name="type_exists" deprecated="Use [method ClassDB.class_exists] instead.">
             <return type="bool" />
             <param index="0" name="type" type="StringName" />
             <description>

--- a/src/script/utility_functions.cpp
+++ b/src/script/utility_functions.cpp
@@ -113,12 +113,14 @@ struct OScriptUtilityFunctionsDefinitions
     /// These are functions that we expose as part of the `@OScript` family of methods to the user as nodes that can
     /// be directly called from scripts. These call into the C++ engine directly.
 
+    #ifndef DISABLE_DEPRECATED
     /// Checks whether the specified class name exists, returning <code>true</code> or <code>false</code>.
     static void type_exists(Variant* r_ret, const Variant** p_args, int p_arg_count, GDExtensionCallError& r_error) {
         DEBUG_VALIDATE_ARG_COUNT(1, 1);
         DEBUG_VALIDATE_ARG_TYPE(0, Variant::STRING_NAME);
         *r_ret = ClassDB::class_exists(*p_args[0]);
     }
+    #endif
 
     static void print_debug(Variant* r_ret, const Variant** p_args, int p_arg_count, GDExtensionCallError& r_error) {
         String s;
@@ -566,8 +568,9 @@ void OScriptUtilityFunctions::register_functions() {
     REGISTER_FUNC(print_debug, false, RET(NIL), NOARGS, true, varray(), false);
     REGISTER_FUNC(print_stack, false, RET(NIL), NOARGS, false, varray(), false);
     REGISTER_FUNC(get_stack, false, RET(ARRAY), NOARGS, false, varray(), false);
-
+    #ifndef DISABLE_DEPRECATED
     REGISTER_FUNC(type_exists, true, RET(BOOL), ARGS(ARG("type", STRING_NAME)), false, varray(), false);
+    #endif
     REGISTER_FUNC(len, true, RET(INT), ARGS(ARGVAR("var")), false, varray(), false);
     REGISTER_FUNC(load, false, RETCLS("Resource"), ARGS( ARG("path", STRING) ), false, varray(), false);
 


### PR DESCRIPTION
Fixes GH-1441

This change will apply to Orchestrator 2.5 & Godot 4.7 only.