### PR TITLE
GH-1469 Override parent script methods using the override button

### DIFF
--- a/src/editor/actions/rules/virtual_function_rule.cpp
+++ b/src/editor/actions/rules/virtual_function_rule.cpp
@@ -27,6 +27,10 @@ bool OrchestratorEditorActionVirtualFunctionRule::matches(const Ref<Orchestrator
         const MethodInfo& method = p_action->method.value();
         if (method.flags & METHOD_FLAG_VIRTUAL) {
             return !_method_exclusion_names.has(method.name);
+        } else {
+            if (!_method_exclusion_names.has(method.name) && _method_override_names.has(method.name)) {
+                return true;
+            }
         }
     }
     return false;

--- a/src/editor/actions/rules/virtual_function_rule.h
+++ b/src/editor/actions/rules/virtual_function_rule.h
@@ -26,6 +26,7 @@ class OrchestratorEditorActionVirtualFunctionRule : public OrchestratorEditorAct
     GDCLASS(OrchestratorEditorActionVirtualFunctionRule, OrchestratorEditorActionFilterRule);
 
     PackedStringArray _method_exclusion_names;
+    PackedStringArray _method_override_names;
 
 protected:
     static void _bind_methods() { }
@@ -37,4 +38,5 @@ public:
     //~ End ActionFilterRule Interface
 
     void set_method_exclusions(const PackedStringArray& p_method_names) { _method_exclusion_names = p_method_names; }
+    void set_method_overrides(const PackedStringArray& p_method_names) { _method_override_names = p_method_names; }
 };

--- a/src/editor/graph/graph_panel.cpp
+++ b/src/editor/graph/graph_panel.cpp
@@ -1238,7 +1238,12 @@ bool OrchestratorEditorGraphPanel::_create_new_function_override(const MethodInf
     NodeSpawnOptions options;
     options.node_class = OScriptNodeFunctionEntry::get_class_static();
     options.context.method = p_method;
-    options.context.user_data = DictionaryUtils::of({ { "user_defined", false } });
+
+    if (p_method.flags & METHOD_FLAG_VIRTUAL) {
+        options.context.user_data = DictionaryUtils::of({ { "user_defined", false } });
+    } else {
+        options.context.user_data = DictionaryUtils::of({ { "user_defined", true } });
+    }
 
     const Ref<OScriptNodeFunctionEntry> entry = function_graph->create_node<OScriptNodeFunctionEntry>(options.context);
     if (!entry.is_valid()) {
@@ -3121,9 +3126,19 @@ void OrchestratorEditorGraphPanel::show_override_function_action_menu(const Call
     graph_type_rule.instantiate();
     graph_type_rule->set_graph_type(OrchestratorEditorActionDefinition::GRAPH_EVENT);
 
+    PackedStringArray user_defined_methods;
+    const TypedArray<Dictionary> methods = _graph->get_orchestration()->as_script()->get_script_method_list();
+    for (int i = 0; i < methods.size(); i++) {
+        const MethodInfo mi = DictionaryUtils::to_method(methods[i]);
+        if (!user_defined_methods.has(mi.name)) {
+            user_defined_methods.push_back(mi.name);
+        }
+    }
+
     Ref<OrchestratorEditorActionVirtualFunctionRule> virtual_function_rule;
     virtual_function_rule.instantiate();
     virtual_function_rule->set_method_exclusions(_graph->get_orchestration()->get_function_names());
+    virtual_function_rule->set_method_overrides(user_defined_methods);
 
     Ref<OrchestratorEditorActionClassHierarchyScopeRule> class_hierarchy_rule;
     class_hierarchy_rule.instantiate();


### PR DESCRIPTION
Fixes GH-1469

## Description
Currently in Godot, there is no real concept of overrides, meaning that if a specific method is defined in the most concrete script in a hierarchy, it's called; however, there is no direct relationship between the stub in the most concrete class and a parent class from the language's PoV.

In Orchestrator, the same applies. This change primarily makes it easier for people to create a function stub in an extended script that wants to override the parent script's behavior; however that's the extent of the behavior. If the parent script function changes, the same changes must be applied to the descendant.