### PR TITLE
GH-1473 Resolve await signal node as self by default

### DIFF
--- a/src/script/node_pin.cpp
+++ b/src/script/node_pin.cpp
@@ -21,7 +21,7 @@
 #include "common/settings.h"
 #include "common/variant_utils.h"
 #include "script/nodes/data/coercion_node.h"
-#include "script/nodes/functions/call_function.h"
+#include "script/nodes/script_nodes.h"
 #include "script/script_server.h"
 
 #include <godot_cpp/classes/engine.hpp>
@@ -740,26 +740,33 @@ PackedStringArray OScriptNodePin::get_suggestions() {
 }
 
 bool OScriptNodePin::is_target_self() const {
-    if (!cast_to<OScriptNodeCallFunction>(get_owning_node())) {
+    //! Nodes only allowed to apply self labels
+    const bool is_await = get_owning_node()->is_type<OScriptNodeAwait>();
+    const bool is_call_function = get_owning_node()->is_type<OScriptNodeCallFunction>();
+
+    if (is_call_function && get_pin_name().match("target")) {
         return false;
     }
 
-    if (!get_pin_name().match("target") || has_any_connections()) {
-        return false;
+    if ((is_await || is_call_function) && !has_any_connections()) {
+        const String target_class = _property.class_name;
+        if (target_class.is_empty()) {
+            return false;
+        }
+
+        String base_type = get_owning_node()->get_orchestration()->get_base_type();
+        if (!base_type.is_empty()) {
+            ScriptServer::GlobalClass global_class = ScriptServer::get_global_class(base_type);
+            if (!global_class.name.is_empty()) {
+                base_type = global_class.base_type;
+            }
+            return ClassDB::is_parent_class(base_type, target_class);
+        }
+
+        return true;
     }
 
-    const String target_class = _property.class_name;
-    if (target_class.is_empty()) {
-        return false;
-    }
-
-    // todo: needs to support classes
-    const String base_type = get_owning_node()->get_orchestration()->get_base_type();
-    if (!ClassDB::is_parent_class(base_type, target_class)) {
-        return false;
-    }
-
-    return true;
+    return false;
 }
 
 void OScriptNodePin::_bind_methods() {

--- a/src/script/nodes/script_nodes.h
+++ b/src/script/nodes/script_nodes.h
@@ -77,12 +77,12 @@
 #include "scene/scene_tree.h"
 
 // Signals
-#include "signals/await_signal.h"
 #include "signals/emit_member_signal.h"
 #include "signals/emit_signal.h"
 
 // Utility
 #include "utilities/autoload.h"
+#include "utilities/await.h"
 #include "utilities/comment.h"
 #include "utilities/engine_singleton.h"
 #include "utilities/self.h"

--- a/src/script/nodes/utilities/await.cpp
+++ b/src/script/nodes/utilities/await.cpp
@@ -14,15 +14,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-#include "script/nodes/signals/await_signal.h"
+#include "script/nodes/utilities/await.h"
 
 #include "common/property_utils.h"
 
-void OScriptNodeAwaitSignal::_upgrade(uint32_t p_version, uint32_t p_current_version) {
+void OScriptNodeAwait::_upgrade(uint32_t p_version, uint32_t p_current_version) {
     if (find_pin("result", PD_Output).is_null()) {
         reconstruct_node();
     }
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// OScriptNodeAwaitSignal
 
 void OScriptNodeAwaitSignal::allocate_default_pins() {
     create_pin(PD_Input, PT_Execution, PropertyUtils::make_exec("ExecIn"));
@@ -50,11 +53,10 @@ void OScriptNodeAwaitSignal::on_pin_disconnected(const Ref<OScriptNodePin>& p_pi
 }
 
 PackedStringArray OScriptNodeAwaitSignal::get_suggestions(const Ref<OScriptNodePin>& p_pin) {
-    if (p_pin.is_valid() && p_pin->is_input() && p_pin->get_pin_name().match("signal_name"))
-    {
+    if (p_pin.is_valid() && p_pin->is_input() && p_pin->get_pin_name().match("signal_name")) {
         const Ref<OScriptNodePin> target_pin = find_pin("target", PD_Input);
         if (target_pin.is_valid()) {
-            return target_pin->resolve_signal_names();
+            return target_pin->resolve_signal_names(true);
         }
     }
     return super::get_suggestions(p_pin);

--- a/src/script/nodes/utilities/await.h
+++ b/src/script/nodes/utilities/await.h
@@ -18,17 +18,9 @@
 
 #include "script/script.h"
 
-/// Awaits a signal.
-///
-/// Much like GDScript, you can use the "await" keyword to create a coroutine that will yield
-/// and waits until the specified signal is raised before the program flow continues. This
-/// node is designed to provide the same functionality in Orchestrator.
-///
-/// This node requires two inputs, the object that will emit the signal and the signal name
-/// that should cause the yield until it is raised.
-///
-class OScriptNodeAwaitSignal : public OScriptNode {
-    ORCHESTRATOR_NODE_CLASS(OScriptNodeAwaitSignal, OScriptNode);
+/// Base class for all Await-based nodes
+class OScriptNodeAwait : public OScriptNode {
+    ORCHESTRATOR_NODE_CLASS(OScriptNodeAwait, OScriptNode);
 
 protected:
     static void _bind_methods() { }
@@ -36,6 +28,14 @@ protected:
     //~ Begin OScriptNode Interface
     void _upgrade(uint32_t p_version, uint32_t p_current_version) override;
     //~ End OScriptNode Interface
+};
+
+/// Awaits Member Signals
+class OScriptNodeAwaitSignal : public OScriptNodeAwait {
+    ORCHESTRATOR_NODE_CLASS(OScriptNodeAwaitSignal, OScriptNodeAwait);
+
+protected:
+    static void _bind_methods() { }
 
 public:
     //~ Begin OScriptNode Interface

--- a/src/script/parser/parser.cpp
+++ b/src/script/parser/parser.cpp
@@ -2746,8 +2746,20 @@ OScriptParser::StatementResult OScriptParser::build_instantiate_scene(const Ref<
 }
 
 OScriptParser::StatementResult OScriptParser::build_await_signal(const Ref<OScriptNodeAwaitSignal>& p_script_node) {
+    ExpressionNode* target = nullptr;
+    const Ref<OScriptNodePin> object = p_script_node->find_pin(1, PD_Input);
+    if (object.is_valid()) {
+        if (object->has_any_connections()) {
+            target = resolve_input(object);
+        } else {
+            SelfNode* self = alloc_node<SelfNode>();
+            self->current_class = current_class;
+            target = self;
+        }
+    }
+
     SubscriptNode* the_signal = alloc_node<SubscriptNode>();
-    the_signal->base = resolve_input(p_script_node->find_pin(1, PD_Input));
+    the_signal->base = target;
     the_signal->index = resolve_input(p_script_node->find_pin(2, PD_Input));
     the_signal->base->script_node_id = p_script_node->get_id();
     the_signal->index->script_node_id = p_script_node->get_id();

--- a/src/script/register_script_types.cpp
+++ b/src/script/register_script_types.cpp
@@ -224,12 +224,13 @@ void register_script_node_types() {
     ORCHESTRATOR_REGISTER_NODE_CLASS(OScriptNodeSceneTree)
 
     //~ Signals
-    ORCHESTRATOR_REGISTER_NODE_CLASS(OScriptNodeAwaitSignal)
     ORCHESTRATOR_REGISTER_NODE_CLASS(OScriptNodeEmitMemberSignal)
     ORCHESTRATOR_REGISTER_NODE_CLASS(OScriptNodeEmitSignal)
 
     //~ Utility
     ORCHESTRATOR_REGISTER_NODE_CLASS(OScriptNodeAutoload)
+    ORCHESTRATOR_REGISTER_NODE_CLASS(OScriptNodeAwait)
+    ORCHESTRATOR_REGISTER_NODE_CLASS(OScriptNodeAwaitSignal)
     ORCHESTRATOR_REGISTER_NODE_CLASS(OScriptNodeComment)
     ORCHESTRATOR_REGISTER_NODE_CLASS(OScriptNodeEngineSingleton)
     ORCHESTRATOR_REGISTER_NODE_CLASS(OScriptNodePrintString)


### PR DESCRIPTION
Fixes GH-1473

## Description

Makes sure that when the `OScriptNodeAwaitSignal` is added to the graph, the target pin resolves as `[Self]` when unconnected, much like how functions operate. This avoids the need to specify a `Get Self` node when referring to awaiting on local signals within the script.
