### PR TITLE
GH-1480 Use script `_to_string` override if present

### DIFF
--- a/src/script/script_instance.cpp
+++ b/src/script/script_instance.cpp
@@ -17,6 +17,7 @@
 #include "script/script_instance.h"
 
 #include "common/dictionary_utils.h"
+#include "core/godot/core_string_names.h"
 #include "core/godot/gdextension_compat.h"
 #include "core/godot/object/script_language.h"
 #include "core/godot/scene_string_names.h"
@@ -210,8 +211,7 @@ struct OScriptInstanceCallbacks {
 
     static void to_string_func(GDExtensionScriptInstanceDataPtr p_instance, GDExtensionBool* r_valid, GDExtensionStringPtr r_value) {
         if (r_value) {
-            *r_valid = true;
-            *static_cast<String*>(r_value) = INSTANCE->to_string();
+            *static_cast<String*>(r_value) = INSTANCE->to_string(CAST_BOOL(r_valid));
         }
     }
 
@@ -441,7 +441,28 @@ Variant OScriptInstanceBase::get_rpc_config() const {
     return _script->get_rpc_config();
 }
 
-String OScriptInstanceBase::to_string() {
+String OScriptInstanceBase::to_string(bool *r_valid) {
+    if (has_method(CoreStringName(_to_string))) {
+        GDExtensionCallError ce;
+        Variant ret = callp(CoreStringName(_to_string), nullptr, 0, ce);
+        if (ce.error == GDEXTENSION_CALL_OK) {
+            if (ret.get_type() != Variant::STRING) {
+                if (r_valid) {
+                    *r_valid = false;
+                }
+                ERR_FAIL_V_MSG(String(), "Wrong type for " + CoreStringName(_to_string) + ", must be a String.");
+            }
+            if (r_valid) {
+                *r_valid = true;
+            }
+            return ret.operator String();
+        }
+    }
+
+    if (r_valid) {
+        *r_valid = true;
+    }
+
     String prefix = "";
     if (Node* node = Object::cast_to<Node>(_owner)) {
         if (!node->get_name().is_empty()) {

--- a/src/script/script_instance.h
+++ b/src/script/script_instance.h
@@ -80,7 +80,7 @@ public:
     virtual bool is_placeholder() const { return false; }
     virtual void notification(int p_notification, bool p_reversed = false) {}
     virtual Variant callp(const StringName& p_method, const Variant** p_args, int p_argcount, GDExtensionCallError& r_error) = 0;
-    virtual String to_string();
+    virtual String to_string(bool *r_valid);
 
     GDExtensionScriptInstancePtr get_instance_info() const { return _script_instance; }
     void set_instance_info(const GDExtensionScriptInstancePtr& p_info);

--- a/tests/scenes/features/override_to_string.out
+++ b/tests/scenes/features/override_to_string.out
@@ -1,0 +1,2 @@
+OSCRIPT_TEST_PASS
+OverrideToStringTest

--- a/tests/scenes/features/override_to_string.torch
+++ b/tests/scenes/features/override_to_string.torch
@@ -1,0 +1,122 @@
+[orchestration type="OScript" load_steps=10 format=3 uid="uid://dj2k1mhn4df7b"]
+
+[obj type="OScriptFunction" id="OScriptFunction_lnixc"]
+guid = "8CE75E6C-527D-4A39-BC77-BD85A53826B7"
+method = {
+"name": &"_ready",
+"flags": 8
+}
+id = 0
+
+[obj type="OScriptFunction" id="OScriptFunction_78nj3"]
+guid = "C0847ED5-C37B-452B-8C66-9E1768648171"
+method = {
+"name": &"_to_string",
+"return": {
+"type": 4
+},
+"flags": 73
+}
+id = 3
+
+[obj type="OScriptGraph" id="OScriptGraph_orolp"]
+graph_name = &"EventGraph"
+flags = 8
+nodes = Array[int]([0, 1, 2])
+functions = Array[int]([0])
+
+[obj type="OScriptGraph" id="OScriptGraph_gnlx5"]
+graph_name = &"_to_string"
+flags = 22
+nodes = Array[int]([3, 4])
+functions = Array[int]([3])
+
+[obj type="OScriptNodeEvent" id="OScriptNodeEvent_2ityq"]
+function_id = "8CE75E6C-527D-4A39-BC77-BD85A53826B7"
+id = 0
+size = Vector2(139, 66)
+position = Vector2(600, 340)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}])
+
+[obj type="OScriptNodeSelf" id="OScriptNodeSelf_84038"]
+id = 1
+size = Vector2(107, 66)
+position = Vector2(640, 420)
+pin_data = Array[Dictionary]([{
+"pin_name": &"self",
+"type": 24,
+"dir": 1,
+"flags": 2,
+"target_class": "Node",
+"dv": null
+}])
+
+[obj type="OScriptNodeCallBuiltinFunction" id="OScriptNodeCallBuiltinFunction_7x18o"]
+function_name = &"prints"
+flags = 33
+method = {
+"name": &"prints",
+"flags": 17,
+"args": [{
+"name": &"arg1",
+"usage": 131078
+}]
+}
+variable_arg_count = 0
+id = 2
+size = Vector2(113, 127)
+position = Vector2(780, 340)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}, {
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}, {
+"pin_name": &"arg1",
+"flags": 2,
+"usage": 131078
+}])
+
+[obj type="OScriptNodeFunctionEntry" id="OScriptNodeFunctionEntry_6udc4"]
+function_id = "C0847ED5-C37B-452B-8C66-9E1768648171"
+id = 3
+size = Vector2(29, 41)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}])
+
+[obj type="OScriptNodeFunctionResult" id="OScriptNodeFunctionResult_rp43a"]
+function_id = "C0847ED5-C37B-452B-8C66-9E1768648171"
+id = 4
+size = Vector2(29, 41)
+position = Vector2(300, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}, {
+"pin_name": &"return_value",
+"type": 4,
+"flags": 2,
+"dv": "OverrideToStringTest"
+}, {
+"pin_name": &"return_out",
+"type": 4,
+"dir": 1,
+"flags": 34
+}])
+
+[resource]
+base_type = &"Node"
+brief_description = "Empty template suitable for all Objects"
+functions = Array[OScriptFunction]([SubResource("OScriptFunction_lnixc"), SubResource("OScriptFunction_78nj3")])
+connections = Array[int]([0, 0, 2, 0, 3, 0, 4, 0, 1, 0, 2, 1])
+nodes = Array[OScriptNode]([SubResource("OScriptNodeEvent_2ityq"), SubResource("OScriptNodeSelf_84038"), SubResource("OScriptNodeCallBuiltinFunction_7x18o"), SubResource("OScriptNodeFunctionEntry_6udc4"), SubResource("OScriptNodeFunctionResult_rp43a")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_orolp"), SubResource("OScriptGraph_gnlx5")])

--- a/tests/scenes/features/override_to_string.tscn
+++ b/tests/scenes/features/override_to_string.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3 uid="uid://cc0flmxouofyk"]
+
+[ext_resource type="Script" uid="uid://dj2k1mhn4df7b" path="res://scenes/features/override_to_string.torch" id="1_78nj3"]
+
+[node name="OverrideToString" type="Node" unique_id=1982854301]
+script = ExtResource("1_78nj3")


### PR DESCRIPTION
Fixes GH-1480

## Description
When a `_to_string` override is present in an Orchestration script, it will be used, otherwise falls back to the default script instance behavior.