### PR TITLE
GH-1498 Improve graph clipboard operations

### DIFF
--- a/src/common/string_utils.h
+++ b/src/common/string_utils.h
@@ -16,6 +16,7 @@
 //
 #pragma once
 
+#include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/variant/string.hpp>
 
 using namespace godot;
@@ -33,6 +34,25 @@ namespace StringUtils {
             result = p_array[0];
             for (int i = 1; i < p_array.size(); i++) {
                 result += (p_delimiter + String(p_array[i]));
+            }
+        }
+        return result;
+    }
+
+    /// Join the set elements with the delimiter
+    /// @tparam T the set type
+    /// @param p_delimiter the delimiter
+    /// @param p_set the hash set
+    /// @return the string result joined by the delimiter
+    template<typename T> String join(const String& p_delimiter, const HashSet<T>& p_set) {
+        String result;
+        if (!p_set.is_empty()) {
+            for (const Variant& p_value : p_set) {
+                if (result.length() == 0) {
+                    result = String(p_value);
+                } else {
+                    result += p_delimiter + String(p_value);
+                }
             }
         }
         return result;

--- a/src/editor/graph/graph_clipboard.cpp
+++ b/src/editor/graph/graph_clipboard.cpp
@@ -1,0 +1,275 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editor/graph/graph_clipboard.h"
+
+#include "common/dictionary_utils.h"
+#include "common/method_utils.h"
+#include "common/property_utils.h"
+#include "orchestration/orchestration.h"
+#include "script/nodes/functions/call_script_function.h"
+#include "script/nodes/functions/event.h"
+#include "script/nodes/signals/emit_signal.h"
+#include "script/nodes/variables/variable.h"
+
+OrchestratorEditorGraphClipboard::Buffer OrchestratorEditorGraphClipboard::_buffer;
+
+bool OrchestratorEditorGraphClipboard::Buffer::is_empty() const {
+    return nodes.is_empty();
+}
+
+void OrchestratorEditorGraphClipboard::Buffer::clear() {
+    nodes.clear();
+    connections.clear();
+    variables.clear();
+    functions.clear();
+    events.clear();
+    signals.clear();
+}
+
+bool OrchestratorEditorGraphClipboard::ClipboardResult::had_skipped_nodes() const {
+    return !skipped_functions.is_empty() || !skipped_events.is_empty() || !skipped_variables.is_empty() || !skipped_signals.is_empty();
+}
+
+OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboard::copy(
+    const Vector<OrchestratorEditorGraphNode*>& p_nodes, const Ref<OrchestrationGraph>& p_source) {
+
+    clear();
+
+    ClipboardResult result;
+    HashSet<uint64_t> node_ids;
+    for (OrchestratorEditorGraphNode* node : p_nodes) {
+        const Ref<OrchestrationGraphNode> script_node = p_source->get_orchestration()->get_node(node->get_id());
+        ERR_CONTINUE(script_node.is_null());
+
+        CopyItem item;
+        item.id = script_node->get_id();
+        item.position = node->get_position_offset();
+        item.size = node->get_size();
+        item.node = p_source->copy_node(item.id, true);
+
+        node_ids.insert(item.id);
+        result.added_nodes.insert(item.id);
+        _buffer.nodes.push_back(item);
+
+        if (const Ref<OScriptNodeEvent>& event = script_node; event.is_valid()) {
+            const Ref<OScriptFunction> function = event->get_function()->duplicate();
+            _buffer.events[function->get_function_name()] = function;
+        } else if (const Ref<OScriptNodeCallScriptFunction>& call_script = script_node; call_script.is_valid()) {
+            const Ref<OScriptFunction> function = call_script->get_function()->duplicate();
+            _buffer.functions[function->get_function_name()] = function;
+        }
+
+        if (const Ref<OScriptNodeVariable>& variable_node = script_node; variable_node.is_valid()) {
+            const Ref<OScriptVariable> variable = variable_node->get_variable()->duplicate();
+            _buffer.variables[variable->get_variable_name()] = variable;
+        }
+
+        if (const Ref<OScriptNodeEmitSignal>& signal_node = script_node; signal_node.is_valid()) {
+            const Ref<OScriptSignal> signal = signal_node->get_signal()->duplicate();
+            _buffer.signals[signal->get_signal_name()] = signal;
+        }
+    }
+
+    for (const OScriptConnection& C : p_source->get_orchestration()->get_connections()) {
+        if (node_ids.has(C.from_node) && node_ids.has(C.to_node)) {
+            _buffer.connections.push_back(C.id);
+        }
+    }
+
+    return result;
+}
+
+OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboard::paste(
+    const Ref<OrchestrationGraph>& p_target, const Vector2& p_offset, bool p_snapping_enabled, int p_snapping_distance) {
+
+    ClipboardResult result;
+
+    // Pass 1 - Verify Functions
+    for (const KeyValue<StringName, Ref<OScriptFunction>>& E : _buffer.functions) {
+        const Ref<OScriptFunction> target_function = p_target->get_orchestration()->find_function(E.key);
+        if (!target_function.is_valid()) {
+            const Ref<OScriptFunction> function = p_target->get_orchestration()->create_function(
+                E.value->get_method_info(), E.value->is_user_defined());
+            if (!function.is_valid()) {
+                result.skipped_functions[E.key] = "Failed to create function.";
+            }
+        } else if (!MethodUtils::has_same_signature(E.value->get_method_info(), target_function->get_method_info())) {
+            result.skipped_functions[E.key] = "Function signatures do not match.";
+        }
+    }
+
+    // Pass 2 - Verify Events
+    for (const KeyValue<StringName, Ref<OScriptFunction>>& E : _buffer.events) {
+        const Ref<OScriptFunction> target_function = p_target->get_orchestration()->find_function(E.key);
+        if (target_function.is_valid()) {
+            if (!MethodUtils::has_same_signature(E.value->get_method_info(), target_function->get_method_info())) {
+                result.skipped_events[E.key] = "Event function signatures do not match.";
+            }
+        }
+    }
+
+    // Pass 3 - Create missing variables
+    for (const KeyValue<StringName, Ref<OScriptVariable>>& E : _buffer.variables) {
+        const Ref<OScriptVariable> target_variable = p_target->get_orchestration()->get_variable(E.key);
+        if (target_variable.is_null()) {
+            const Ref<OScriptVariable> variable = p_target->get_orchestration()->create_variable(E.key);
+            ERR_CONTINUE(!variable.is_valid());
+            variable->copy_persistent_state(E.value);
+        } else if (!PropertyUtils::are_equal(E.value->get_info(), target_variable->get_info())) {
+            result.skipped_variables[E.key] = "Variable declarations do not match.";
+        }
+    }
+
+    // Pass 4 - Create missing signals
+    for (const KeyValue<StringName, Ref<OScriptSignal>>& E : _buffer.signals) {
+        const Ref<OScriptSignal> target_signal = p_target->get_orchestration()->find_custom_signal(E.key);
+        if (target_signal.is_null()) {
+            const Ref<OScriptSignal> signal = p_target->get_orchestration()->create_custom_signal(E.key);
+            ERR_CONTINUE(!signal.is_valid());
+            signal->copy_persistent_state(E.value);
+        } else if (!MethodUtils::has_same_signature(E.value->get_method_info(), target_signal->get_method_info())) {
+            result.skipped_signals[E.key] = "Signal signatures do not match.";
+        }
+    }
+
+    // Pass 5 - Compute Paste Offset
+    Vector2 offset = p_offset;
+    if (!_buffer.nodes.is_empty()) {
+        #if GODOT_VERSION >= 0x040500
+        offset -= _buffer.nodes.get(0).position;
+        #else
+        offset -= _buffer.nodes[0].position;
+        #endif
+    }
+
+    if (p_snapping_enabled) {
+        offset = offset.snapped(Vector2(p_snapping_distance, p_snapping_distance));
+    }
+
+    // Pass 6 - Create Nodes
+    HashMap<uint64_t, uint64_t> connection_remap;
+    for (const CopyItem& item : _buffer.nodes) {
+
+        Ref<OrchestrationGraphNode> new_node;
+        const Ref<OrchestrationGraphNode>& node = item.node;
+
+        const Ref<OScriptNodeEvent> event = node;
+        if (event.is_valid()) {
+            const Ref<OScriptFunction> event_function = event->get_function();
+            if (!event_function.is_valid() || result.skipped_events.has(event_function->get_function_name())) {
+                continue;
+            }
+
+            // Event nodes can only be placed inside event graphs
+            if (!p_target->get_flags().has_flag(OrchestrationGraph::GF_EVENT)) {
+                result.skipped_events[event_function->get_function_name()] = "Cannot paste event nodes into non-event graphs.";
+                continue;
+            }
+
+            const Ref<OScriptFunction> target_function = p_target->get_orchestration()->find_function(event_function->get_function_name());
+            if (target_function.is_valid()) {
+                result.skipped_events[event_function->get_function_name()] = "An event node already exists with the same name.";
+                continue;
+            }
+
+            OScriptNodeInitContext context;
+            context.method = event_function->get_method_info();
+            context.user_data = DictionaryUtils::of({ { "user_defined", event_function->is_user_defined() } });
+
+            // This creates the node and its matching event function signature
+            // Event nodes require this special handling versus the pasting.
+            new_node = p_target->create_node<OScriptNodeEvent>(context, item.position + offset);
+
+        } else {
+            // Call-script-function nodes need their function GUID remapped to the target orchestration.
+            // If the function doesn't exist (or has a different signature) in the target, skip the node.
+            const Ref<OScriptNodeCallScriptFunction> call_script_func = node;
+            if (call_script_func.is_valid()) {
+                const StringName function_name = call_script_func->get_function()->get_function_name();
+                if (result.skipped_functions.has(function_name)) {
+                    continue;
+                }
+
+                const Ref<OScriptFunction> target_function = p_target->get_orchestration()->find_function(function_name);
+                if (!target_function.is_valid()) {
+                    continue;
+                }
+
+                call_script_func->set("guid", target_function->get_guid().to_string());
+            }
+
+            // Variable and signal nodes whose referenced resource was incompatible are skipped.
+            const Ref<OScriptNodeVariable> variable_node = node;
+            if (variable_node.is_valid() && result.skipped_variables.has(variable_node->get_variable()->get_variable_name())) {
+                continue;
+            }
+
+            const Ref<OScriptNodeEmitSignal> signal_node = node;
+            if (signal_node.is_valid() && result.skipped_signals.has(signal_node->get_signal()->get_signal_name())) {
+                continue;
+            }
+
+            new_node = p_target->paste_node(node, item.position + offset);
+        }
+
+        ERR_CONTINUE(!new_node.is_valid());
+        connection_remap[item.id] = new_node->get_id();
+        result.added_nodes.insert(new_node->get_id());
+    }
+
+    // Pass 7 - Create connections
+    for (const uint64_t id : _buffer.connections) {
+        const OScriptConnection C(id);
+        const uint64_t source_node = connection_remap[C.from_node];
+        const uint64_t target_node = connection_remap[C.to_node];
+
+        if (result.added_nodes.has(source_node) && result.added_nodes.has(target_node)) {
+            p_target->link(source_node, C.from_port, target_node, C.to_port);
+        }
+    }
+
+    return result;
+}
+
+OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboard::duplicate(
+    const Vector<OrchestratorEditorGraphNode*>& p_nodes, const Ref<OrchestrationGraph>& p_graph, const Vector2& p_offset) {
+
+    ClipboardResult result;
+    HashMap<uint64_t, uint64_t> connection_remap;
+
+    for (OrchestratorEditorGraphNode* node : p_nodes) {
+        const Ref<OrchestrationGraphNode> new_node = p_graph->duplicate_node(node->get_id(), p_offset, true);
+        ERR_CONTINUE(!new_node.is_valid());
+
+        connection_remap[node->get_id()] = new_node->get_id();
+        result.added_nodes.insert(new_node->get_id());
+    }
+
+    for (const OScriptConnection& C : p_graph->get_orchestration()->get_connections()) {
+        if (connection_remap.has(C.from_node) && connection_remap.has(C.to_node)) {
+            uint64_t source_node = connection_remap[C.from_node];
+            uint64_t target_node = connection_remap[C.to_node];
+            p_graph->link(source_node, C.from_port, target_node, C.to_port);
+        }
+    }
+
+    return result;
+}
+
+void OrchestratorEditorGraphClipboard::clear() {
+    _buffer.clear();
+}

--- a/src/editor/graph/graph_clipboard.h
+++ b/src/editor/graph/graph_clipboard.h
@@ -1,0 +1,66 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include "editor/graph/graph_node.h"
+#include "script/node.h"
+#include "script/signals.h"
+#include "script/variable.h"
+
+#include <godot_cpp/templates/hash_set.hpp>
+
+/// Manages the clipboard state for <code>OrchestratorEditorGraphPanel</code>.
+class OrchestratorEditorGraphClipboard {
+
+    struct CopyItem {
+        int id;
+        Ref<OrchestrationGraphNode> node;
+        Vector2 position;
+        Vector2 size;
+    };
+
+    struct Buffer {
+        List<CopyItem> nodes;
+        List<uint64_t> connections;
+        HashMap<StringName, Ref<OScriptVariable>> variables;
+        HashMap<StringName, Ref<OScriptFunction>> functions;
+        HashMap<StringName, Ref<OScriptFunction>> events;
+        HashMap<StringName, Ref<OScriptSignal>> signals;
+
+        bool is_empty() const;
+        void clear();
+    };
+
+    static Buffer _buffer;
+
+public:
+    struct ClipboardResult {
+        HashSet<uint64_t> added_nodes;
+        HashMap<StringName, String> skipped_functions;
+        HashMap<StringName, String> skipped_events;
+        HashMap<StringName, String> skipped_variables;
+        HashMap<StringName, String> skipped_signals;
+
+        bool had_skipped_nodes() const;
+    };
+
+    ClipboardResult copy(const Vector<OrchestratorEditorGraphNode*>& p_nodes, const Ref<OrchestrationGraph>& p_source);
+    ClipboardResult paste(const Ref<OrchestrationGraph>& p_target, const Vector2& p_offset, bool p_snapping_enabled, int p_snapping_distance);
+    ClipboardResult duplicate(const Vector<OrchestratorEditorGraphNode*>& p_nodes, const Ref<OrchestrationGraph>& p_graph, const Vector2& p_offset);
+
+    void clear();
+};

--- a/src/editor/graph/graph_panel.cpp
+++ b/src/editor/graph/graph_panel.cpp
@@ -19,7 +19,6 @@
 #include "common/callable_lambda.h"
 #include "common/dictionary_utils.h"
 #include "common/macros.h"
-#include "common/method_utils.h"
 #include "common/name_utils.h"
 #include "common/property_utils.h"
 #include "common/scene_utils.h"
@@ -87,8 +86,6 @@
 #include <godot_cpp/classes/v_separator.hpp>
 
 #define IS_COMMENT(n) cast_to<OrchestratorEditorGraphNodeComment>(n) != nullptr
-
-OrchestratorEditorGraphPanel::CopyBuffer OrchestratorEditorGraphPanel::_copy_buffer;
 
 using Connection = OScriptConnection;
 
@@ -255,247 +252,91 @@ void OrchestratorEditorGraphPanel::_connection_drag_ended() {
 }
 
 void OrchestratorEditorGraphPanel::_copy_nodes_request() {
-    _clear_copy_buffer();
-
-    Vector2 selection_center;
-    HashSet<int> node_ids;
-
     const Vector<OrchestratorEditorGraphNode*> selected_nodes = get_selected<OrchestratorEditorGraphNode>();
     if (!selected_nodes.is_empty() && !_can_duplicate_nodes(selected_nodes)) {
         return;
     }
 
-    for (OrchestratorEditorGraphNode* node : selected_nodes) {
-        const int node_id = node->get_id();
-        const Ref<OrchestrationGraphNode> script_node = _graph->get_orchestration()->get_node(node_id);
-
-        const Vector2 position = node->get_position_offset();
-        selection_center += position;
-
-        CopyItem item;
-        item.id = node_id;
-        item.node = _graph->copy_node(node_id, true);
-        item.position = position;
-        item.size = node->get_size();
-
-        node_ids.insert(node_id);
-        _copy_buffer.nodes.push_back(item);
-
-        const Ref<OScriptNodeCallScriptFunction> call_script_func_node = script_node;
-        if (call_script_func_node.is_valid()) {
-            _copy_buffer.function_names.insert(call_script_func_node->get_function()->get_function_name());
-        }
-
-        const Ref<OScriptNodeVariable> variable_node = script_node;
-        if (variable_node.is_valid()) {
-            _copy_buffer.variable_names.insert(variable_node->get_variable()->get_variable_name());
-        }
-
-        const Ref<OScriptNodeEmitSignal> signal_node = script_node;
-        if (signal_node.is_valid()) {
-            _copy_buffer.signal_names.insert(signal_node->get_signal()->get_signal_name());
-        }
-    }
-
-    for (const Connection& C : _graph->get_orchestration()->get_connections()) {
-        if (node_ids.has(C.from_node) && node_ids.has(C.to_node)) {
-            _copy_buffer.connections.push_back(C.id);
-        }
-    }
-
-    _copy_buffer.orchestration = _graph->get_orchestration();
+    _clipboard.copy(selected_nodes, _graph);
 }
 
 void OrchestratorEditorGraphPanel::_cut_nodes_request() {
-    _clear_copy_buffer();
-    _copy_nodes_request();
-
-    if (_copy_buffer.is_empty()) {
+    const Vector<OrchestratorEditorGraphNode*> selected = get_selected<OrchestratorEditorGraphNode>();
+    if (selected.is_empty() || !_can_duplicate_nodes(selected)) {
         return;
     }
 
-    for (const CopyItem& item : _copy_buffer.nodes) {
-        OrchestratorEditorGraphNode* node = find_node(item.id);
+    const OrchestratorEditorGraphClipboard::ClipboardResult result = _clipboard.copy(selected, _graph);
+    if (result.added_nodes.is_empty()) {
+        return;
+    }
+
+    for (OrchestratorEditorGraphNode* node : selected) {
         remove_node(node, false);
     }
 }
 
 void OrchestratorEditorGraphPanel::_duplicate_nodes_request() {
     const Vector<OrchestratorEditorGraphNode*> selected = get_selected<OrchestratorEditorGraphNode>();
-    if (selected.is_empty()) {
+    if (selected.is_empty() || !_can_duplicate_nodes(selected)) {
         return;
     }
 
-    if (!_can_duplicate_nodes(selected)) {
+    OrchestratorEditorGraphClipboard::ClipboardResult result = _clipboard.duplicate(selected, _graph, Vector2(25, 25));
+    if (result.added_nodes.is_empty()) {
         return;
-    }
-
-    HashMap<int, int> connection_remap;
-    HashSet<int> added_set;
-
-    const Vector2 offset = Vector2(25, 25);
-    for (OrchestratorEditorGraphNode* node : selected) {
-        const Ref<OrchestrationGraphNode> new_node = _graph->duplicate_node(node->get_id(), offset, true);
-        ERR_CONTINUE(!new_node.is_valid());
-
-        connection_remap[node->get_id()] = new_node->get_id();
-        added_set.insert(new_node->get_id());
-    }
-
-    for (const Connection& C : _graph->get_orchestration()->get_connections()) {
-        if (connection_remap.has(C.from_node) && connection_remap.has(C.to_node)) {
-            _graph->link(connection_remap[C.from_node], C.from_port, connection_remap[C.to_node], C.to_port);
-        }
     }
 
     _set_edited(true);
     _refresh_panel_connections_with_model();
 
+    emit_signal("nodes_changed");
+
     clear_selections();
 
-    for (int node_id : added_set) {
+    for (uint64_t node_id : result.added_nodes) {
         find_node(node_id)->set_selected(true);
     }
 }
 
 void OrchestratorEditorGraphPanel::_paste_nodes_request() {
-    // Pass 1 - Verify functions
-    for (const StringName& function_name : _copy_buffer.function_names) {
-        const Ref<OScriptFunction> source_function = _copy_buffer.orchestration->find_function(function_name);
-        if (!source_function.is_valid()) {
-            const String message = vformat("Cannot paste because source function '%s' no longer exists", function_name);
-            ORCHESTRATOR_ERROR_TITLE(message, "Clipboard error");
-        }
+    const Vector2 offset = (get_scroll_offset() + get_local_mouse_position()) / get_zoom();
 
-        const Ref<OScriptFunction> function = _graph->get_orchestration()->find_function(function_name);
-        if (!function.is_valid()) {
-            const String message = vformat("Cannot paste because function '%s' does not exist", function_name);
-            ORCHESTRATOR_ERROR_TITLE(message, "Clipboard error");
-        }
+    OrchestratorEditorGraphClipboard::ClipboardResult result = _clipboard.paste(
+        _graph, offset, is_snapping_enabled(), get_snapping_distance());
 
-        if (!MethodUtils::has_same_signature(source_function->get_method_info(), function->get_method_info())) {
-            const String message = vformat("Function '%s' exists but with a different definition", function_name);
-            ORCHESTRATOR_ERROR_TITLE(message, "Clipboard error");
-        }
+    if (result.added_nodes.is_empty()) {
+        ORCHESTRATOR_ERROR("No nodes were pasted");
     }
 
-    // Pass 2 - Verify Variables
-    for (const StringName& variable_name : _copy_buffer.variable_names) {
-        const Ref<OScriptVariable> source_variable = _copy_buffer.orchestration->get_variable(variable_name);
-        if (!source_variable.is_valid()) {
-            const String message = vformat("Variable '%s' no longer exists in the source orchestration", variable_name);
-            ORCHESTRATOR_ERROR_TITLE(message, "Clipboard error");
-        }
-
-        const Ref<OScriptVariable> variable = _graph->get_orchestration()->get_variable(variable_name);
-        if (variable.is_valid() && !PropertyUtils::are_equal(source_variable->get_info(), variable->get_info())) {
-            const String message = vformat("Variable '%s' exists but with a different definition", variable_name);
-            ORCHESTRATOR_ERROR_TITLE(message, "Clipboard error");
-        }
-    }
-
-    // Pass 3 - Verify Signals
-    for (const StringName& signal_name : _copy_buffer.signal_names) {
-        const Ref<OScriptSignal> source_signal = _copy_buffer.orchestration->find_custom_signal(signal_name);
-        if (!source_signal.is_valid()) {
-            const String message = vformat("Cannot paste because source signal '%s' no longer exists", signal_name);
-            ORCHESTRATOR_ERROR_TITLE(message, "Clipboard error");
-        }
-
-        const Ref<OScriptSignal> signal = _graph->get_orchestration()->find_custom_signal(signal_name);
-        if (!signal.is_valid()) {
-            const String message = vformat("Cannot paste because signal '%s' does not exist", signal_name);
-            ORCHESTRATOR_ERROR_TITLE(message, "Clipboard error");
-        }
-
-        if (!MethodUtils::has_same_signature(source_signal->get_method_info(), signal->get_method_info())) {
-            const String message = vformat("Signal '%s' exists but with a different definition", signal_name);
-            ORCHESTRATOR_ERROR_TITLE(message, "Clipboard error");
-        }
-    }
-
-    // Pass 4 - Create variable references that don't already exist
-    for (const StringName& variable_name : _copy_buffer.variable_names) {
-        const Ref<OScriptVariable> source_variable = _copy_buffer.orchestration->get_variable(variable_name);
-        if (source_variable.is_valid()) {
-            continue;
-        }
-
-        const Ref<OScriptVariable> variable = _graph->get_orchestration()->create_variable(variable_name);
-        ERR_CONTINUE(!variable.is_valid());
-
-        variable->copy_persistent_state(source_variable);
-    }
-
-    // Pass 5 - Create signal references that don't already exist
-    for (const StringName& signal_name : _copy_buffer.signal_names) {
-        const Ref<OScriptSignal> source_signal = _copy_buffer.orchestration->find_custom_signal(signal_name);
-        if (source_signal.is_valid()) {
-            continue;
-        }
-
-        const Ref<OScriptSignal> signal = _graph->get_orchestration()->create_custom_signal(signal_name);
-        ERR_CONTINUE(!signal.is_valid());
-
-        signal->copy_persistent_state(source_signal);
-    }
-
-    // Pass 6 - Compute paste offset
-    Vector2 offset = (get_scroll_offset() + get_local_mouse_position()) / get_zoom();
-    #if GODOT_VERSION >= 0x040500
-    if (!_copy_buffer.nodes.is_empty()) {
-        offset -= _copy_buffer.nodes.get(0).position;
-    }
-    #else
-    if (!_copy_buffer.nodes.is_empty()) {
-        offset -= _copy_buffer.nodes[0].position;
-    }
-    #endif
-
-    if (is_snapping_enabled()) {
-        offset = offset.snapped(Vector2(get_snapping_distance(), get_snapping_distance()));
-    }
-
-    // Pass 7 - Create the nodes
-    HashMap<int, int> connection_remap;
-    HashSet<int> added_set;
-
-    for (const CopyItem& item : _copy_buffer.nodes) {
-        const Ref<OrchestrationGraphNode> node = item.node;
-
-        // Since the source and target function definitions may, the copy needs to refer to the GUID
-        // in the target because while the function signatures match, they have different GUIDs.
-        const Ref<OScriptNodeCallScriptFunction> call_script_func = node;
-        if (call_script_func.is_valid()) {
-            const StringName func_name = call_script_func->get_function()->get_function_name();
-            const Ref<OScriptFunction> target_func = _graph->get_orchestration()->find_function(func_name);
-            if (target_func.is_valid()) {
-                call_script_func->set("guid", target_func->get_guid().to_string());
-            }
-        }
-
-        const Ref<OrchestrationGraphNode> new_node = _graph->paste_node(node, item.position + offset);
-
-        connection_remap[item.id] = new_node->get_id();
-        added_set.insert(new_node->get_id());
-    }
-
-    // Pass 8 - Apply connections between pasted nodes
-    for (const uint64_t connection_id : _copy_buffer.connections) {
-        const Connection C(connection_id);
-        _graph->link(connection_remap[C.from_node], C.from_port, connection_remap[C.to_node], C.to_port);
-    }
-
-    // Pass 9 - Update the UI
     _refresh_panel_connections_with_model();
 
-    // Pass 10 - Apply selections on the newly pasted nodes
+    emit_signal("nodes_changed");
+
     clear_selections();
-    for (int node_id : added_set) {
+
+    for (uint64_t node_id : result.added_nodes) {
         find_node(node_id)->set_selected(true);
     }
 
     _set_edited(true);
+
+    if (result.had_skipped_nodes()) {
+        String message = "Several nodes were not pasted due to the following reasons:\n\n";
+        for (const KeyValue<StringName, String>& E : result.skipped_functions) {
+            message += "* Function " + E.key + ": " + E.value + "\n";
+        }
+        for (const KeyValue<StringName, String>& E : result.skipped_events) {
+            message += "* Event " + E.key + ": " + E.value + "\n";
+        }
+        for (const KeyValue<StringName, String>& E : result.skipped_variables) {
+            message += "* Variable " + E.key + ": " + E.value + "\n";
+        }
+        for (const KeyValue<StringName, String>& E : result.skipped_signals) {
+            message += "* Signal " + E.key + ": " + E.value + "\n";
+        }
+        ORCHESTRATOR_ERROR(message);
+    }
 }
 
 void OrchestratorEditorGraphPanel::_begin_node_move() {
@@ -873,12 +714,7 @@ void OrchestratorEditorGraphPanel::_knots_changed() {
 }
 
 void OrchestratorEditorGraphPanel::_clear_copy_buffer() {
-    _copy_buffer.nodes.clear();
-    _copy_buffer.connections.clear();
-    _copy_buffer.orchestration = nullptr;
-    _copy_buffer.variable_names.clear();
-    _copy_buffer.function_names.clear();
-    _copy_buffer.signal_names.clear();
+    _clipboard.clear();
 }
 
 void OrchestratorEditorGraphPanel::_toggle_resizer_for_selected_nodes() {
@@ -1191,81 +1027,28 @@ void OrchestratorEditorGraphPanel::_collapse_selected_nodes_to_function() {
 }
 
 bool OrchestratorEditorGraphPanel::_create_new_function(const String& p_name, bool p_has_return) {
-    ERR_FAIL_COND_V_MSG(_graph->get_orchestration()->has_function(p_name), false, "A function already exists with that name");
-
-    const int flags = OrchestrationGraph::GF_FUNCTION | OrchestrationGraph::GF_DEFAULT;
-    const Ref<OrchestrationGraph> function_graph = _graph->get_orchestration()->create_graph(p_name, flags);
-    ERR_FAIL_COND_V_MSG(!function_graph.is_valid(), false, "Failed to create function graph");
-
-    MethodInfo mi;
-    mi.name = p_name;
-    mi.flags = METHOD_FLAG_NORMAL;
-    mi.return_val.type = Variant::NIL;
-    mi.return_val.hint = PROPERTY_HINT_NONE;
-    mi.return_val.usage = PROPERTY_USAGE_DEFAULT;
-
-    NodeSpawnOptions options;
-    options.node_class = OScriptNodeFunctionEntry::get_class_static();
-    options.context.method = mi;
-
-    const Ref<OrchestrationGraphNode> entry = function_graph->create_node<OScriptNodeFunctionEntry>(options.context);
-    if (!entry.is_valid()) {
-        _graph->get_orchestration()->remove_graph(function_graph->get_graph_name());
-        ERR_FAIL_V_MSG(false, "Failed to create function entry node in the function graph");
+    const Ref<OScriptFunction> function = _graph->get_orchestration()->create_function(p_name, p_has_return);
+    if (function.is_null()) {
+        return false;
     }
 
     _set_edited(true);
-
-    if (!p_has_return) {
-        return true;
-    }
-
-    const Vector2 position = entry->get_position() + Vector2(300, 0);
-    if (!function_graph->create_node<OScriptNodeFunctionResult>(options.context, position).is_valid()) {
-        ERR_FAIL_V_MSG(false, "Failed to create function result node in the function graph, please create it manually.");
-    }
 
     return true;
 }
 
 bool OrchestratorEditorGraphPanel::_create_new_function_override(const MethodInfo& p_method) {
-    ERR_FAIL_COND_V_MSG(_graph->get_orchestration()->has_function(p_method.name), false, "A function already exists with that name");
+    bool user_defined = !(p_method.flags & METHOD_FLAG_VIRTUAL);
 
-    const int flags = OrchestrationGraph::GF_FUNCTION | OrchestrationGraph::GF_DEFAULT;
-    const Ref<OrchestrationGraph> function_graph = _graph->get_orchestration()->create_graph(p_method.name, flags);
-    ERR_FAIL_COND_V_MSG(!function_graph.is_valid(), false, "Failed to create function graph");
-
-    NodeSpawnOptions options;
-    options.node_class = OScriptNodeFunctionEntry::get_class_static();
-    options.context.method = p_method;
-
-    if (p_method.flags & METHOD_FLAG_VIRTUAL) {
-        options.context.user_data = DictionaryUtils::of({ { "user_defined", false } });
-    } else {
-        options.context.user_data = DictionaryUtils::of({ { "user_defined", true } });
-    }
-
-    const Ref<OScriptNodeFunctionEntry> entry = function_graph->create_node<OScriptNodeFunctionEntry>(options.context);
-    if (!entry.is_valid()) {
-        _graph->get_orchestration()->remove_graph(function_graph->get_graph_name());
-        ERR_FAIL_V_MSG(false, "Failed to create function entry node in the function graph");
+    const Ref<OScriptFunction> function = _graph->get_orchestration()->create_function(p_method, user_defined);
+    if (!function.is_valid()) {
+        return false;
     }
 
     _set_edited(true);
 
-    if (MethodUtils::has_return_value(p_method)) {
-        const Vector2 position = entry->get_position() + Vector2(300, 0);
+    call_deferred("emit_signal", "focus_requested", function);
 
-        const Ref<OScriptNodeFunctionResult> result = function_graph->create_node<OScriptNodeFunctionResult>(options.context, position);
-        if (!result.is_valid()) {
-            _graph->get_orchestration()->remove_graph(function_graph->get_graph_name());
-            ERR_FAIL_V_MSG(false, "Failed to create function " + p_method.name);
-        }
-
-        entry->find_pin(0, PD_Output)->link(result->find_pin(0, PD_Input));
-    }
-
-    call_deferred("emit_signal", "focus_requested", entry->get_function());
     return true;
 }
 

--- a/src/editor/graph/graph_panel.h
+++ b/src/editor/graph/graph_panel.h
@@ -18,6 +18,7 @@
 
 #include "common/godot_version.h"
 #include "core/godot/object/weak_ref.h"
+#include "editor/graph/graph_clipboard.h"
 #include "editor/graph/graph_node.h"
 #include "editor/graph/graph_panel_styler.h"
 
@@ -87,27 +88,7 @@ private:
         int32_t pin_port;
     };
 
-    struct CopyItem {
-        int id;
-        Ref<OrchestrationGraphNode> node;
-        Vector2 position;
-        Vector2 size;
-    };
-
-    struct CopyBuffer {
-        List<CopyItem> nodes;
-        List<uint64_t> connections;
-        Orchestration* orchestration = nullptr;
-        HashSet<StringName> variable_names;
-        HashSet<StringName> function_names;
-        HashSet<StringName> signal_names;
-
-        bool is_empty() const {
-            return nodes.is_empty();
-        }
-    };
-
-    static CopyBuffer _copy_buffer;
+    OrchestratorEditorGraphClipboard _clipboard;
 
     GodotVersionInfo _godot_version;
 

--- a/src/orchestration/orchestration.cpp
+++ b/src/orchestration/orchestration.cpp
@@ -16,6 +16,7 @@
 //
 #include "orchestration/orchestration.h"
 
+#include "common/dictionary_utils.h"
 #include "common/method_utils.h"
 #include "common/name_utils.h"
 #include "common/variant_utils.h"
@@ -643,6 +644,80 @@ PackedStringArray Orchestration::get_graph_names() const {
 
 bool Orchestration::has_function(const StringName& p_name) const {
     return _functions.has(p_name);
+}
+
+Ref<OScriptFunction> Orchestration::create_function(const StringName& p_name, bool p_has_return) {
+    ERR_FAIL_COND_V_MSG(_has_instances(), nullptr, "Cannot create functions, instances exist.");
+    ERR_FAIL_COND_V_MSG(!String(p_name).is_valid_identifier(), nullptr, "Invalid function name: " + p_name);
+    ERR_FAIL_COND_V_MSG(_functions.has(p_name), nullptr, "A function already exists with the name: " + p_name);
+    ERR_FAIL_COND_V_MSG(_variables.has(p_name), nullptr, "A variable already exists with the name: " + p_name);
+    ERR_FAIL_COND_V_MSG(_signals.has(p_name), nullptr, "A signal already exists with the name: " + p_name);
+
+    constexpr int flags = OrchestrationGraph::GF_FUNCTION | OrchestrationGraph::GF_DEFAULT;
+    const Ref<OrchestrationGraph> graph = create_graph(p_name, flags);
+    ERR_FAIL_COND_V_MSG(!graph.is_valid(), {}, "Failed to create the function graph");
+
+    MethodInfo method;
+    method.name = p_name;
+    method.flags = METHOD_FLAG_NORMAL;
+    method.return_val.type = Variant::NIL;
+    method.return_val.hint = PROPERTY_HINT_NONE;
+    method.return_val.usage = PROPERTY_USAGE_DEFAULT;
+
+    OScriptNodeInitContext context;
+    context.method = method;
+
+    const Ref<OrchestrationGraphNode> entry = graph->create_node<OScriptNodeFunctionEntry>(context);
+    if (!entry.is_valid()) {
+        remove_graph(graph->get_graph_name());
+        ERR_FAIL_V_MSG({}, "Failed to create function entry node in the function graph");
+    }
+
+    const Ref<OScriptFunction> function = find_function(graph->get_graph_name());
+
+    if (p_has_return) {
+        const Vector2 position = entry->get_position() + Vector2(300, 0);
+        if (!graph->create_node<OScriptNodeFunctionResult>(context, position).is_valid()) {
+            ERR_FAIL_V_MSG(function, "Failed to create function result node in the graph, please create it manually.");
+        }
+    }
+
+    return function;
+}
+
+Ref<OScriptFunction> Orchestration::create_function(const MethodInfo& p_method, bool p_user_defined) {
+    ERR_FAIL_COND_V_MSG(_has_instances(), nullptr, "Cannot create functions, instances exist.");
+    ERR_FAIL_COND_V_MSG(!String(p_method.name).is_valid_identifier(), nullptr, "Invalid function name: " + p_method.name);
+    ERR_FAIL_COND_V_MSG(_functions.has(p_method.name), nullptr, "A function already exists with the name: " + p_method.name);
+    ERR_FAIL_COND_V_MSG(_variables.has(p_method.name), nullptr, "A variable already exists with the name: " + p_method.name);
+    ERR_FAIL_COND_V_MSG(_signals.has(p_method.name), nullptr, "A signal already exists with the name: " + p_method.name);
+
+    constexpr int flags = OrchestrationGraph::GF_FUNCTION | OrchestrationGraph::GF_DEFAULT;
+    const Ref<OrchestrationGraph> graph = create_graph(p_method.name, flags);
+    ERR_FAIL_COND_V_MSG(!graph.is_valid(), {}, "Failed to create the function graph");
+
+    OScriptNodeInitContext context;
+    context.method = p_method;
+    context.user_data = DictionaryUtils::of({ { "user_defined", p_user_defined } });
+
+    const Ref<OrchestrationGraphNode> entry = graph->create_node<OScriptNodeFunctionEntry>(context);
+    if (!entry.is_valid()) {
+        remove_graph(graph->get_graph_name());
+        ERR_FAIL_V_MSG({}, "Failed to create function entry node in the function graph");
+    }
+
+    if (MethodUtils::has_return_value(p_method)) {
+        const Vector2 position = entry->get_position() + Vector2(300, 0);
+        const Ref<OScriptNodeFunctionResult> result = graph->create_node<OScriptNodeFunctionResult>(context, position);
+        if (!result.is_valid()) {
+            remove_graph(graph->get_graph_name());
+            ERR_FAIL_V_MSG({}, "Failed to create function " + p_method.name);
+        }
+
+        entry->find_pin(0, PD_Output)->link(result->find_pin(0, PD_Input));
+    }
+
+    return find_function(graph->get_graph_name());
 }
 
 Ref<OScriptFunction> Orchestration::create_function(const MethodInfo& p_method, int p_node_id, bool p_user_defined) {

--- a/src/orchestration/orchestration.h
+++ b/src/orchestration/orchestration.h
@@ -239,6 +239,8 @@ public:
 
     //~ Begin Function API
     bool has_function(const StringName& p_name) const;
+    Ref<OScriptFunction> create_function(const StringName& p_name, bool p_has_return);
+    Ref<OScriptFunction> create_function(const MethodInfo& p_method, bool p_user_defined = false);
     Ref<OScriptFunction> create_function(const MethodInfo& p_method, int p_node_id, bool p_user_defined = false);
     Ref<OScriptFunction> duplicate_function(const StringName& p_name, bool p_include_code);
     void remove_function(const StringName& p_name);

--- a/src/script/nodes/functions/event.h
+++ b/src/script/nodes/functions/event.h
@@ -49,7 +49,7 @@ public:
     String get_icon() const override { return "PlayStart"; }
     bool can_user_delete_node() const override { return true; }
     bool can_inspect_node_properties() const override { return true; }
-    bool can_duplicate() const override { return false; }
+    bool can_duplicate() const override { return true; }
     StringName resolve_type_class(const Ref<OScriptNodePin>& p_pin) const override;
     //~ End OScriptNode Interface
 

--- a/src/script/nodes/signals/emit_signal.cpp
+++ b/src/script/nodes/signals/emit_signal.cpp
@@ -82,7 +82,7 @@ void OScriptNodeEmitSignal::_on_signal_changed() {
 void OScriptNodeEmitSignal::post_initialize() {
     _signal = get_orchestration()->find_custom_signal(_signal_name);
     if (_signal.is_valid() && _is_in_editor()) {
-        _signal->connect("changed", callable_mp_this(_on_signal_changed));
+        OCONNECT(_signal, "changed", callable_mp_this(_on_signal_changed));
     }
     super::post_initialize();
 }


### PR DESCRIPTION
Fixes GH-1498

## Description

This introduces a new clipboard implementation that allows for the following:

* Supports the copy/cut and paste across orchestration boundaries
* Creates function stubs when a call script function node is in the clipboard buffer
* Creates variables/signals in the target orchestration if they do not exist
* Reports errors if functions/variables/signals exist but their declarations differ from the source
* Allows for moving complete event graph functions into new event graphs using cut-n-paste
* Event nodes can be placed into the clipboard

What is not included in this change:

* The ability to copy entire functions across script boundaries will still require creating the target function manually or copying a call script function node that creates the function stub. A second copy-n-paste operation can be used to move the contents of one function to another in separate operations.
* Local variables or local variable nodes still cannot be duplicated and placed into the clipboard

These limitations are still blocked by these two remaining issues:

* https://github.com/CraterCrash/godot-orchestrator/issues/495
* https://github.com/CraterCrash/godot-orchestrator/issues/1383