### PR TITLE
GH-1534 Apply temp file prefix when making templates

### DIFF
--- a/src/script/language.cpp
+++ b/src/script/language.cpp
@@ -256,7 +256,7 @@ Ref<Script> OScriptLanguage::_make_template(const String& p_template, const Stri
     }
 
     if (!source.is_empty()) {
-        const Ref<FileAccess> temp = FileAccess::create_temp(FileAccess::WRITE_READ, "", "torch");
+        const Ref<FileAccess> temp = FileAccess::create_temp(FileAccess::WRITE_READ, "orchestration-template", "torch");
         temp->store_string(source);
         temp->seek(0);
         temp->flush();


### PR DESCRIPTION
Fixes GH-1534

This primarily fixes the issue for 2.2/2.3 there the `FileAccess::create_temp` behavior differs.