### PR TITLE
GH-1612 Add additional keywords to type cast node

### DIFF
--- a/src/orchestration/nodes/type_cast.cpp
+++ b/src/orchestration/nodes/type_cast.cpp
@@ -112,6 +112,10 @@ String OScriptNodeTypeCast::get_tooltip_text() const {
     }
 }
 
+PackedStringArray OScriptNodeTypeCast::get_keywords() const {
+    return Array::make("is", "type", "cast", "instanceof", "check");
+}
+
 String OScriptNodeTypeCast::get_node_title() const {
     return vformat("Cast To %s", _get_target_type());
 }

--- a/src/orchestration/nodes/type_cast.h
+++ b/src/orchestration/nodes/type_cast.h
@@ -47,6 +47,7 @@ public:
     void post_node_autowired(const Ref<OScriptNode>& p_node, EPinDirection p_direction) override;
     void allocate_default_pins() override;
     String get_tooltip_text() const override;
+    PackedStringArray get_keywords() const override;
     String get_node_title() const override;
     String get_node_title_color_name() const override { return "type_cast"; }
     String get_icon() const override;


### PR DESCRIPTION
Fixes GH-1612

## Description

Adds `is`, `type`, `check`, `cast`, and `instanceof` as keywords for the Type Cast node.