### PR TITLE
GH-1649 Improve promotable operator node behavior

### DIFF
--- a/src/editor/actions/rules/port_rule.cpp
+++ b/src/editor/actions/rules/port_rule.cpp
@@ -19,9 +19,11 @@
 #include "common/dictionary_utils.h"
 #include "common/method_utils.h"
 #include "common/property_utils.h"
+#include "common/settings.h"
 #include "common/string_utils.h"
 #include "editor/actions/filter_engine.h"
 #include "editor/graph/graph_pin.h"
+#include "orchestration/nodes/operator_node.h"
 #include "script/script_server.h"
 
 bool OrchestratorEditorActionPortRule::matches(const Ref<OrchestratorEditorActionDefinition>& p_action, const FilterContext& p_context) {
@@ -42,6 +44,17 @@ bool OrchestratorEditorActionPortRule::matches(const Ref<OrchestratorEditorActio
     // For example, dragging from a Callable pin provides access to methods like bind.
     if (_type != Variant::VARIANT_MAX && _target_classes.has(p_action->target_class)) {
         return true;
+    }
+
+    if (_enable_type_promotion && p_action->node_class == OScriptNodePromotableOperator::get_class_static()) {
+        if (_type >= Variant::NIL && _type < Variant::VARIANT_MAX) {
+            const BuiltInType builtin_type = ExtensionDB::get_builtin_type(_type);
+            for (const OperatorInfo& oi : builtin_type.operators) {
+                if (oi.left_type == _type || oi.right_type == _type) {
+                    return true;
+                }
+            }
+        }
     }
 
     // Match against method
@@ -117,6 +130,7 @@ bool OrchestratorEditorActionPortRule::matches(const Ref<OrchestratorEditorActio
 void OrchestratorEditorActionPortRule::configure(const OrchestratorEditorGraphPin* p_pin, const Object* p_target) {
     _output = p_pin->get_direction() == PD_Output;
     _execution = p_pin->is_execution();
+    _enable_type_promotion = ORCHESTRATOR_GET("editor/behavior/general/enable_type_promotion", true);
 
     const PropertyInfo& property = p_pin->get_property_info();
     if (property.type != Variant::NIL && property.type != Variant::OBJECT) {

--- a/src/editor/actions/rules/port_rule.h
+++ b/src/editor/actions/rules/port_rule.h
@@ -32,6 +32,7 @@ class OrchestratorEditorActionPortRule : public OrchestratorEditorActionFilterRu
     PackedStringArray _target_classes;
     bool _output = false;
     bool _execution = false;
+    bool _enable_type_promotion = false;
 
 protected:
     static void _bind_methods() { }

--- a/src/orchestration/nodes/operator_node.cpp
+++ b/src/orchestration/nodes/operator_node.cpp
@@ -300,14 +300,50 @@ Variant::Type OScriptNodePromotableOperator::_get_result_type(Variant::Type p_le
 }
 
 Variant::Type OScriptNodePromotableOperator::_get_result_type() const {
-    if (!_operands.is_empty()) {
-        Variant::Type left = _operands[0];
-        for (int i = 1; i < _operands.size(); i++) {
-            left = _get_result_type(left, _operands[i]);
+    switch (_op) {
+        // Comparisons
+        case VariantOperators::OP_LESS:
+        case VariantOperators::OP_LESS_EQUAL:
+        case VariantOperators::OP_GREATER:
+        case VariantOperators::OP_GREATER_EQUAL:
+        case VariantOperators::OP_EQUAL:
+        case VariantOperators::OP_NOT_EQUAL:
+        // Logic
+        case VariantOperators::OP_AND:
+        case VariantOperators::OP_OR:
+        case VariantOperators::OP_XOR:
+        case VariantOperators::OP_NOT:
+        // Containment
+        case VariantOperators::OP_IN: {
+            return Variant::BOOL;
         }
-        return left;
+        default: {
+            if (!_operands.is_empty()) {
+                Variant::Type left = _operands[0];
+                for (int i = 1; i < _operands.size(); i++) {
+                    left = _get_result_type(left, _operands[i]);
+                }
+                return left;
+            }
+            return Variant::NIL;
+        }
     }
-    return Variant::NIL;
+}
+
+void OScriptNodePromotableOperator::_reset_to_variant() {
+    for (int i = 0; i < _operands.size(); i++) {
+        _operands.write[i] = Variant::NIL;
+    }
+
+    _result = _get_result_type();
+
+    for (const Ref<OScriptNodePin>& input : find_pins(PD_Input)) {
+        if (input.is_valid() && input->has_any_connections()) {
+            input->unlink_all();
+        }
+    }
+
+    _queue_reconstruct();
 }
 
 void OScriptNodePromotableOperator::allocate_default_pins() {
@@ -340,6 +376,13 @@ void OScriptNodePromotableOperator::allocate_default_pins() {
     create_pin(PD_Output, PT_Data, pi, VariantUtils::make_default(_result))->hide_label();
 
     super::allocate_default_pins();
+}
+
+void OScriptNodePromotableOperator::post_placed_new_node() {
+    if (!is_in_object() && !is_string_format_using_modulo()) {
+        _reset_to_variant();
+    }
+    super::post_placed_new_node();
 }
 
 String OScriptNodePromotableOperator::get_tooltip_text() const {
@@ -529,8 +572,12 @@ void OScriptNodePromotableOperator::change_pin_types(const Ref<OScriptNodePin>& 
     }
 
     if (_operands[0] == Variant::NIL || p_type == Variant::NIL) {
-        for (int i = 0; i < _operands.size(); i++) {
-            _operands.write[i] = p_type;
+        if (p_type == Variant::NIL) {
+            _reset_to_variant();
+        } else {
+            for (int i = 0; i < _operands.size(); i++) {
+                _operands.write[i] = p_type;
+            }
         }
     } else {
         _operands.write[pin_offset] = p_type;
@@ -588,6 +635,14 @@ void OScriptNodePromotableOperator::post_reconstruct_node() {
     }
 
     super::post_reconstruct_node();
+}
+
+void OScriptNodePromotableOperator::on_pin_connected(const Ref<OScriptNodePin>& p_pin) {
+    if (p_pin.is_valid() && p_pin->is_input() && _operands.size() >= 1 && _operands[0] == Variant::NIL) {
+        if (can_change_pin_type(p_pin)) {
+            change_pin_types(p_pin, p_pin->get_connection()->get_property_info().type);
+        }
+    }
 }
 
 bool OScriptNodePromotableOperator::can_add_dynamic_pin() const {

--- a/src/orchestration/nodes/operator_node.h
+++ b/src/orchestration/nodes/operator_node.h
@@ -92,9 +92,12 @@ protected:
     Variant::Type _get_result_type(Variant::Type p_left, Variant::Type p_right) const;
     Variant::Type _get_result_type() const;
 
+    void _reset_to_variant();
+
 public:
     //~ Begin OScriptNode Interface
     void allocate_default_pins() override;
+    void post_placed_new_node() override;
     bool rewire_old_pins_by_position() const override { return true; }
     String get_tooltip_text() const override;
     String get_node_title() const override;
@@ -109,6 +112,7 @@ public:
     PackedStringArray get_keywords() const override;
     void get_actions(List<Ref<OScriptAction>>& p_action_list) override;
     void post_reconstruct_node() override;
+    void on_pin_connected(const Ref<OScriptNodePin>& p_pin) override;
     //~ End OScriptNode Interface
 
     //~ Begin OScriptEditablePinNode Interface


### PR DESCRIPTION
Fixes GH-1649

## Changes

* Duplicating non-format/in-object operators defaults to Variant
* Automatically change pin type on first connection
* Spawn comparison/containment/logic nodes with boolean output
* Display operator nodes when dragging from output node
* Promotable operator nodes are autowire enabled