### PR TITLE
GH-1689 Fix collapse to function / expand node behavior

### DIFF
--- a/src/editor/graph/graph_clipboard.cpp
+++ b/src/editor/graph/graph_clipboard.cpp
@@ -20,11 +20,12 @@
 #include "common/method_utils.h"
 #include "common/property_utils.h"
 #include "common/version.h"
-#include "orchestration/orchestration.h"
 #include "orchestration/nodes/call_function.h"
 #include "orchestration/nodes/emit_signal.h"
 #include "orchestration/nodes/event.h"
+#include "orchestration/nodes/operator_node.h"
 #include "orchestration/nodes/variables.h"
+#include "orchestration/orchestration.h"
 
 OrchestratorEditorGraphClipboard::Buffer OrchestratorEditorGraphClipboard::_buffer;
 
@@ -243,6 +244,14 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
         }
     }
 
+    // Pass 8 - Restore pin types if pasted PromotableOperator nodes have connections
+    for (const CopyItem& item : _buffer.nodes) {
+        const int new_node_id = connection_remap[item.node->get_id()];
+        const Ref<OrchestrationGraphNode> new_node = p_target->get_orchestration()->get_node(new_node_id);
+        const Ref<OrchestrationGraphNode> old_node = item.node->get_orchestration()->get_node(item.node->get_id());
+        OScriptNodePromotableOperator::copy_pin_types(old_node, new_node);
+    }
+
     return result;
 }
 
@@ -266,6 +275,15 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
             uint64_t target_node = connection_remap[C.to_node];
             p_graph->link(source_node, C.from_port, target_node, C.to_port);
         }
+    }
+
+    // Makes sure that if a PromotableOperator node has any connections that are duplicated, the pin types
+    // from the original node are restored.
+    for (OrchestratorEditorGraphNode* node : p_nodes) {
+        const int new_node_id = connection_remap[node->get_id()];
+        const Ref<OrchestrationGraphNode> new_node = p_graph->get_orchestration()->get_node(new_node_id);
+        const Ref<OrchestrationGraphNode> old_node = p_graph->get_orchestration()->get_node(node->get_id());
+        OScriptNodePromotableOperator::copy_pin_types(old_node, new_node);
     }
 
     return result;

--- a/src/editor/graph/graph_panel.cpp
+++ b/src/editor/graph/graph_panel.cpp
@@ -779,6 +779,15 @@ void OrchestratorEditorGraphPanel::_expand_node(OrchestratorEditorGraphNode* p_n
                 _graph->link(connection_remap[C.from_node], C.from_port, connection_remap[C.to_node], C.to_port);
             }
         }
+
+        // Makes sure that if a PromotableOperator node has any connections that are duplicated, the pin types
+        // from the original node are restored.
+        for (int old_node_id : nodes_to_duplicate) {
+            const int new_node_id = connection_remap[old_node_id];
+            const Ref<OrchestrationGraphNode> new_node = _graph->get_orchestration()->get_node(new_node_id);
+            const Ref<OrchestrationGraphNode> old_node = _graph->get_orchestration()->get_node(old_node_id);
+            OScriptNodePromotableOperator::copy_pin_types(old_node, new_node);
+        }
     }
 
     remove_node(p_node, false);
@@ -873,7 +882,15 @@ void OrchestratorEditorGraphPanel::_collapse_selected_nodes_to_function() {
     // Reapply connections in new graph
     for (uint64_t connection_id : connections) {
         const Connection C(connection_id);
-        target_graph->link(C.from_node, C.from_port, C.to_node, C.to_port);
+        const Ref<OrchestrationGraphNode> source_node = target_graph->get_node(C.from_node);
+        const Ref<OrchestrationGraphNode> target_node = target_graph->get_node(C.to_node);
+        if (source_node.is_valid() && target_node.is_valid()) {
+            const Ref<OrchestrationGraphPin> source_pin = source_node->find_pin(C.from_port, PD_Output);
+            const Ref<OrchestrationGraphPin> target_pin = target_node->find_pin(C.to_port, PD_Input);
+            if (source_pin.is_valid() && target_pin.is_valid()) {
+                source_pin->link(target_pin);
+            }
+        }
     }
 
     // Spawn the call functino node in the source graph
@@ -974,7 +991,7 @@ void OrchestratorEditorGraphPanel::_collapse_selected_nodes_to_function() {
             }
         }
 
-        const Ref<OrchestrationGraphPin> result_exec = result->find_pin(0, PD_Output);
+        const Ref<OrchestrationGraphPin> result_exec = result->find_pin(0, PD_Input);
         if (result_exec.is_valid() && !result_exec->has_any_connections()) {
             const Ref<OrchestrationGraphNode> entry = function->get_owning_node();
             const Ref<OrchestrationGraphPin> entry_exec = entry->find_pin(0, PD_Output);

--- a/src/orchestration/nodes/operator_node.cpp
+++ b/src/orchestration/nodes/operator_node.cpp
@@ -811,6 +811,23 @@ String OScriptNodePromotableOperator::get_operator_tooltip_text(VariantOperators
     }
 }
 
+void OScriptNodePromotableOperator::copy_pin_types(const Ref<OrchestrationGraphNode>& p_source, const Ref<OrchestrationGraphNode>& p_target) {
+    if (p_source.is_null() || p_target.is_null() || !p_target->has_any_connections()) {
+        return;
+    }
+
+    const Ref<OScriptNodePromotableOperator> promotable_operator = p_target;
+    if (promotable_operator.is_null()) {
+        return;
+    }
+
+    for (const Ref<OrchestrationGraphPin>& pin : promotable_operator->get_all_pins()) {
+        if (const Ref<OrchestrationGraphPin>& source_pin = p_source->find_pin(pin->get_pin_name(), pin->get_direction()); source_pin.is_valid()) {
+            promotable_operator->change_pin_types(pin, source_pin->get_type());
+        }
+    }
+}
+
 void OScriptNodePromotableOperator::_bind_methods() {
 
 }

--- a/src/orchestration/nodes/operator_node.h
+++ b/src/orchestration/nodes/operator_node.h
@@ -134,4 +134,5 @@ public:
     static String get_operator_lexical_code(VariantOperators::Code p_operator);
     static String get_operator_tooltip_text(VariantOperators::Code p_operator);
 
+    static void copy_pin_types(const Ref<OrchestrationGraphNode>& p_source, const Ref<OrchestrationGraphNode>& p_target);
 };


### PR DESCRIPTION
Fixes GH-1689

* Fixes the duplicate/copy/paste behavior with promotable operators; pin types are retained with connections
* Fixes reroute types on collapse to node/expand node 
* Correctly sets the result node type 
* Fixed bug with result nodes during collapse to function with an invalid connection.