### PR TITLE
GH-1715 Fix inspector property get/set path resolution

### DIFF
--- a/src/common/scene_utils.cpp
+++ b/src/common/scene_utils.cpp
@@ -167,6 +167,19 @@ namespace SceneUtils {
         return wrapped;
     }
 
+    Node* get_scene_base_node(const Ref<Script>& p_script) {
+        if (SceneTree* tree = Object::cast_to<SceneTree>(Engine::get_singleton()->get_main_loop())) {
+            if (Node* root = tree->get_edited_scene_root()) {
+                Vector<Node*> nodes;
+                find_all_nodes_for_script(root, root, p_script, nodes);
+                if (!nodes.is_empty()) {
+                    return nodes[0];
+                }
+            }
+        }
+        return nullptr;
+    }
+
     Node* get_node_with_script(const Ref<Script>& p_script, Node* p_node, Node* p_root) {
         // Non-instanced scene children
         if (p_node == p_root || p_node->get_owner() == p_root) {

--- a/src/common/scene_utils.h
+++ b/src/common/scene_utils.h
@@ -94,6 +94,11 @@ namespace SceneUtils {
     /// @return the wrapped tooltip text
     String create_wrapped_tooltip_text(const String& p_tooltip_text, int p_width = 512);
 
+    /// Get the scene base node (first node with the script attached)
+    /// @param p_script the script
+    /// @return the scene base node or null if not found
+    Node* get_scene_base_node(const Ref<Script>& p_script);
+
     /// Finds the first node with the specified script attached
     /// @param p_script the script instance, should be valid
     /// @param p_node the node being inspected, should not be <code>null</code>

--- a/src/editor/graph/graph_panel.cpp
+++ b/src/editor/graph/graph_panel.cpp
@@ -2810,7 +2810,16 @@ void OrchestratorEditorGraphPanel::_drop_data(const Vector2& p_at_position, cons
         NodePath path;
         if (Node* root = get_tree()->get_edited_scene_root()) {
             if (Node* object_node = cast_to<Node>(object)) {
-                path = root->get_path_to(object_node);
+                if (object_node->is_unique_name_in_owner()) {
+                    path = NodePath("%" + object_node->get_name());
+                } else {
+                    Vector<Node*> attached_nodes;
+                    SceneUtils::find_all_nodes_for_script(root, root, _graph->get_orchestration()->as_script(), attached_nodes);
+                    if (attached_nodes.is_empty()) {
+                        ORCHESTRATOR_ERROR("Cannot drop a node property in a script that is not attached to a node in this scene.");
+                    }
+                    path = attached_nodes[0]->get_path_to(object_node);
+                }
             }
         }
 

--- a/src/orchestration/nodes/properties.cpp
+++ b/src/orchestration/nodes/properties.cpp
@@ -18,6 +18,7 @@
 
 #include "common/dictionary_utils.h"
 #include "common/property_utils.h"
+#include "common/scene_utils.h"
 #include "orchestration/orchestration.h"
 #include "script/script_server.h"
 
@@ -26,21 +27,23 @@
 #include <godot_cpp/classes/scene_tree.hpp>
 
 void OScriptNodeProperty::_get_property_list(List<PropertyInfo>* r_list) const {
-    uint32_t usage = PROPERTY_USAGE_STORAGE;
+    uint32_t mode_usage = PROPERTY_USAGE_STORAGE;
+    uint32_t path_usage = PROPERTY_USAGE_STORAGE;
     if (!_node_path.is_empty()) {
-        usage |= PROPERTY_USAGE_EDITOR;
-        usage |= PROPERTY_USAGE_READ_ONLY;
+        mode_usage |= PROPERTY_USAGE_EDITOR;
+        mode_usage |= PROPERTY_USAGE_READ_ONLY;
+        path_usage |= PROPERTY_USAGE_EDITOR;
     }
 
     const String modes = "Self,Instance,Node Path";
-    r_list->push_back(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, modes, usage));
+    r_list->push_back(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, modes, mode_usage));
 
     // todo: deprecated, remove in a future release
     r_list->push_back(PropertyInfo(Variant::STRING, "target_class", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
     r_list->push_back(PropertyInfo(Variant::STRING, "property_name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
     r_list->push_back(PropertyInfo(Variant::STRING, "property_hint", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 
-    r_list->push_back(PropertyInfo(Variant::NODE_PATH, "node_path", PROPERTY_HINT_NONE, "", usage));
+    r_list->push_back(PropertyInfo(Variant::NODE_PATH, "node_path", PROPERTY_HINT_NONE, "", path_usage));
 
     // todo:
     // For now we encode property details at the node and pin level, which is wasteful.
@@ -91,9 +94,28 @@ bool OScriptNodeProperty::_set(const StringName& p_name, const Variant& p_value)
         return true;
     } else if (p_name.match("node_path")) {
         _node_path = p_value;
+
+        if (_initialized) {
+            // Make sure that when changed, if it's a unique-named node, we use the unique name
+            if (Node* base_node = _get_scene_base_node()) {
+                if (Node* node = base_node->get_node_or_null(_node_path)) {
+                    if (!_node_path.get_concatenated_names().begins_with("%") && node->is_unique_name_in_owner()) {
+                        _node_path = "%" + node->get_name();
+                    }
+                }
+            }
+        }
+
         return true;
     }
     return false;
+}
+
+Node* OScriptNodeProperty::_get_scene_base_node() const {
+    if (_is_in_editor() && !_node_path.is_empty()) {
+        return SceneUtils::get_scene_base_node(get_orchestration()->get_self());
+    }
+    return nullptr;
 }
 
 bool OScriptNodeProperty::_property_exists(const TypedArray<Dictionary>& p_properties) const {
@@ -212,6 +234,14 @@ String OScriptNodeProperty::get_help_topic() const {
     return super::get_help_topic();
 }
 
+Ref<Resource> OScriptNodeProperty::get_inspect_object() {
+    if (_is_in_editor()) {
+        if (Node* base_node = _get_scene_base_node()) {
+            set_meta("__base_node_relative", base_node);
+        }
+    }
+    return super::get_inspect_object();
+}
 
 void OScriptNodeProperty::initialize(const OScriptNodeInitContext& p_context) {
     ERR_FAIL_COND_MSG(!p_context.property, "A property node requires a PropertyInfo");

--- a/src/orchestration/nodes/properties.h
+++ b/src/orchestration/nodes/properties.h
@@ -57,6 +57,8 @@ protected:
     bool _set(const StringName& p_name, const Variant& p_value);
     //~ End Wrapped Interface
 
+    Node* _get_scene_base_node() const;
+
     /// Checks whether a property exists with the given name in the array
     /// @param p_properties an array of properties
     /// @return true if the property exists, false otherwise
@@ -89,6 +91,7 @@ public:
     String get_icon() const override;
     String get_node_title_color_name() const override { return "properties"; }
     String get_help_topic() const override;
+    Ref<Resource> get_inspect_object() override;
     void initialize(const OScriptNodeInitContext& p_context) override;
     //~ End OScriptNode Interface
 

--- a/src/orchestration/nodes/scene_node.cpp
+++ b/src/orchestration/nodes/scene_node.cpp
@@ -92,18 +92,7 @@ void OScriptNodeSceneNode::_upgrade(uint32_t p_version, uint32_t p_current_versi
 
 Node* OScriptNodeSceneNode::_get_scene_base_node() const {
     if (_is_in_editor() && !_node_path.is_empty()) {
-        if (SceneTree* st = cast_to<SceneTree>(Engine::get_singleton()->get_main_loop())) {
-            if (st->get_edited_scene_root()) {
-                if (Node* root = st->get_edited_scene_root()) {
-                    Vector<Node*> nodes;
-                    const Ref<Script> script = get_orchestration()->get_self();
-                    SceneUtils::find_all_nodes_for_script(root, root, script, nodes);
-                    if (!nodes.is_empty()) {
-                        return nodes[0];
-                    }
-                }
-            }
-        }
+        return SceneUtils::get_scene_base_node(get_orchestration()->get_self());
     }
     return nullptr;
 }


### PR DESCRIPTION
Fixes GH-1715

## Description

When dragging properties from the inspector, the node path resolution does not correctly resolve the node path based on the same logic as the scene node does. This PR aligns the behavior so it mirrors "Get Scene Node".