### PR TITLE
GH-1712 Focus first type drop-down on pop-up

### DIFF
--- a/src/editor/inspector/properties/type_selector.cpp
+++ b/src/editor/inspector/properties/type_selector.cpp
@@ -400,6 +400,20 @@ void OrchestratorEditorTypeSelector::setup(const String& p_cache_suffix, bool p_
     _user_exclusions = p_exclusions;
 }
 
+void OrchestratorEditorTypeSelector::_notification(int p_what) {
+    switch (p_what) {
+        case NOTIFICATION_VISIBILITY_CHANGED: {
+            if (is_visible_in_tree()) {
+                // Hack to handle popup in component panel
+                if (cast_to<AcceptDialog>(get_parent())) {
+                    _left_type->grab_focus();
+                }
+            }
+            break;
+        }
+    }
+}
+
 void OrchestratorEditorTypeSelector::_bind_methods() {
     ADD_SIGNAL(MethodInfo("changed", PropertyInfo(Variant::DICTIONARY, "property")));
 }

--- a/src/editor/inspector/properties/type_selector.h
+++ b/src/editor/inspector/properties/type_selector.h
@@ -77,6 +77,10 @@ class OrchestratorEditorTypeSelector : public HBoxContainer {
 protected:
     static void _bind_methods();
 
+    //~ Begin Wrapped Interface
+    void _notification(int p_what);
+    //~ End Wrapped Interface
+
 public:
 
     void set_property(const PropertyInfo& p_property);


### PR DESCRIPTION
Fixes GH-1712

## Description

When the `OrchestratorEditorTypeSelector` popup is made visible when changing the variable type from the component panel, the first type drop-down will be the focus, allowing the use of enter/space to trigger the type selection dialog.