### PR TITLE
[ci] Update cache-warmer to `main`, `2.5`, and `2.4` only

### DIFF
--- a/.github/workflows/cache_warmer.yml
+++ b/.github/workflows/cache_warmer.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        branch: [main, '2.4', '2.3', '2.2']
+        branch: [main, '2.5', '2.4']
     steps:
       - name: Trigger workflow on ${{ matrix.branch }}
         run: |


### PR DESCRIPTION
## Descriptions
Updates the cache-warmer job to refresh current active branches only.