### PR TITLE
GH-1734 Exclude `__base_node_relative` from serialization

### DIFF
--- a/src/orchestration/serialization/binary/binary_serializer.cpp
+++ b/src/orchestration/serialization/binary/binary_serializer.cpp
@@ -737,7 +737,7 @@ Error OrchestrationBinarySerializer::save(const Ref<Resource>& p_resource, const
                 continue;
             }
 
-            if (pi.name.match("metadata/_missing_resources")) {
+            if (!_is_property_serialized(pi)) {
                 continue;
             }
 

--- a/src/orchestration/serialization/serializer.cpp
+++ b/src/orchestration/serialization/serializer.cpp
@@ -165,3 +165,7 @@ void OrchestrationSerializer::_find_resources_resource_properties(const Ref<Reso
 
     _saved_resources.push_back(p_resource);
 }
+
+bool OrchestrationSerializer::_is_property_serialized(const PropertyInfo& p_property) const {
+    return !(p_property.name.match("metadata/_missing_resources") || p_property.name.match("metadata/__base_node_relative"));
+}

--- a/src/orchestration/serialization/serializer.h
+++ b/src/orchestration/serialization/serializer.h
@@ -63,6 +63,8 @@ protected:
     virtual void _find_resources_resource(const Ref<Resource>& p_resource, bool p_main) = 0;
     virtual void _find_resources_resource_properties(const Ref<Resource>& p_resource, bool p_main);
 
+    virtual bool _is_property_serialized(const PropertyInfo& p_property) const;
+
 public:
     virtual PackedStringArray get_recognized_extensions(const Ref<Resource>& p_resource) = 0;
     virtual bool recognize(const Ref<Resource>& p_resource) = 0;

--- a/src/orchestration/serialization/text/text_serializer.cpp
+++ b/src/orchestration/serialization/text/text_serializer.cpp
@@ -281,7 +281,7 @@ Error OrchestrationTextSerializer::save(const Ref<Resource>& p_resource, const S
                 continue;
             }
 
-            if (pi.name.match("metadata/_missing_resources")) {
+            if (!_is_property_serialized(pi)) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes GH-1734

## Description

While serializing the `__base_node_relative` is not necessarily going to create problems, it bloats the script for no real gain, and the value that is serialized is purely for editor-side operations in the Inspector. So it makes sense to prevent adding the value as a serialized value if it has been set.

If we add any new properties like this in the future, ideally the best approach would be to remove this from the serializers and instead use an Inspector-level proxy object, where the value can be set on the proxy rather than the underlying serialized object, to keep them separate. But given this is the only use case so far, that seems heavy for this.
