### PR TITLE
GH-1756 Add descriptions for user-defined functions/signals/variables to tooltips

### DIFF
--- a/src/editor/script_components_container.cpp
+++ b/src/editor/script_components_container.cpp
@@ -1018,9 +1018,6 @@ void OrchestratorScriptComponentsContainer::_update_graphs_and_functions() {
                 int function_id = _get_orchestration()->get_function_node_id(script_graph->get_graph_name());
 
                 const Ref<OScriptFunction> function = _get_orchestration()->find_function(script_graph->get_graph_name());
-                if (function.is_valid()) {
-
-                }
                 if (function.is_valid() && !function->is_connected(CoreStringName(changed), callable_mp_this(_functions_changed))) {
                     function->connect(CoreStringName(changed), callable_mp_this(_functions_changed));
                 }
@@ -1034,6 +1031,11 @@ void OrchestratorScriptComponentsContainer::_update_graphs_and_functions() {
                 item->set_meta("__component_type", SCRIPT_FUNCTION);
                 item->set_meta("__node_id", function_id);
                 item->set_meta("__override", function.is_valid() ? !function->is_user_defined() : false);
+
+                if (function.is_valid() && !function->get_description().strip_edges().is_empty()) {
+                    const String tooltip = vformat("%s\n\n%s", function->get_function_name(), function->get_description().strip_edges());
+                    item->set_tooltip_text(0, SceneUtils::create_wrapped_tooltip_text(tooltip));
+                }
             }
         }
     }
@@ -1122,8 +1124,8 @@ void OrchestratorScriptComponentsContainer::_update_variables() {
             item->add_button(0, class_icon, 2, false, "Change variable type");
         }
 
-        if (!variable->get_description().is_empty()) {
-            const String tooltip = variable->get_variable_name() + "\n\n" + variable->get_description();
+        if (!variable->get_description().strip_edges().is_empty()) {
+            const String tooltip = vformat("%s\n\n%s", variable->get_variable_name(), variable->get_description().strip_edges());
             item->set_tooltip_text(0, SceneUtils::create_wrapped_tooltip_text(tooltip));
         }
 
@@ -1166,8 +1168,15 @@ void OrchestratorScriptComponentsContainer::_update_signals() {
     const Ref<Texture2D> signal_icon = SceneUtils::get_editor_icon("MemberSignal");
     for (const String& signal_name: signal_names) {
         const Ref<OScriptSignal> signal = _get_orchestration()->get_custom_signal(signal_name);
-        TreeItem* item = _signals->add_tree_item(signal->get_signal_name(), signal_icon);
-        item->set_meta("__component_type", SCRIPT_SIGNAL);
+        if (signal.is_valid()) {
+            TreeItem* item = _signals->add_tree_item(signal->get_signal_name(), signal_icon);
+            item->set_meta("__component_type", SCRIPT_SIGNAL);
+
+            if (!signal->get_description().strip_edges().is_empty()) {
+                String tooltip = vformat("%s\n\n%s", signal->get_signal_name(), signal->get_description().strip_edges());
+                item->set_tooltip_text(0, SceneUtils::create_wrapped_tooltip_text(tooltip));
+            }
+        }
     }
 }
 

--- a/src/orchestration/nodes/call_function.cpp
+++ b/src/orchestration/nodes/call_function.cpp
@@ -623,7 +623,13 @@ void OScriptNodeCallScriptFunction::post_placed_new_node() {
 }
 
 String OScriptNodeCallScriptFunction::get_tooltip_text() const {
-    return vformat("Target is %s", get_orchestration()->get_base_type());
+    String tooltip = "Calls the method " + _reference.method.name;
+    if (!_function.is_valid() || _function->get_description().strip_edges().is_empty()) {
+        return tooltip;
+    }
+
+    tooltip += "\n\nDescription:\n" + _function->get_description().strip_edges();
+    return tooltip;
 }
 
 String OScriptNodeCallScriptFunction::get_node_title() const {

--- a/src/orchestration/nodes/emit_signal.cpp
+++ b/src/orchestration/nodes/emit_signal.cpp
@@ -114,11 +114,17 @@ void OScriptNodeEmitSignal::allocate_default_pins() {
 }
 
 String OScriptNodeEmitSignal::get_tooltip_text() const {
-    if (_signal.is_valid()) {
-        return vformat("Emit the signal '%s'", _signal->get_signal_name());
-    } else {
+    if (_signal_name.is_empty()) {
         return "Emits a Godot signal with optional arguments";
     }
+
+    String tooltip = "Emit the signal '" + _signal_name + "'";
+    if (!_signal.is_valid() || _signal->get_description().strip_edges().is_empty()) {
+        return tooltip;
+    }
+
+    tooltip += "\n\nDescription:\n" + _signal->get_description().strip_edges();
+    return tooltip;
 }
 
 String OScriptNodeEmitSignal::get_node_title() const {

--- a/src/orchestration/nodes/variables.cpp
+++ b/src/orchestration/nodes/variables.cpp
@@ -167,15 +167,17 @@ void OScriptNodeVariableGet::allocate_default_pins() {
 }
 
 String OScriptNodeVariableGet::get_tooltip_text() const {
-    if (_variable.is_valid()) {
-        String tooltip_text = vformat("Read the value of variable %s", _variable->get_variable_name());
-        if (!_variable->get_description().is_empty()) {
-            tooltip_text += "\n\nDescription:\n" + _variable->get_description();
-        }
-        return tooltip_text;
+    if (_variable_name.is_empty()) {
+        return "Read the value of a variable";
     }
 
-    return "Read the value of a variable";
+    String tooltip = "Read the value of variable " + _variable_name;
+    if (!_variable.is_valid() || _variable->get_description().strip_edges().is_empty()) {
+        return tooltip;
+    }
+
+    tooltip += "\n\nDescription:\n" + _variable->get_description().strip_edges();
+    return tooltip;
 }
 
 String OScriptNodeVariableGet::get_node_title() const {
@@ -297,15 +299,17 @@ void OScriptNodeVariableSet::allocate_default_pins() {
 }
 
 String OScriptNodeVariableSet::get_tooltip_text() const {
-    if (_variable.is_valid()) {
-        String tooltip_text = vformat("Set the value of variable %s", _variable->get_variable_name());
-        if (!_variable->get_description().is_empty()) {
-            tooltip_text += "\n\nDescription:\n" + _variable->get_description();
-        }
-        return tooltip_text;
+    if (_variable_name.is_empty()) {
+        return "Set the value of a variable";
     }
 
-    return vformat("Set the value of a variable");
+    String tooltip = "Set the value of variable " + _variable_name;
+    if (!_variable.is_valid() || _variable->get_description().is_empty()) {
+        return tooltip;
+    }
+
+    tooltip += "\n\nDescription:\n" + _variable->get_description().strip_edges();
+    return tooltip;
 }
 
 String OScriptNodeVariableSet::get_node_title() const {


### PR DESCRIPTION
Fixes GH-1756

## Descriptions

Uniformly shows user-defined descriptions for variables, signals, and functions on script call function nodes, signal emitter nodes, and variable get/set nodes, and in the component panel hover tooltips for all 3 types.