### PR TITLE
GH-854 Disable "Ignore Asset Root" on AssetStore/Lib Install

### DIFF
--- a/.github/actions/orchestrator-build/action.yml
+++ b/.github/actions/orchestrator-build/action.yml
@@ -117,14 +117,50 @@ runs:
         cp '${{ github.workspace }}/README.md' '${{ github.workspace }}/project/addons/orchestrator/'
         cp '${{ github.workspace }}/LICENSE' '${{ github.workspace }}/project/addons/orchestrator/'
 
-    # Creates a demo archive of this specific build, including only the "project" subfolder
+    # DO NOT REMOVE -- this file is load-bearing, see GH-854.
+    #
+    # Godot's asset installer (EditorAssetInstaller::_check_has_toplevel) enables its
+    # "Ignore asset root" toggle only when every entry in the archive shares a single
+    # common root directory, and the AssetLib download path ticks that toggle by default.
+    # With `addons/` as the sole root, Godot strips it and installs Orchestrator into
+    # `res://orchestrator/`, where the .gdextension library paths no longer resolve.
+    #
+    # Placing any second entry at the archive root makes that check bail out, which
+    # disables the toggle entirely so the root can never be stripped. The file only has
+    # to exist in the archive; the user is free to leave it unchecked when installing.
+    #
+    # It must live under `project/` so that actions/upload-artifact keeps the archive
+    # rooted there. A file outside `project/` would raise the least-common-ancestor to
+    # the workspace and nest everything under a `project/` folder instead.
+    - name: Prepare asset root marker
+      shell: bash
+      run: |
+        cat > '${{ github.workspace }}/project/ORCHESTRATOR-README.md' <<'EOF'
+        # Orchestrator
+
+        Orchestrator was installed into `res://addons/orchestrator/`.
+
+        **This file is safe to delete.** It is not part of the plug-in.
+
+        It is shipped at the root of the distribution archive so that Godot's asset
+        installer cannot strip the `addons/` directory. Without it, installing from the
+        AssetLib places the plug-in in `res://orchestrator/`, where its GDExtension
+        library paths do not resolve and the plug-in silently fails to load.
+
+        See https://github.com/CraterCrash/godot-orchestrator/issues/854
+        EOF
+
+    # Creates a demo archive of this specific build, including only the "project" subfolder.
+    # The demo is a full project, so its archive root already holds several entries and it
+    # is unaffected by GH-854 -- the asset root marker is excluded to keep it clean.
     - name: Upload artifact (Demo)
       uses: actions/upload-artifact@v7
       with:
         name: ${{ github.event.repository.name }}-demo-${{ inputs.artifact-name }}
         retention-days: 1
-        path:
+        path: |
           ${{ github.workspace }}/project/
+          !${{ github.workspace }}/project/ORCHESTRATOR-README.md
 
     # Creates the distribution plugin
     - name: Upload artifact (Plug-in)

--- a/.github/workflows/artifact_builds.yml
+++ b/.github/workflows/artifact_builds.yml
@@ -14,10 +14,12 @@ jobs:
           - name: Build demo artifact
             pattern: ${{ github.event.repository.name }}-demo-*
             upload-name: ${{ github.event.repository.name }}-demo
+            verify-asset-root: false
 
           - name: Build plug-in artifact
             pattern: ${{ github.event.repository.name }}-plugin-*
             upload-name: ${{ github.event.repository.name }}-plugin
+            verify-asset-root: true
 
     steps:
 
@@ -26,6 +28,32 @@ jobs:
         with:
           pattern: ${{ matrix.pattern }}
           merge-multiple: true
+
+      # Guards the GH-854 fix. The distribution archive must contain at least one entry
+      # alongside `addons/` at its root, otherwise Godot's asset installer offers to strip
+      # `addons/` -- and does so by default when installing from the AssetLib -- landing
+      # the plug-in in `res://orchestrator/` where it cannot load. The marker is generated
+      # by the "Prepare asset root marker" step in .github/actions/orchestrator-build.
+      - name: Verify asset root layout
+        if: matrix.verify-asset-root
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -d addons/orchestrator ]; then
+            echo "::error::Distribution archive is missing addons/orchestrator/."
+            exit 1
+          fi
+          if [ ! -f ORCHESTRATOR-README.md ]; then
+            echo "::error::Distribution archive is missing the ORCHESTRATOR-README.md asset root marker (see GH-854)."
+            exit 1
+          fi
+          entries=$(find . -mindepth 1 -maxdepth 1 | wc -l)
+          if [ "$entries" -lt 2 ]; then
+            echo "::error::Distribution archive has a single root entry; Godot's AssetLib would strip it (see GH-854)."
+            find . -mindepth 1 -maxdepth 1
+            exit 1
+          fi
+          echo "Asset root layout OK (${entries} root entries)."
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Fixes GH-854

## Description

In Godot, when the top-level directory in an asset contains two or more files/directories, Godot automatically disables the "Ignore Asset Root", leaving it unchecked. This is a guard that should prevent users from misinstalling the plugin through the Asset Store/Library, whether via download or manual imports.
