### PR TITLE
GH-1416 Allow variable types to use OScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ project/addons/orchestrator/~orchestrator*.*
 
 # Test files
 project/tests
+project-playground/
 
 # Imported translations (automatically generated from CSV files)
 *.translation

--- a/src/editor/gui/select_class_dialog.cpp
+++ b/src/editor/gui/select_class_dialog.cpp
@@ -116,6 +116,33 @@ Vector<Ref<OrchestratorEditorSearchDialog::SearchItem>> OrchestratorSelectClassS
     return items;
 }
 
+bool OrchestratorSelectClassSearchDialog::_is_class_excluded(const String& p_class_name) const {
+    if (_excluded_classes.has(p_class_name)) {
+        return true;
+    }
+
+    if (p_class_name.begins_with(OScript::get_class_static()) || p_class_name.begins_with("Orchestrator")) {
+        if (p_class_name != OScript::get_class_static()) {
+            return true;
+        }
+    }
+
+    if (_base_type == p_class_name) {
+        return true;
+    }
+
+    if (_is_base_type_node && p_class_name.begins_with("Editor")) {
+        return true;
+    }
+
+    // An internal class for the editor
+    if (p_class_name.match("MissingNode") || p_class_name.match("MissingResource")) {
+        return true;
+    }
+
+    return false;
+}
+
 bool OrchestratorSelectClassSearchDialog::_is_preferred(const String& p_item) const {
     if (ClassDB::class_exists(p_item)) {
         return ClassDB::is_parent_class(p_item, _preferred_search_result_type);
@@ -157,24 +184,9 @@ Vector<Ref<OrchestratorEditorSearchDialog::SearchItem>> OrchestratorSelectClassS
 
     // Classes
     for (const String& class_name : ClassDB::get_class_list()) {
-        // Exclude Orchestrator Types
-        if (class_name.begins_with("OScript") || class_name.begins_with("Orchestrator")) {
+        if (_is_class_excluded(class_name)) {
             continue;
         }
-
-        if (_base_type == class_name) {
-            continue;
-        }
-
-        if (_is_base_type_node && class_name.begins_with("Editor")) {
-            continue;
-        }
-
-        // An internal class for the editor
-        if (class_name.match("MissingNode") || class_name.match("MissingResource")) {
-            continue;
-        }
-
         items.append_array(_get_class_hierarchy_search_items(class_name, hierarchy_cache, root));
     }
 
@@ -268,4 +280,10 @@ void OrchestratorSelectClassSearchDialog::set_allow_abstract_types(bool p_allow_
 
 void OrchestratorSelectClassSearchDialog::set_popup_title(const String& p_title) {
     _title = p_title;
+}
+
+void OrchestratorSelectClassSearchDialog::add_class_exclusion(const String& p_class_name) {
+    if (!_excluded_classes.has(p_class_name)) {
+        _excluded_classes.push_back(p_class_name);
+    }
 }

--- a/src/editor/gui/select_class_dialog.h
+++ b/src/editor/gui/select_class_dialog.h
@@ -33,6 +33,7 @@ class OrchestratorSelectClassSearchDialog : public OrchestratorEditorSearchDialo
     String _preferred_search_result_type;
     String _data_suffix;
     String _title;
+    PackedStringArray _excluded_classes;
 
     /// Creates the class hierarchy path, i.e. "Parent/Child/GrandChild"
     /// @param p_class the class name
@@ -50,6 +51,11 @@ class OrchestratorSelectClassSearchDialog : public OrchestratorEditorSearchDialo
     /// @param r_cache the seearch item cache
     /// @param p_root the root search item
     Vector<Ref<SearchItem>> _get_class_hierarchy_search_items(const String& p_class, HashMap<String, Ref<SearchItem>>& r_cache, const Ref<SearchItem>& p_root);
+
+    /// Specifies whether the native class name is excluded
+    /// @param p_class_name the native class name
+    /// @return true to exclude the class, false otherwise
+    bool _is_class_excluded(const String& p_class_name) const;
 
 protected:
     static void _bind_methods() { }
@@ -91,4 +97,7 @@ public:
     /// @param p_title the title to display
     void set_popup_title(const String& p_title);
 
+    /// Adds a class as an exclusion
+    /// @param p_class_name the class name
+    void add_class_exclusion(const String& p_class_name);
 };

--- a/src/editor/inspector/properties/editor_property_extends.cpp
+++ b/src/editor/inspector/properties/editor_property_extends.cpp
@@ -25,6 +25,7 @@
 #include "editor/gui/dialogs_helper.h"
 #include "editor/gui/file_dialog.h"
 #include "editor/gui/select_class_dialog.h"
+#include "script/script.h"
 #include "script/script_server.h"
 
 #include <godot_cpp/classes/editor_file_dialog.hpp>
@@ -130,6 +131,8 @@ void OrchestratorEditorPropertyExtends::_notification(int p_what) {
 
             _dialog = memnew(OrchestratorSelectClassSearchDialog);
             _dialog->set_data_suffix("extends");
+            // Prevent extending OScript
+            _dialog->add_class_exclusion(OScript::get_class_static());
             _dialog->connect("selected", callable_mp_this(_extends_class_selected));
             add_child(_dialog);
 


### PR DESCRIPTION
Fixes GH-1416

## Description

Previously, variables could not be typed as `OScript`, and the only supertype that could be used was `ScriptExtension` or `Script`. This changes that to allow variables to be typed as `OScript`.

### Note

An `OScript` is not the orchestration; it's the script interface that wraps the `Orchestration`. Currently, an `Orchestration` is considered an editor-only internal construct.

