### PR TITLE
GH-1783 Auto-focus newly added argument name

### DIFF
--- a/src/editor/inspector/properties/editor_property_pin_properties.cpp
+++ b/src/editor/inspector/properties/editor_property_pin_properties.cpp
@@ -29,6 +29,31 @@
 
 #include <godot_cpp/classes/v_box_container.hpp>
 
+void OrchestratorEditorPropertyPinProperties::_focus_name_field(int p_index) {
+    if (p_index < _slots.size()) {
+        _slots[p_index].name->grab_focus();
+        _slots[p_index].name->select_all();
+    }
+}
+
+void OrchestratorEditorPropertyPinProperties::_focus_pending_name_field() {
+    // Return values use a read-only, fixed name field and are never focused.
+    if (_focus_property.is_empty() || !_args) {
+        return;
+    }
+
+    // Keyed by name rather than index because rearranging reorders the property list.
+    for (int index = 0; index < _properties.size(); ++index) {
+        if (_properties[index].name == _focus_property) {
+            // Deferred because the slot's widgets were only just added to the container.
+            callable_mp_this(_focus_name_field).call_deferred(index);
+            break;
+        }
+    }
+
+    _focus_property = StringName();
+}
+
 void OrchestratorEditorPropertyPinProperties::_selector_type_changed(const Dictionary& p_property, int p_index) {
     const PropertyInfo property = DictionaryUtils::to_property(p_property);
     _properties.write[p_index].type = property.type;
@@ -52,6 +77,8 @@ void OrchestratorEditorPropertyPinProperties::_add_property() {
     property.hint = PROPERTY_HINT_NONE;
 
     _properties.push_back(property);
+
+    _focus_property = property.name;
 
     _set_properties();
 }
@@ -224,6 +251,8 @@ void OrchestratorEditorPropertyPinProperties::_update_property() {
 
     _add_button->set_disabled(_properties.size() == _max_entries || is_read_only());
     _update_move_buttons();
+
+    _focus_pending_name_field();
 }
 
 void OrchestratorEditorPropertyPinProperties::setup(bool p_inputs, int p_max_entries) {

--- a/src/editor/inspector/properties/editor_property_pin_properties.h
+++ b/src/editor/inspector/properties/editor_property_pin_properties.h
@@ -51,6 +51,14 @@ class OrchestratorEditorPropertyPinProperties : public EditorProperty {
     int _max_entries = INT_MAX;                              //! Maximum allowed properties
     bool _args = false;                                      //! Represents argument or return value list
     bool _allow_rearrange = false;                           //! Whether move up/down is enabled
+    StringName _focus_property;                              //! Property whose name field should take focus
+
+    /// Focuses and selects the name field of the given slot.
+    /// @param p_index the slot index
+    void _focus_name_field(int p_index);
+
+    /// Focuses the name field of the property queued by a prior add, if any.
+    void _focus_pending_name_field();
 
 protected:
     static void _bind_methods();

--- a/src/orchestration/function.cpp
+++ b/src/orchestration/function.cpp
@@ -117,15 +117,10 @@ bool OScriptFunction::_set(const StringName &p_name, const Variant &p_value)
         _description = p_value;
         result = true;
     } else if (p_name.match("inputs")) {
-        const TypedArray<Dictionary> arguments = p_value;
-        const bool refresh_required = _method.arguments.size() != size_t(arguments.size());
-
+        // The inspector's argument editor adds and removes its own rows, and graph nodes that
+        // reference this function reconstruct from "changed", so a property list refresh here
+        // would only force a full inspector rebuild that discards in-progress edit state.
         set_arguments(p_value);
-
-        if (refresh_required) {
-            notify_property_list_changed();
-        }
-
         return true;
     } else if (p_name.match("outputs")) {
         const TypedArray<Dictionary> results = p_value;

--- a/src/orchestration/signals.cpp
+++ b/src/orchestration/signals.cpp
@@ -66,18 +66,16 @@ bool OScriptSignal::_set(const StringName &p_name, const Variant &p_value) {
         return true;
     } else if (p_name.match("inputs")) {
         TypedArray<Dictionary> properties = p_value;
-        const bool refresh_required = _method.arguments.size() != static_cast<size_t>(properties.size());
 
         _method.arguments.resize(properties.size());
         for (int index = 0; index < properties.size(); ++index) {
             _method.arguments[index] = DictionaryUtils::to_property(properties[index]);
         }
 
+        // The inspector's argument editor adds and removes its own rows, and emit signal nodes
+        // reconstruct from "changed", so a property list refresh here would only force a full
+        // inspector rebuild that discards in-progress edit state.
         emit_changed();
-
-        if (refresh_required) {
-            notify_property_list_changed();
-        }
 
         return true;
     }


### PR DESCRIPTION
Fixes GH-1783

## Description

Automatically focus the function/signal argument name field after adding a new argument.