### PR TITLE
GH-1788 Preserve component category state across edits

### DIFF
--- a/src/editor/script_components_container.cpp
+++ b/src/editor/script_components_container.cpp
@@ -1049,8 +1049,20 @@ void OrchestratorScriptComponentsContainer::_update_macros() {
     _macros->add_tree_empty_item("No macros defined");
 }
 
+void OrchestratorScriptComponentsContainer::_save_category_state(TreeItem* p_item) {
+    // One need to save state for items that have children, currently only variables
+    if (p_item->has_meta("__name") && p_item->get_child_count() > 0) {
+        const String category_name = p_item->get_meta("__name");
+        _category_states[category_name] = p_item->is_collapsed();
+    }
+}
+
 void OrchestratorScriptComponentsContainer::_update_variables() {
     ERR_FAIL_COND_MSG(!_orchestration.is_valid(), "Orchestration is invalid");
+
+    // The panel is rebuilt on any orchestration change, so the collapsed state of the
+    // categories must be remembered and reapplied below.
+    _variables->for_each_item(callable_mp_this(_save_category_state));
 
     _variables->clear_tree();
 
@@ -1080,6 +1092,9 @@ void OrchestratorScriptComponentsContainer::_update_variables() {
     for (const String& category_name : category_names) {
         TreeItem* item = _variables->add_tree_item(category_name);
         if (item) {
+            if (const bool* collapsed = _category_states.getptr(category_name)) {
+                item->set_collapsed(*collapsed);
+            }
             categories[category_name] = item;
         }
     }

--- a/src/editor/script_components_container.h
+++ b/src/editor/script_components_container.h
@@ -22,6 +22,7 @@
 #include <godot_cpp/classes/button.hpp>
 #include <godot_cpp/classes/scroll_container.hpp>
 #include <godot_cpp/classes/tree_item.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
 
 using namespace godot;
 
@@ -77,6 +78,8 @@ class OrchestratorScriptComponentsContainer : public ScrollContainer {
     bool _use_function_friendly_names = false;
     bool _editing = false;
 
+    HashMap<String, bool> _category_states;
+
     Ref<Orchestration> _get_orchestration();
 
     bool _make_inspector_dock_visible() const;
@@ -111,6 +114,7 @@ class OrchestratorScriptComponentsContainer : public ScrollContainer {
     void _find_and_edit_variable(const String& p_variable_name);
     void _update_graphs_and_functions();
     void _update_macros();
+    void _save_category_state(TreeItem* p_item);
     void _update_variables();
     void _update_signals();
     void _update_slots();


### PR DESCRIPTION
Fixes GH-1788

## Description

When placing variables in a group/category, any operation that triggers the component panel to refresh the variables panel will re-expand any group/category that was previously collapsed.

The collapse state is not persisted across sessions, but is preserved within a single session.