### PR TITLE
GH-1795 Preserve local variable name label on refresh

### DIFF
--- a/src/orchestration/nodes/local_variable.cpp
+++ b/src/orchestration/nodes/local_variable.cpp
@@ -70,6 +70,22 @@ void OScriptNodeLocalVariable::post_initialize() {
     super::post_initialize();
 }
 
+void OScriptNodeLocalVariable::reallocate_pins_during_reconstruction(const Vector<Ref<OScriptNodePin>>& p_old_pins) {
+    super::reallocate_pins_during_reconstruction(p_old_pins);
+
+    // The variable name is stored as the output pin's label, and pin labels are not carried over
+    // when the node's pins are reallocated.
+    const Ref<OScriptNodePin> variable = find_pin("variable", PD_Output);
+    if (variable.is_valid()) {
+        for (const Ref<OScriptNodePin>& old_pin : p_old_pins) {
+            if (old_pin->is_output() && old_pin->get_pin_name().match("variable")) {
+                variable->set_label(old_pin->get_label());
+                break;
+            }
+        }
+    }
+}
+
 void OScriptNodeLocalVariable::allocate_default_pins() {
     // todo: When local variables ported to function-scoped API, handle complex types like objects, enums, bitfields, etc.
     create_pin(PD_Output, PT_Data, PropertyUtils::make_typed("variable", _type));

--- a/src/orchestration/nodes/local_variable.h
+++ b/src/orchestration/nodes/local_variable.h
@@ -37,6 +37,7 @@ protected:
 public:
     //~ Begin OScriptNode Interface
     void post_initialize() override;
+    void reallocate_pins_during_reconstruction(const Vector<Ref<OScriptNodePin>>& p_old_pins) override;
     void allocate_default_pins() override;
     String get_node_title() const override;
     String get_icon() const override;


### PR DESCRIPTION
Fixes GH-1795

## Description

When selecting Refresh Node on a local variable node, or when node reconstruction is triggered, the local variable output pin label (if customized) was lost and reset to `Variable`. This didn't break scripts, but it did cause users to lose context about what the variable was meant to represent.

The fix preserves the label name across refreshes and node reconstruction.
