### PR TITLE
GH-1791 Fix object pin type resolution

### DIFF
--- a/src/common/property_utils.cpp
+++ b/src/common/property_utils.cpp
@@ -73,6 +73,11 @@ namespace PropertyUtils {
         if (p_variant_on_nil && p_type == Variant::NIL) {
             return make_variant(p_name);
         }
+        if (p_type == Variant::OBJECT) {
+            // Godot never encodes an object property without a class name; an object of an unspecified
+            // class is an "Object", whereas an untyped value is a NIL property that is a variant.
+            return make_object(p_name, Object::get_class_static());
+        }
         return { p_type, p_name, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT };
     }
 

--- a/src/common/property_utils.h
+++ b/src/common/property_utils.h
@@ -60,8 +60,10 @@ namespace PropertyUtils {
 
     /// Makes a simple typed property.
     ///
-    /// @note This should not be used to make complex types such as objects, enums, or bitfields, nor
-    /// to construct properties that represent various hinted types such as files or multilined text.
+    /// @note This should not be used to make complex types such as enums or bitfields, nor to
+    /// construct properties that represent various hinted types such as files or multilined text.
+    /// An <code>OBJECT</code> type creates an untyped <code>Object</code> property; use
+    /// <code>make_object</code> instead when the class is known.
     /// @param p_name the property pin name
     /// @param p_type the basic type
     /// @param p_variant_on_nil whether the property should be a variant if the type is NIL

--- a/src/editor/actions/rules/port_rule.cpp
+++ b/src/editor/actions/rules/port_rule.cpp
@@ -140,19 +140,22 @@ void OrchestratorEditorActionPortRule::configure(const OrchestratorEditorGraphPi
     }
     else {
         _type = Variant::VARIANT_MAX;
-        if (!property.class_name.is_empty()) {
-            if (ScriptServer::is_global_class(property.class_name)) {
-                _target_classes = ScriptServer::get_class_hierarchy(property.class_name, true);
-            }
-            else if (p_target) {
-                String class_name = p_target->get_class();
-                while (!class_name.is_empty()) {
-                    _target_classes.push_back(class_name);
-                    class_name = ClassDB::get_parent_class(class_name);
-                }
+
+        // Object pins are not always given a class name, such as a local variable of type Object.
+        // These pins still provide access to the members declared by the Object class itself.
+        String class_name = property.class_name;
+        if (class_name.is_empty() && property.type == Variant::OBJECT) {
+            class_name = Object::get_class_static();
+        }
+
+        if (!class_name.is_empty()) {
+            if (ScriptServer::is_global_class(class_name)) {
+                _target_classes = ScriptServer::get_class_hierarchy(class_name, true);
             }
             else {
-                String class_name = property.class_name;
+                if (p_target) {
+                    class_name = p_target->get_class();
+                }
                 while (!class_name.is_empty()) {
                     _target_classes.push_back(class_name);
                     class_name = ClassDB::get_parent_class(class_name);


### PR DESCRIPTION
Fixes GH-1791

## Description

This introduces two core changes that are worth describing in detail:
* Any pin created by using PropertyUtils::make_typed that is OBJECT and has no concrete type will now automatically set its class_name as `Object`. This makes the behavior consistent with Godot.
* The port rule now falls back and assumes that if a pin has no class_name and its type is of `OBJECT`, the class_name will be inferred as Object. This also makes sure that any old pin without a class_name matches and that the `Get` method is available in the action dialog.