### PR TITLE
GH-1772 Replace SceneTree cast with get_singleton

### DIFF
--- a/src/common/scene_utils.cpp
+++ b/src/common/scene_utils.cpp
@@ -21,7 +21,6 @@
 
 #include <godot_cpp/classes/editor_interface.hpp>
 #include <godot_cpp/classes/editor_settings.hpp>
-#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/font.hpp>
 #include <godot_cpp/classes/image.hpp>
 #include <godot_cpp/classes/image_texture.hpp>
@@ -168,7 +167,7 @@ namespace SceneUtils {
     }
 
     Node* get_scene_base_node(const Ref<Script>& p_script) {
-        if (SceneTree* tree = Object::cast_to<SceneTree>(Engine::get_singleton()->get_main_loop())) {
+        if (SceneTree* tree = SceneTree::get_singleton()) {
             if (Node* root = tree->get_edited_scene_root()) {
                 Vector<Node*> nodes;
                 find_all_nodes_for_script(root, root, p_script, nodes);
@@ -233,7 +232,7 @@ namespace SceneUtils {
     }
 
     Vector<Node*> find_all_nodes_for_script_in_edited_scene(const Ref<Script>& p_script) {
-        SceneTree* scene_tree = Object::cast_to<SceneTree>(Engine::get_singleton()->get_main_loop());
+        SceneTree* scene_tree = SceneTree::get_singleton();
         if (scene_tree) {
             Node* scene_root = scene_tree->get_edited_scene_root();
 

--- a/src/editor/settings/editor_settings.cpp
+++ b/src/editor/settings/editor_settings.cpp
@@ -21,7 +21,6 @@
 
 #include <godot_cpp/classes/editor_interface.hpp>
 #include <godot_cpp/classes/editor_settings.hpp>
-#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/input_event_key.hpp>
 #include <godot_cpp/classes/input_map.hpp>
 #include <godot_cpp/classes/node.hpp>
@@ -302,7 +301,7 @@ bool OrchestratorEditorSettings::is_event_array_equal(const Array& p_a, const Ar
 }
 
 void OrchestratorEditorSettings::notify_changes() { // NOLINT
-    SceneTree* tree = cast_to<SceneTree>(Engine::get_singleton()->get_main_loop());
+    SceneTree* tree = SceneTree::get_singleton();
     if (!tree) {
         return;
     }

--- a/src/orchestration/node_pin.cpp
+++ b/src/orchestration/node_pin.cpp
@@ -26,7 +26,6 @@
 #include "orchestration/orchestration.h"
 #include "script/script_server.h"
 
-#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/scene_tree.hpp>
 #include <godot_cpp/classes/script.hpp>
 
@@ -787,8 +786,7 @@ PackedStringArray OScriptNodePin::resolve_signal_names(bool p_self_fallback) con
         } else if (p_self_fallback) {
             Ref<Script> script = get_owning_node()->get_orchestration()->get_self();
             if (script.is_valid()) {
-                MainLoop* main_loop = Engine::get_singleton()->get_main_loop();
-                if (Node* root = cast_to<SceneTree>(main_loop)->get_edited_scene_root()) {
+                if (Node* root = SceneTree::get_singleton()->get_edited_scene_root()) {
                     if (Node* node = SceneUtils::get_node_with_script(script, root, root)) {
                         const TypedArray<Dictionary> signal_list = node->get_signal_list();
                         for (uint32_t i = 0; i < signal_list.size(); i++) {

--- a/src/orchestration/nodes/print_string.cpp
+++ b/src/orchestration/nodes/print_string.cpp
@@ -21,7 +21,6 @@
 #include "common/settings.h"
 
 #include <godot_cpp/classes/control.hpp>
-#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/margin_container.hpp>
 #include <godot_cpp/classes/node.hpp>
 #include <godot_cpp/classes/rich_text_label.hpp>
@@ -120,13 +119,12 @@ void OScriptNodePrintStringOverlay::add_text(const String& p_text, const String&
     label->append_text(p_text);
     label->pop();
 
-    SceneTree* tree = cast_to<SceneTree>(Engine::get_singleton()->get_main_loop());
-    Ref<SceneTreeTimer> timer = tree->create_timer(p_duration_sec);
+    Ref<SceneTreeTimer> timer = SceneTree::get_singleton()->create_timer(p_duration_sec);
     timer->connect("timeout", callable_mp_cast(label, Node, queue_free));
 }
 
 OScriptNodePrintStringOverlay* OScriptNodePrintStringOverlay::get_or_create_overlay() {
-    SceneTree* tree = cast_to<SceneTree>(Engine::get_singleton()->get_main_loop());
+    SceneTree* tree = SceneTree::get_singleton();
     ERR_FAIL_NULL_V_MSG(tree, nullptr, "Cannot get or create print string overlay, no scene tree was found.");
 
     Node* root = tree->get_root();

--- a/src/orchestration/nodes/properties.cpp
+++ b/src/orchestration/nodes/properties.cpp
@@ -22,7 +22,6 @@
 #include "orchestration/orchestration.h"
 #include "script/script_server.h"
 
-#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/node.hpp>
 #include <godot_cpp/classes/scene_tree.hpp>
 
@@ -220,7 +219,7 @@ String OScriptNodeProperty::get_help_topic() const {
         case CALL_SELF:
             return vformat("class_property:%s:%s", get_orchestration()->get_base_type(), _property.name);
         case CALL_NODE_PATH: {
-            if (SceneTree* st = cast_to<SceneTree>(Engine::get_singleton()->get_main_loop())) {
+            if (SceneTree* st = SceneTree::get_singleton()) {
                 Node* node = st->get_edited_scene_root()->get_node_or_null(_node_path);
                 if (node) {
                     return vformat("class_property:%s:%s", node->get_class(), _property.name);

--- a/src/orchestration/nodes/self.cpp
+++ b/src/orchestration/nodes/self.cpp
@@ -21,7 +21,6 @@
 #include "common/scene_utils.h"
 #include "orchestration/orchestration.h"
 
-#include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/scene_tree.hpp>
 #include <godot_cpp/classes/script.hpp>
 
@@ -92,7 +91,7 @@ Ref<OScriptTargetObject> OScriptNodeSelf::resolve_target(const Ref<OScriptNodePi
             // For now look at the current edited scene, and if one exists, try and find the node
             // that has the attached script to refer to as "self". This is just an approximation,
             // as multiple nodes could have the script attached.
-            Node* root = cast_to<SceneTree>(Engine::get_singleton()->get_main_loop())->get_edited_scene_root();
+            Node* root = SceneTree::get_singleton()->get_edited_scene_root();
             if (root) {
                 Node* node = SceneUtils::get_node_with_script(script, root, root);
                 return memnew(OScriptTargetObject(node, false));


### PR DESCRIPTION
Fixes GH-1772

## Description

Replaces various casts of the `Engine::get_main_loop()` to `SceneTree` with its native `get_singleton()` method.