### PR TITLE
GH-1670 Add ForEach for Dictionary collections 

### DIFF
--- a/src/editor/actions/introspector.cpp
+++ b/src/editor/actions/introspector.cpp
@@ -688,6 +688,8 @@ void OrchestratorEditorIntrospector::generate_actions_from_script_nodes(ActionSe
 
     const Dictionary with_break = DictionaryUtils::of({ { "with_break", true } });
     const Dictionary without_break = DictionaryUtils::of({ { "with_break", false } });
+    const Dictionary dict_with_break = DictionaryUtils::of({ { "collection_type", Variant::DICTIONARY }, { "with_break", true } });
+    const Dictionary dict_without_break = DictionaryUtils::of({ { "collection_type", Variant::DICTIONARY }, { "with_break", false } });
     const Dictionary array_data = DictionaryUtils::of({ { "collection_type", Variant::ARRAY },{ "index_type", Variant::NIL } });
 
     // Constants
@@ -738,6 +740,10 @@ void OrchestratorEditorIntrospector::generate_actions_from_script_nodes(ActionSe
         .executions(true).inputs(Variant::ARRAY).outputs(Variant::NIL, Variant::INT).build());
     r_actions.insert(_script_node_builder<OScriptNodeForEach>("Flow Control", "For Each With Break", with_break)
         .executions(true).inputs(Variant::ARRAY).outputs(Variant::NIL, Variant::INT).build());
+    r_actions.insert(_script_node_builder<OScriptNodeForEach>("Flow Control", "For Each Key-Value", dict_without_break)
+        .executions(true).inputs(Variant::DICTIONARY).outputs(Variant::NIL, Variant::NIL).build());
+    r_actions.insert(_script_node_builder<OScriptNodeForEach>("Flow Control", "For Each Key-Value With Break", dict_with_break)
+        .executions(true).inputs(Variant::DICTIONARY).outputs(Variant::NIL, Variant::NIL).build());
     r_actions.insert(_script_node_builder<OScriptNodeForLoop>("Flow Control", "For Loop", without_break)
         .executions(true).inputs(Variant::INT).outputs(Variant::INT).build());
     r_actions.insert(_script_node_builder<OScriptNodeForLoop>("Flow Control", "For Loop With Break", with_break)

--- a/src/editor/actions/introspector.cpp
+++ b/src/editor/actions/introspector.cpp
@@ -35,7 +35,72 @@
 
 #include <godot_cpp/classes/engine.hpp>
 
-HashMap<String, Ref<OScriptNode>> OrchestratorEditorIntrospector::_script_node_cache;
+namespace {
+
+/// The presentation a node class gives for a specific action, read from a pooled node that is
+/// reconfigured on every fetch. The values are copied out so that no caller can hold the node
+/// itself across a later fetch, which would observe another action's configuration.
+struct NodeTemplateInfo {
+    String icon;
+    String tooltip;
+    PackedStringArray keywords;
+    bool experimental = false;
+};
+
+HashMap<String, Ref<OScriptNode>> node_template_cache;
+
+Ref<OScriptNode> get_or_create_node_template(const String& p_node_type, const Dictionary& p_data, bool p_ignore_not_catalogable) {
+    if (!node_template_cache.has(p_node_type)) {
+        const Ref<OScriptNode> node = OScriptNodeFactory::create_node_from_name(p_node_type, nullptr);
+        if (!node.is_valid()) {
+            WARN_PRINT("Failed to create template node with name " + p_node_type);
+            return Ref<OScriptNode>();
+        }
+
+        node_template_cache[p_node_type] = node;
+    }
+
+    const Ref<OScriptNode> node = node_template_cache[p_node_type];
+    if (!node->get_flags().has_flag(OScriptNode::CATALOGABLE) && !p_ignore_not_catalogable) {
+        WARN_PRINT("Node " + p_node_type + " is not catalogable");
+        return Ref<OScriptNode>();
+    }
+
+    // A node class can describe several actions, such as the array and dictionary flavors of the
+    // for-each loop, and the icon, tooltip, and keywords all depend on which one is being
+    // described. The cached node is therefore reconfigured on every fetch rather than left in the
+    // state the previous caller gave it. Applying the data allocates no pins and does not reach
+    // for an orchestration, which a node used this way does not have.
+    OScriptNodeInitContext context;
+    context.user_data = p_data;
+
+    node->configure(context);
+
+    return node;
+}
+
+NodeTemplateInfo get_node_template_info(const String& p_node_type, const Dictionary& p_data = Dictionary(),
+    bool p_ignore_not_catalogable = false) {
+
+    NodeTemplateInfo info;
+
+    const Ref<OScriptNode> node = get_or_create_node_template(p_node_type, p_data, p_ignore_not_catalogable);
+    if (node.is_valid()) {
+        info.icon = node->get_icon();
+        info.tooltip = node->get_tooltip_text();
+        info.keywords = node->get_keywords();
+        info.experimental = node->get_flags().has_flag(OScriptNode::EXPERIMENTAL);
+    }
+
+    return info;
+}
+
+template <typename T>
+NodeTemplateInfo get_node_template_info(const Dictionary& p_data = Dictionary(), bool p_ignore_not_catalogable = false) {
+    return get_node_template_info(T::get_class_static(), p_data, p_ignore_not_catalogable);
+}
+
+} // namespace
 
 void OrchestratorEditorIntrospector::_apply_method_overrides(const String& p_class_name, MethodInfo& r_method) {
     // For Object.connect, override the flags attribute to disable a list of connect flag enum values
@@ -78,8 +143,7 @@ void OrchestratorEditorIntrospector::_register_global_class_static_methods(const
 OrchestratorEditorIntrospector::ActionBuilder OrchestratorEditorIntrospector::_script_node_builder(
     const String& p_node_type, const String& p_category, const String& p_name, const Dictionary& p_data) {
 
-    const Ref<OScriptNode> node_template = _get_or_create_node_template(p_node_type);
-    const bool experimental = node_template->get_flags().has_flag(OScriptNode::EXPERIMENTAL);
+    const NodeTemplateInfo info = get_node_template_info(p_node_type, p_data);
 
     // todo:
     //  for nodes that have static pin configurations, flow control, and many others, it would
@@ -88,33 +152,13 @@ OrchestratorEditorIntrospector::ActionBuilder OrchestratorEditorIntrospector::_s
     //  action, likely relying on a PropertyInfo struct for now.
     return ActionBuilder(p_category, p_name)
         .type(ActionType::ACTION_SPAWN_NODE)
-        .icon(node_template->get_icon())
-        .tooltip(node_template->get_tooltip_text())
-        .keywords(node_template->get_keywords())
+        .icon(info.icon)
+        .tooltip(info.tooltip)
+        .keywords(info.keywords)
         .selectable(true)
         .node_class(p_node_type)
-        .flags(experimental ? Action::FLAG_EXPERIMENTAL : Action::FLAG_NONE)
+        .flags(info.experimental ? Action::FLAG_EXPERIMENTAL : Action::FLAG_NONE)
         .data(p_data);
-}
-
-Ref<OScriptNode> OrchestratorEditorIntrospector::_get_or_create_node_template(const String& p_node_type, bool p_ignore_not_catalogable) {
-    if (!_script_node_cache.has(p_node_type)) {
-        const Ref<OScriptNode> node = OScriptNodeFactory::create_node_from_name(p_node_type, nullptr);
-        if (!node.is_valid()) {
-            WARN_PRINT("Failed to create template node with name " + p_node_type);
-            return Ref<OScriptNode>();
-        }
-
-        _script_node_cache[p_node_type] = node;
-    }
-
-    const Ref<OScriptNode> node = _script_node_cache[p_node_type];
-    if (!node->get_flags().has_flag(OScriptNode::CATALOGABLE) && !p_ignore_not_catalogable) {
-        WARN_PRINT("Node " + p_node_type + " is not catalogable");
-        return Ref<OScriptNode>();
-    }
-
-    return node;
 }
 
 void OrchestratorEditorIntrospector::_create_categories_from_path(ActionSet& r_actions, const String& p_category_path, const String& p_icon) {
@@ -333,8 +377,7 @@ void OrchestratorEditorIntrospector::_get_actions_for_class(const String& p_clas
     }
 
     if (!p_methods.is_empty()) {
-        const Ref<OScriptNodeEvent> event_node = _get_or_create_node_template<OScriptNodeEvent>(true);
-        const Ref<OScriptNodeCallMemberFunction> func_node = _get_or_create_node_template<OScriptNodeCallMemberFunction>();
+        const String member_call_tooltip = get_node_template_info<OScriptNodeCallMemberFunction>().tooltip;
 
         const bool prefer_properties_over_methods = ORCHESTRATOR_GET("interface/editor/actions_menu/prefer_properties_over_methods", false);
 
@@ -373,7 +416,7 @@ void OrchestratorEditorIntrospector::_get_actions_for_class(const String& p_clas
                     ActionBuilder(methods_category, method.name)
                     .type(ActionType::ACTION_CALL_MEMBER_FUNCTION)
                     .icon(_get_method_icon_name(method))
-                    .tooltip(func_node->get_tooltip_text())
+                    .tooltip(member_call_tooltip)
                     .keywords(keywords)
                     .target_class(p_class_name)
                     .selectable(true)
@@ -386,11 +429,11 @@ void OrchestratorEditorIntrospector::_get_actions_for_class(const String& p_clas
     }
 
     if (!p_signals.is_empty()) {
-        const Ref<OScriptNodeEmitSignal> node = _get_or_create_node_template<OScriptNodeEmitSignal>();
+        const NodeTemplateInfo emit_signal_info = get_node_template_info<OScriptNodeEmitSignal>();
         for (int i = 0; i < p_signals.size(); i++) {
             const MethodInfo signal = DictionaryUtils::to_method(p_signals[i]);
 
-            PackedStringArray keywords = node->get_keywords();
+            PackedStringArray keywords = emit_signal_info.keywords;
             keywords.append_array(signal.name.capitalize().to_lower().split(" ", false));
             keywords.append(signal.name);
             keywords.append(p_class_name);
@@ -401,7 +444,7 @@ void OrchestratorEditorIntrospector::_get_actions_for_class(const String& p_clas
                 ActionBuilder(signals_category, vformat("Emit %s", signal.name))
                 .type(ActionType::ACTION_EMIT_MEMBER_SIGNAL)
                 .icon("Signal")
-                .tooltip(node->get_tooltip_text())
+                .tooltip(emit_signal_info.tooltip)
                 .keywords(keywords)
                 .target_class(p_class_name)
                 .selectable(true)
@@ -1124,5 +1167,5 @@ Vector<Ref<OrchestratorEditorIntrospector::Action>> OrchestratorEditorIntrospect
 }
 
 void OrchestratorEditorIntrospector::free_resources() {
-    _script_node_cache.clear();
+    node_template_cache.clear();
 }

--- a/src/editor/actions/introspector.h
+++ b/src/editor/actions/introspector.h
@@ -20,8 +20,6 @@
 #include "editor/actions/definition.h"
 #include "orchestration/node.h"
 
-#include <godot_cpp/templates/hash_map.hpp>
-
 /// A standalone component that is responsible for being able to read and generate a set of actions based on
 /// provided class, object, or script metadata. It also can provide actions based on the visual scripting
 /// language, built-in Godot types, and project configured autoloads.
@@ -34,17 +32,11 @@ class OrchestratorEditorIntrospector {
     using GraphType = Action::GraphType;
     using ActionSet = OrchestratorEditorActionSet;
 
-    static HashMap<String, Ref<OScriptNode>> _script_node_cache;
-
     template <typename T>
     static ActionBuilder _script_node_builder(const String& p_category, const String& p_name, const Dictionary& p_data = Dictionary())
     { return _script_node_builder(T::get_class_static(), p_category, p_name, p_data); }
 
-    template <typename T> static Ref<OScriptNode> _get_or_create_node_template(bool p_ignore_not_catalogable = false)
-    { return _get_or_create_node_template(T::get_class_static(), p_ignore_not_catalogable); }
-
-    static ActionBuilder _script_node_builder(const String& p_node_type, const String& p_name, const String& p_category, const Dictionary& p_data = Dictionary());
-    static Ref<OScriptNode> _get_or_create_node_template(const String& p_node_type, bool p_ignore_not_catalogable = false);
+    static ActionBuilder _script_node_builder(const String& p_node_type, const String& p_category, const String& p_name, const Dictionary& p_data = Dictionary());
     static void _create_categories_from_path(ActionSet& r_actions, const String& p_category_path, const String& p_icon = String());
     static PackedStringArray _get_native_class_hierarchy(const String& p_class_name);
 

--- a/src/orchestration/graph.cpp
+++ b/src/orchestration/graph.cpp
@@ -76,6 +76,8 @@ void OScriptGraph::_set_functions(const TypedArray<int>& p_functions) {
 }
 
 void OScriptGraph::_initialize_node(const Ref<OScriptNode>& p_node, const OScriptNodeInitContext& p_context, const Vector2& p_position) {
+    // Configured first so that initialize, and every override it runs through, sees the node's state.
+    p_node->configure(p_context);
     p_node->initialize(p_context);
 
     if (p_position != Vector2()) {

--- a/src/orchestration/node.h
+++ b/src/orchestration/node.h
@@ -312,7 +312,13 @@ public:
     /// @return true if the user-defined pin can be created, false otherwise
     virtual bool can_create_user_defined_pin(EPinDirection p_direction, String& r_message) { return false; }
 
-    /// Initializes the node from spawner data
+    /// Applies the spawner data to the node's state, without allocating pins or touching the
+    /// owning orchestration. This makes it safe to call on a node that is only being used to
+    /// describe an action, where no orchestration exists to allocate pins against.
+    /// @param p_context the initialization context
+    virtual void configure(const OScriptNodeInitContext& p_context) { }
+
+    /// Initializes the node from spawner data, expecting configure to have already been called.
     /// @param p_context the initialization context
     virtual void initialize(const OScriptNodeInitContext& p_context);
 

--- a/src/orchestration/nodes/call_function.cpp
+++ b/src/orchestration/nodes/call_function.cpp
@@ -483,36 +483,42 @@ String OScriptNodeCallMemberFunction::get_help_topic() const {
     return super::get_help_topic();
 }
 
-void OScriptNodeCallMemberFunction::initialize(const OScriptNodeInitContext& p_context) {
+void OScriptNodeCallMemberFunction::configure(const OScriptNodeInitContext& p_context) {
+    super::configure(p_context);
+
     MethodInfo mi;
-    StringName target_class = get_orchestration()->get_base_type();
+    StringName target_class;
     Variant::Type target_type = Variant::NIL;
-    if (p_context.user_data) {
+
+    if (p_context.user_data && p_context.user_data.value().has("method")) {
         // Built-in types supply target_type (Variant.Type) and "method" (dictionary)
         const Dictionary& data = p_context.user_data.value();
-        if (!data.has("target_type") && !data.has("method")) {
-            ERR_FAIL_MSG("Cannot initialize member function node, missing 'target_type' and 'method'");
-        }
-
-        target_type = VariantUtils::to_type(data["target_type"]);
+        target_type = VariantUtils::to_type(data.get("target_type", Variant::NIL));
         mi = DictionaryUtils::to_method(data["method"]);
-        target_class = "";
     } else if (p_context.method && p_context.class_name) {
         // Class-type member function call, includes 'class_name' and 'method' (MethodInfo)
         mi = p_context.method.value();
         target_class = p_context.class_name.value();
         target_type = Variant::OBJECT;
-    } else {
-        ERR_FAIL_MSG("Cannot initialize member function node, missing attributes.");
     }
-
-    ERR_FAIL_COND_MSG(mi.name.is_empty(), "Failed to initialize CallMemberFunction without a MethodInfo");
 
     _reference.method = mi;
     _reference.target_type = target_type;
     _reference.target_class_name = target_class;
 
+    _function_flags = FF_NONE;
     _set_function_flags(_reference.method);
+}
+
+void OScriptNodeCallMemberFunction::initialize(const OScriptNodeInitContext& p_context) {
+    if (p_context.user_data) {
+        const Dictionary& data = p_context.user_data.value();
+        ERR_FAIL_COND_MSG(!data.has("target_type") && !data.has("method"),
+            "Cannot initialize member function node, missing 'target_type' and 'method'");
+    } else {
+        ERR_FAIL_COND_MSG(!p_context.method || !p_context.class_name,
+            "Cannot initialize member function node, missing attributes.");
+    }
 
     super::initialize(p_context);
 }
@@ -740,16 +746,20 @@ String OScriptNodeCallBuiltinFunction::get_help_topic() const {
     return vformat("class_method:@GlobalScope:%s", _reference.method.name);
 }
 
+void OScriptNodeCallBuiltinFunction::configure(const OScriptNodeInitContext& p_context) {
+    super::configure(p_context);
+
+    const Dictionary data = p_context.user_data.value_or(Dictionary());
+
+    _reference.method = data.has("name") ? DictionaryUtils::to_method(data) : MethodInfo();
+
+    _function_flags = FF_NONE;
+    _set_function_flags(_reference.method);
+}
+
 void OScriptNodeCallBuiltinFunction::initialize(const OScriptNodeInitContext& p_context) {
     ERR_FAIL_COND_MSG(!p_context.user_data, "Failed to initialize BuiltInFunction without data");
-
-    const Dictionary& data = p_context.user_data.value();
-    ERR_FAIL_COND_MSG(!data.has("name"), "MethodInfo is incomplete.");
-
-    const MethodInfo mi = DictionaryUtils::to_method(data);
-    _reference.method = mi;
-
-    _set_function_flags(_reference.method);
+    ERR_FAIL_COND_MSG(!p_context.user_data.value().has("name"), "MethodInfo is incomplete.");
 
     super::initialize(p_context);
 }
@@ -909,15 +919,19 @@ String OScriptNodeCallStaticFunction::get_help_topic() const {
     return super::get_help_topic();
 }
 
+void OScriptNodeCallStaticFunction::configure(const OScriptNodeInitContext& p_context) {
+    super::configure(p_context);
+
+    const Dictionary data = p_context.user_data.value_or(Dictionary());
+
+    _class_name = data.get("class_name", StringName());
+    _method = p_context.method.value_or(MethodInfo());
+}
+
 void OScriptNodeCallStaticFunction::initialize(const OScriptNodeInitContext& p_context) {
     ERR_FAIL_COND_MSG(!p_context.user_data, "Failed to initialize CallStaticFunction without user data");
     ERR_FAIL_COND_MSG(!p_context.method, "Method is missing");
-
-    const Dictionary data = p_context.user_data.value();
-    ERR_FAIL_COND_MSG(!data.has("class_name"), "Data is missing the class name.");
-
-    _class_name = data["class_name"];
-    _method = p_context.method.value();
+    ERR_FAIL_COND_MSG(!p_context.user_data.value().has("class_name"), "Data is missing the class name.");
 
     super::initialize(p_context);
 }

--- a/src/orchestration/nodes/call_function.h
+++ b/src/orchestration/nodes/call_function.h
@@ -173,6 +173,7 @@ public:
     String get_node_title() const override;
     String get_node_title_color_name() const override;
     String get_help_topic() const override;
+    void configure(const OScriptNodeInitContext& p_context) override;
     void initialize(const OScriptNodeInitContext& p_context) override;
     PackedStringArray get_suggestions(const Ref<OScriptNodePin>& p_pin) override;
     //~ End OScriptNode Interface
@@ -290,6 +291,7 @@ public:
     String get_node_title() const override;
     String get_node_title_color_name() const override { return "pure_function_call"; }
     String get_help_topic() const override;
+    void configure(const OScriptNodeInitContext& p_context) override;
     void initialize(const OScriptNodeInitContext& p_context) override;
     bool is_pure() const override { return true; }
     //~ End OScriptNode Interface
@@ -324,6 +326,7 @@ public:
     String get_node_title_color_name() const override { return "function_call"; }
     String get_help_topic() const override;
     String get_icon() const override { return "MemberMethod"; }
+    void configure(const OScriptNodeInitContext& p_context) override;
     void initialize(const OScriptNodeInitContext& p_context) override;
     //~ End OScriptNode Interface
 

--- a/src/orchestration/nodes/compose.cpp
+++ b/src/orchestration/nodes/compose.cpp
@@ -63,13 +63,18 @@ String OScriptNodeCompose::get_icon() const {
     return SceneUtils::get_icon_path("Compose");
 }
 
+void OScriptNodeCompose::configure(const OScriptNodeInitContext& p_context) {
+    super::configure(p_context);
+
+    const Dictionary data = p_context.user_data.value_or(Dictionary());
+
+    _type = VariantUtils::to_type(data.get("type", Variant::NIL));
+}
+
 void OScriptNodeCompose::initialize(const OScriptNodeInitContext& p_context) {
     ERR_FAIL_COND_MSG(!p_context.user_data, "A Compose node requires custom data");
+    ERR_FAIL_COND_MSG(!p_context.user_data.value().has("type"), "Cannot properly initialize compose node, no type specified.");
 
-    const Dictionary& data = p_context.user_data.value();
-    ERR_FAIL_COND_MSG(!data.has("type"), "Cannot properly initialize compose node, no type specified.");
-
-    _type = VariantUtils::to_type(data["type"]);
     super::initialize(p_context);
 }
 
@@ -190,13 +195,14 @@ PackedStringArray OScriptNodeComposeFrom::get_keywords() const {
     return Array::make("combine", "compose", "create", "make", Variant::get_type_name(_type));
 }
 
-void OScriptNodeComposeFrom::initialize(const OScriptNodeInitContext& p_context) {
-    ERR_FAIL_COND_MSG(!p_context.user_data, "A ComposeFrom node requires custom data");
+void OScriptNodeComposeFrom::configure(const OScriptNodeInitContext& p_context) {
+    super::configure(p_context);
 
-    const Dictionary& data = p_context.user_data.value();
-    ERR_FAIL_COND_MSG(!data.has("type"), "Cannot properly initialize compose from node, no type specified.");
+    const Dictionary data = p_context.user_data.value_or(Dictionary());
 
-    _type = VariantUtils::to_type(data["type"]);
+    _type = VariantUtils::to_type(data.get("type", Variant::NIL));
+
+    _constructor_args.clear();
     if (data.has("constructor_args")) {
         const Array constructor_types = data["constructor_args"];
         for (int i = 0; i < constructor_types.size(); i++) {
@@ -204,6 +210,11 @@ void OScriptNodeComposeFrom::initialize(const OScriptNodeInitContext& p_context)
             _constructor_args.push_back(pi);
         }
     }
+}
+
+void OScriptNodeComposeFrom::initialize(const OScriptNodeInitContext& p_context) {
+    ERR_FAIL_COND_MSG(!p_context.user_data, "A ComposeFrom node requires custom data");
+    ERR_FAIL_COND_MSG(!p_context.user_data.value().has("type"), "Cannot properly initialize compose from node, no type specified.");
 
     super::initialize(p_context);
 }

--- a/src/orchestration/nodes/compose.h
+++ b/src/orchestration/nodes/compose.h
@@ -48,6 +48,7 @@ public:
     String get_node_title() const override;
     String get_node_title_color_name() const override { return "pure_function_call"; }
     String get_icon() const override;
+    void configure(const OScriptNodeInitContext& p_context) override;
     void initialize(const OScriptNodeInitContext& p_context) override;
     bool is_pure() const override { return true; }
     //~ End OScriptNode Interface
@@ -81,6 +82,7 @@ public:
     String get_icon() const override;
     String get_help_topic() const override;
     PackedStringArray get_keywords() const override;
+    void configure(const OScriptNodeInitContext& p_context) override;
     void initialize(const OScriptNodeInitContext& p_context) override;
     bool is_pure() const override { return true; }
     //~ End OScriptNode Interface

--- a/src/orchestration/nodes/decompose.cpp
+++ b/src/orchestration/nodes/decompose.cpp
@@ -113,7 +113,9 @@ PackedStringArray OScriptNodeDecompose::get_keywords() const {
     return Array::make("break", "split", "separate", "decompose", Variant::get_type_name(_type));
 }
 
-void OScriptNodeDecompose::initialize(const OScriptNodeInitContext& p_context) {
+void OScriptNodeDecompose::configure(const OScriptNodeInitContext& p_context) {
+    super::configure(p_context);
+
     ERR_FAIL_COND_MSG(!p_context.user_data, "A Decompose node requires custom data");
 
     const Dictionary& data = p_context.user_data.value();
@@ -121,8 +123,6 @@ void OScriptNodeDecompose::initialize(const OScriptNodeInitContext& p_context) {
 
     _type = VariantUtils::to_type(data["type"]);
     _sub_type = static_cast<SubType>(static_cast<int32_t>(data.get("sub_type", ST_NONE)));
-
-    super::initialize(p_context);
 }
 
 void OScriptNodeDecompose::_bind_methods() {

--- a/src/orchestration/nodes/decompose.h
+++ b/src/orchestration/nodes/decompose.h
@@ -67,7 +67,7 @@ public:
     String get_icon() const override;
     String get_help_topic() const override;
     PackedStringArray get_keywords() const override;
-    void initialize(const OScriptNodeInitContext& p_context) override;
+    void configure(const OScriptNodeInitContext& p_context) override;
     bool is_pure() const override { return true; }
     //~ End OScriptNode Interface
 

--- a/src/orchestration/nodes/for_loop.cpp
+++ b/src/orchestration/nodes/for_loop.cpp
@@ -20,6 +20,7 @@
 #include "common/dictionary_utils.h"
 #include "common/macros.h"
 #include "common/property_utils.h"
+#include "common/variant_utils.h"
 
 void OScriptNodeForLoop::_get_property_list(List<PropertyInfo> *r_list) const {
     r_list->push_back(PropertyInfo(Variant::BOOL, "with_break", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
@@ -168,11 +169,15 @@ void OScriptNodeForLoop::_set_with_break(bool p_break_status) {
 
 void OScriptNodeForEach::_get_property_list(List<PropertyInfo>* r_list) const {
     r_list->push_back(PropertyInfo(Variant::BOOL, "with_break", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
+    r_list->push_back(PropertyInfo(Variant::INT, "collection_type", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
 }
 
 bool OScriptNodeForEach::_get(const StringName& p_name, Variant& r_value) const {
     if (p_name.match("with_break")) {
         r_value = _with_break;
+        return true;
+    } else if (p_name.match("collection_type")) {
+        r_value = _collection_type;
         return true;
     }
     return false;
@@ -183,47 +188,53 @@ bool OScriptNodeForEach::_set(const StringName& p_name, const Variant& p_value) 
         _with_break = p_value;
         _notify_pins_changed();
         return true;
+    } else if (p_name.match("collection_type")) {
+        _collection_type = VariantUtils::to_type(p_value);
+        _notify_pins_changed();
+        return true;
     }
     return false;
 }
 
 void OScriptNodeForEach::post_initialize() {
-    bool reconstructed = false;
+    if (_collection_type == Variant::ARRAY) {
+        bool reconstructed = false;
 
-    // Automatically coerces old element pins to using NIL for Any rather than OBJECT
-    Ref<OScriptNodePin> element = find_pin("element", PD_Output);
-    if (element.is_valid() && element->get_type() == Variant::OBJECT) {
-        element->set_type(Variant::NIL);
-    }
+        // Automatically coerces old element pins to using NIL for Any rather than OBJECT
+        Ref<OScriptNodePin> element = find_pin("element", PD_Output);
+        if (element.is_valid() && element->get_type() == Variant::OBJECT) {
+            element->set_type(Variant::NIL);
+        }
 
-    // Fixes issue where a break pin exists but the break status was not persisted
-    if (!_with_break && find_pin("break", PD_Input).is_valid()) {
-        _with_break = true;
-    }
+        // Fixes issue where a break pin exists but the break status was not persisted
+        if (!_with_break && find_pin("break", PD_Input).is_valid()) {
+            _with_break = true;
+        }
 
-    // Automatically adjusts old nodes to having the new aborted node layout
-    if (_with_break && !find_pin("aborted", PD_Output).is_valid()) {
-        reconstruct_node();
-        reconstructed = true;
-
-        // This needs to be delayed until the end of frame due to pin index caching
-        callable_mp_lambda(this, [&,this]() {
-            const Ref<OScriptNodePin> aborted = find_pin("aborted", PD_Output);
-            const Ref<OScriptNodePin> completed = find_pin("completed", PD_Output);
-            if (aborted.is_valid() && completed.is_valid()) {
-                const Vector<Ref<OScriptNodePin>> targets = completed->get_connections();
-                if (!targets.is_empty()) {
-                    aborted->link(targets[0]);
-                }
-            }
-        }).call_deferred();
-    }
-
-    // Fixup - reconstruct element pins
-    if (!reconstructed && element.is_valid()) {
-        if (PropertyUtils::is_nil_no_variant(element->get_property_info())) {
+        // Automatically adjusts old nodes to having the new aborted node layout
+        if (_with_break && !find_pin("aborted", PD_Output).is_valid()) {
             reconstruct_node();
             reconstructed = true;
+
+            // This needs to be delayed until the end of frame due to pin index caching
+            callable_mp_lambda(this, [&,this]() {
+                const Ref<OScriptNodePin> aborted = find_pin("aborted", PD_Output);
+                const Ref<OScriptNodePin> completed = find_pin("completed", PD_Output);
+                if (aborted.is_valid() && completed.is_valid()) {
+                    const Vector<Ref<OScriptNodePin>> targets = completed->get_connections();
+                    if (!targets.is_empty()) {
+                        aborted->link(targets[0]);
+                    }
+                }
+            }).call_deferred();
+        }
+
+        // Fixup - reconstruct element pins
+        if (!reconstructed && element.is_valid()) {
+            if (PropertyUtils::is_nil_no_variant(element->get_property_info())) {
+                reconstruct_node();
+                reconstructed = true;
+            }
         }
     }
 
@@ -232,15 +243,26 @@ void OScriptNodeForEach::post_initialize() {
 
 void OScriptNodeForEach::allocate_default_pins() {
     create_pin(PD_Input, PT_Execution, PropertyUtils::make_exec("ExecIn"));
-    create_pin(PD_Input, PT_Data, PropertyUtils::make_typed("array", Variant::ARRAY))->set_flag(OScriptNodePin::IGNORE_DEFAULT);
+
+    if (_collection_type == Variant::DICTIONARY) {
+        create_pin(PD_Input, PT_Data, PropertyUtils::make_typed("dictionary", Variant::DICTIONARY))->set_flag(OScriptNodePin::IGNORE_DEFAULT);
+    } else {
+        create_pin(PD_Input, PT_Data, PropertyUtils::make_typed("array", Variant::ARRAY))->set_flag(OScriptNodePin::IGNORE_DEFAULT);
+    }
 
     if (_with_break) {
         create_pin(PD_Input, PT_Execution, PropertyUtils::make_exec("break"))->show_label();
     }
 
     create_pin(PD_Output, PT_Execution, PropertyUtils::make_exec("loop_body"))->show_label();
-    create_pin(PD_Output, PT_Data, PropertyUtils::make_variant("element"));
-    create_pin(PD_Output, PT_Data, PropertyUtils::make_typed("index", Variant::INT));
+    if (_collection_type == Variant::DICTIONARY) {
+        create_pin(PD_Output, PT_Data, PropertyUtils::make_variant("key"));
+        create_pin(PD_Output, PT_Data, PropertyUtils::make_variant("value"));
+    } else {
+        create_pin(PD_Output, PT_Data, PropertyUtils::make_variant("element"));
+        create_pin(PD_Output, PT_Data, PropertyUtils::make_typed("index", Variant::INT));
+    }
+
     create_pin(PD_Output, PT_Execution, PropertyUtils::make_exec("completed"))->show_label();
 
     if (_with_break) {
@@ -249,19 +271,32 @@ void OScriptNodeForEach::allocate_default_pins() {
 }
 
 String OScriptNodeForEach::get_tooltip_text() const {
+    if (_collection_type == Variant::DICTIONARY) {
+        return "Executes the 'Loop Body' for each key-value pair in the dictionary.";
+    }
     return "Executes the 'Loop Body' for each element in the array.";
 }
 
 String OScriptNodeForEach::get_node_title() const {
-    return vformat("For Each%s", _with_break ? " With Break" : "");
+    return vformat("For Each%s%s",
+        _collection_type == Variant::DICTIONARY ? " Key-Value" : "",
+        _with_break ? " With Break" : "");
 }
 
 String OScriptNodeForEach::get_icon() const {
     return "Loop";
 }
 
+PackedStringArray OScriptNodeForEach::get_keywords() const {
+    if (_collection_type == Variant::DICTIONARY) {
+        return Array::make("for", "each", "key", "value", "map", "dictionary", "dict", "loop", "range");
+    }
+    return Array::make("for", "each", "loop", "range", "array");
+}
+
 bool OScriptNodeForEach::is_loop_port(int p_port) const {
-    // Body, Index, Element
+    // Array: Body, Index, Element
+    // Dictionary: Body, Key, Value
     return p_port <= 2;
 }
 
@@ -288,9 +323,18 @@ void OScriptNodeForEach::configure(const OScriptNodeInitContext& p_context) {
     const Dictionary data = p_context.user_data.value_or(Dictionary());
 
     _with_break = data.get("with_break", false);
+    _collection_type = VariantUtils::to_type(data.get("collection_type", Variant::ARRAY));
 }
 
 void OScriptNodeForEach::_set_with_break(bool p_break_status) {
     _with_break = p_break_status;
     reconstruct_node();
+}
+
+void OScriptNodeForEach::set_collection_type(Variant::Type p_type) {
+    ERR_FAIL_COND_MSG(p_type != Variant::ARRAY && p_type != Variant::DICTIONARY, "ForEach must be ARRAY or DICTIONARY");
+    if (_collection_type != p_type) {
+        _collection_type = p_type;
+        reconstruct_node();
+    }
 }

--- a/src/orchestration/nodes/for_loop.cpp
+++ b/src/orchestration/nodes/for_loop.cpp
@@ -280,14 +280,14 @@ void OScriptNodeForEach::get_actions(List<Ref<OScriptAction>>& p_action_list) {
     super::get_actions(p_action_list);
 }
 
-void OScriptNodeForEach::initialize(const OScriptNodeInitContext& p_context) {
-    if (p_context.user_data) {
-        const Dictionary& data = p_context.user_data.value();
-        if (data.has("with_break")) {
-            _with_break = data["with_break"];
-        }
-    }
-    super::initialize(p_context);
+void OScriptNodeForEach::configure(const OScriptNodeInitContext& p_context) {
+    super::configure(p_context);
+
+    // Every configurable value is assigned, defaulting the ones the context does not carry, so
+    // that a node describing an action cannot inherit the configuration described before it.
+    const Dictionary data = p_context.user_data.value_or(Dictionary());
+
+    _with_break = data.get("with_break", false);
 }
 
 void OScriptNodeForEach::_set_with_break(bool p_break_status) {

--- a/src/orchestration/nodes/for_loop.h
+++ b/src/orchestration/nodes/for_loop.h
@@ -67,6 +67,7 @@ class OScriptNodeForEach : public OScriptNode
     ORCHESTRATOR_NODE_CLASS(OScriptNodeForEach, OScriptNode);
 
     bool _with_break = false; // Whether break is enabled
+    Variant::Type _collection_type = Variant::ARRAY; // Which collection type is iterated
 
 protected:
     static void _bind_methods() { }
@@ -89,11 +90,14 @@ public:
     String get_node_title() const override;
     String get_node_title_color_name() const override { return "flow_control"; }
     String get_icon() const override;
-    PackedStringArray get_keywords() const override { return Array::make("for", "each", "loop", "range"); }
+    PackedStringArray get_keywords() const override;
     bool is_loop_port(int p_port) const override;
     bool is_loop_break_pin(const Ref<OScriptNodePin>& p_pin) override;
     void get_actions(List<Ref<OScriptAction>>& p_action_list) override;
     void configure(const OScriptNodeInitContext& p_context) override;
     //~ End OScriptNode Interface
+
+    Variant::Type get_collection_type() const { return _collection_type; }
+    void set_collection_type(Variant::Type p_type);
 };
 

--- a/src/orchestration/nodes/for_loop.h
+++ b/src/orchestration/nodes/for_loop.h
@@ -93,7 +93,7 @@ public:
     bool is_loop_port(int p_port) const override;
     bool is_loop_break_pin(const Ref<OScriptNodePin>& p_pin) override;
     void get_actions(List<Ref<OScriptAction>>& p_action_list) override;
-    void initialize(const OScriptNodeInitContext& p_context) override;
+    void configure(const OScriptNodeInitContext& p_context) override;
     //~ End OScriptNode Interface
 };
 

--- a/src/orchestration/nodes/local_variable.cpp
+++ b/src/orchestration/nodes/local_variable.cpp
@@ -112,17 +112,19 @@ bool OScriptNodeLocalVariable::is_compatible_with_graph(const Ref<OScriptGraph>&
     return p_graph->get_flags().has_flag(OScriptGraph::GraphFlags::GF_FUNCTION);
 }
 
+void OScriptNodeLocalVariable::configure(const OScriptNodeInitContext& p_context) {
+    super::configure(p_context);
+
+    const Dictionary data = p_context.user_data.value_or(Dictionary());
+
+    _type = VariantUtils::to_type(data.get("type", Variant::NIL));
+}
+
 void OScriptNodeLocalVariable::initialize(const OScriptNodeInitContext& p_context) {
     ERR_FAIL_COND_MSG(!p_context.user_data, "A local variable node requires a type argument.");
 
-    _type = Variant::NIL;
-
-    const Dictionary data = p_context.user_data.value();
-    if (data.has("type")) {
-        _type = VariantUtils::to_type(data["type"]);
-    }
-
     _guid = Guid::create_guid();
+
     super::initialize(p_context);
 }
 

--- a/src/orchestration/nodes/local_variable.h
+++ b/src/orchestration/nodes/local_variable.h
@@ -45,6 +45,7 @@ public:
     String get_tooltip_text() const override;
     bool is_compatible_with_graph(const Ref<OScriptGraph>& p_graph) const override;
     bool can_duplicate() const override { return false; }
+    void configure(const OScriptNodeInitContext& p_context) override;
     void initialize(const OScriptNodeInitContext& p_context) override;
     bool is_pure() const override { return true; }
     //~ End OScriptNode Interface

--- a/src/orchestration/nodes/memory.cpp
+++ b/src/orchestration/nodes/memory.cpp
@@ -101,14 +101,12 @@ String OScriptNodeNew::get_icon() const {
     return "CurveCreate";
 }
 
-void OScriptNodeNew::initialize(const OScriptNodeInitContext& p_context) {
-    _class_name = "Object";
+void OScriptNodeNew::configure(const OScriptNodeInitContext& p_context) {
+    super::configure(p_context);
 
-    if (p_context.user_data && p_context.user_data.value().has("class_name")) {
-        _class_name = p_context.user_data.value()["class_name"];
-    }
+    const Dictionary data = p_context.user_data.value_or(Dictionary());
 
-    super::initialize(p_context);
+    _class_name = data.get("class_name", "Object");
 }
 
 OScriptNodeNew::OScriptNodeNew() {

--- a/src/orchestration/nodes/memory.h
+++ b/src/orchestration/nodes/memory.h
@@ -45,7 +45,7 @@ public:
     String get_help_topic() const override;
     String get_icon() const override;
     StringName resolve_type_class(const Ref<OScriptNodePin>& p_pin) const override { return _class_name; }
-    void initialize(const OScriptNodeInitContext& p_context) override;
+    void configure(const OScriptNodeInitContext& p_context) override;
     //~ End OScriptNode Interface
 
     String get_allocated_class_name() { return _class_name; }

--- a/src/orchestration/nodes/operator_node.cpp
+++ b/src/orchestration/nodes/operator_node.cpp
@@ -480,19 +480,23 @@ String OScriptNodePromotableOperator::get_help_topic() const {
     return super::get_help_topic();
 }
 
-void OScriptNodePromotableOperator::initialize(const OScriptNodeInitContext& p_context) {
-    ERR_FAIL_COND_MSG(!p_context.user_data, "No data provided to create an Operator node");
+void OScriptNodePromotableOperator::configure(const OScriptNodeInitContext& p_context) {
+    super::configure(p_context);
 
-    const Dictionary& data = p_context.user_data.value();
-    ERR_FAIL_COND_MSG(!data.has("op"), "An operation node requires specify an 'op' value.");
+    const Dictionary data = p_context.user_data.value_or(Dictionary());
 
-    _op = CAST_INT_TO_ENUM(VariantOperators::Code, data["op"]);
-    if (is_unary()) {
-        _operands.push_back(Variant::NIL);
-    } else {
-        _operands.push_back(Variant::NIL);
+    _op = CAST_INT_TO_ENUM(VariantOperators::Code, data.get("op", VariantOperators::OP_EQUAL));
+
+    _operands.clear();
+    _operands.push_back(Variant::NIL);
+    if (!is_unary()) {
         _operands.push_back(Variant::NIL);
     }
+}
+
+void OScriptNodePromotableOperator::initialize(const OScriptNodeInitContext& p_context) {
+    ERR_FAIL_COND_MSG(!p_context.user_data, "No data provided to create an Operator node");
+    ERR_FAIL_COND_MSG(!p_context.user_data.value().has("op"), "An operation node requires specify an 'op' value.");
 
     super::initialize(p_context);
 }

--- a/src/orchestration/nodes/operator_node.h
+++ b/src/orchestration/nodes/operator_node.h
@@ -107,6 +107,7 @@ public:
     String get_node_title_color_name() const override { return "math_operations"; }
     String get_icon() const override { return "Translation"; }
     String get_help_topic() const override;
+    void configure(const OScriptNodeInitContext& p_context) override;
     void initialize(const OScriptNodeInitContext& p_context) override;
     bool is_pure() const override;
     bool can_change_pin_type(const Ref<OScriptNodePin>& p_pin) const override;

--- a/src/script/parser/parser.cpp
+++ b/src/script/parser/parser.cpp
@@ -2533,21 +2533,30 @@ OScriptParser::StatementResult OScriptParser::build_for_each(const Ref<OScriptNo
 
     // todo: need to guard that control flow from the loop does not re-enter the for
 
-    // The ForEach node is a bit unique in that it outputs two values per loop iteration,
-    // the array item and it's index. Right now there is not a clean way to expose both
-    // of these without trade-offs with how the compiler/vm are designed.
+    // The ForEach node is a bit unique in that it outputs two values per loop iteration.
+    // For arrays that pair is the element and its index, and for dictionaries it is the
+    // key and its value. Right now there is not a clean way to expose both of these
+    // without trade-offs with how the compiler/vm are designed.
     //
-    // So the way this works is that if the index-pin is not connected, the ForEach loop
-    // will use the standard "for element in array" syntax by specifying the input array
-    // as the list item in the ForNode. If the index pin is connected, then the list is
-    // populated with a size call and used in a range-based for loop. In addition, the
-    // first operation in the for loop will be to assign the element variable with the
-    // array item using the "element = array[index]" syntax.
+    // Only one of the two outputs can act as the loop variable, so the other is assigned
+    // inside the loop body by subscripting the collection. The second data output, the
+    // index or the value, is what decides the shape of the emitted loop:
     //
+    //  Array, index unused      "for element in array"
+    //  Array, index used        "for index in range(0, array.size())" and "element = array[index]"
+    //  Dictionary, value unused "for key in dictionary"
+    //  Dictionary, value used   "for key in dictionary" and "value = dictionary[key]"
+    //
+    // A dictionary iterates its keys directly, so the range-based rewrite that gives arrays
+    // access to their index is never needed there.
+    //
+    const bool is_dictionary = p_script_node->get_collection_type() == Variant::DICTIONARY;
+    const bool is_second_output_used = p_script_node->find_pin(2, PD_Output)->has_any_connections();
+    const bool is_index_required = !is_dictionary && is_second_output_used;
+
     ExpressionNode* for_list = nullptr;
-    const bool is_index_required = p_script_node->find_pin(2, PD_Output)->has_any_connections();
     if (!is_index_required) {
-        // Uses the simple "for element in array" syntax
+        // Uses the simple "for element in array" or "for key in dictionary" syntax
         for_list = resolve_input(p_script_node->find_pin(1, PD_Input));
     } else {
         ExpressionNode* array = resolve_input(p_script_node->find_pin(1, PD_Input));
@@ -2585,22 +2594,30 @@ OScriptParser::StatementResult OScriptParser::build_for_each(const Ref<OScriptNo
     suite->parent_block = current_suite;
     suite->parent_function = current_function;
 
-    // Setup element variable in nested suite
+    // Setup loop variable in nested suite
     add_local_variable(for_node->variable, suite);
 
-    if (is_index_required) {
-        // Set up the index pin variable, and create assignment operation
-        const String index_name = vformat("for_elem_%d", p_script_node->get_id());
+    if (is_second_output_used) {
+        // The loop variable is the array index when the index pin is used, and otherwise it
+        // is the array element or, for dictionaries, the key.
+        const int loop_variable_port = is_index_required ? 2 : 1;
+        const int subscript_port = is_dictionary ? 2 : 1;
+
+        // Set up the pin variable that is not the loop variable, creating the assignment
+        // operation that reads it back out of the collection.
+        const String subscript_name = is_dictionary
+            ? vformat("for_value_%d", p_script_node->get_id())
+            : vformat("for_elem_%d", p_script_node->get_id());
 
         SubscriptNode* subscript = alloc_node<SubscriptNode>();
         subscript->base = resolve_input(p_script_node->find_pin(1, PD_Input));
         subscript->index = build_identifier(for_node->variable->name, suite);
 
-        VariableNode* index = create_local(index_name, subscript, suite);
-        add_statement(index, suite);
+        VariableNode* subscript_variable = create_local(subscript_name, subscript, suite);
+        add_statement(subscript_variable, suite);
 
-        add_pin_alias(index_name, p_script_node->find_pin(1, PD_Output), suite);
-        add_pin_alias(for_node->variable->name, p_script_node->find_pin(2, PD_Output), suite);
+        add_pin_alias(subscript_name, p_script_node->find_pin(subscript_port, PD_Output), suite);
+        add_pin_alias(for_node->variable->name, p_script_node->find_pin(loop_variable_port, PD_Output), suite);
     } else {
         add_pin_alias(for_node->variable->name, p_script_node->find_pin(1, PD_Output), suite);
     }

--- a/tests/scenes/features/for_each.out
+++ b/tests/scenes/features/for_each.out
@@ -1,0 +1,4 @@
+OSCRIPT_TEST_PASS
+a
+b
+c

--- a/tests/scenes/features/for_each.torch
+++ b/tests/scenes/features/for_each.torch
@@ -1,0 +1,121 @@
+[orchestration type="OScript" load_steps=7 format=4 uid="uid://bforeach0001"]
+
+[obj type="OScriptFunction" id="OScriptFunction_fn"]
+guid = "A1000000-0000-4000-8000-00000000E001"
+method = {
+"name": &"_ready",
+"flags": 8
+}
+id = 0
+
+[obj type="OScriptGraph" id="OScriptGraph_gr"]
+graph_name = &"EventGraph"
+flags = 8
+nodes = Array[int]([0, 1, 2, 3])
+functions = Array[int]([0])
+
+[obj type="OScriptNodeEvent" id="OScriptNodeEvent_evt"]
+function_id = "A1000000-0000-4000-8000-00000000E001"
+id = 0
+position = Vector2(0, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}])
+
+[obj type="OScriptNodeMakeArray" id="OScriptNodeMakeArray_mk"]
+id = 1
+position = Vector2(0, 200)
+pin_data = Array[Dictionary]([{
+"pin_name": &"Element_0",
+"flags": 2,
+"label": "[0]",
+"usage": 131078,
+"dv": "a"
+}, {
+"pin_name": &"Element_1",
+"flags": 2,
+"label": "[1]",
+"usage": 131078,
+"dv": "b"
+}, {
+"pin_name": &"Element_2",
+"flags": 2,
+"label": "[2]",
+"usage": 131078,
+"dv": "c"
+}, {
+"pin_name": &"array",
+"type": 28,
+"dir": 1,
+"flags": 2,
+"dv": []
+}])
+
+[obj type="OScriptNodeForEach" id="OScriptNodeForEach_fe"]
+id = 2
+position = Vector2(300, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}, {
+"pin_name": &"array",
+"type": 28,
+"flags": 10,
+"dv": []
+}, {
+"pin_name": &"loop_body",
+"dir": 1,
+"flags": 516
+}, {
+"pin_name": &"element",
+"dir": 1,
+"flags": 2,
+"usage": 131078
+}, {
+"pin_name": &"index",
+"type": 2,
+"dir": 1,
+"flags": 2,
+"dv": 0
+}, {
+"pin_name": &"completed",
+"dir": 1,
+"flags": 516
+}])
+
+[obj type="OScriptNodeCallBuiltinFunction" id="OScriptNodeCallBuiltinFunction_p1"]
+function_name = &"print"
+flags = 33
+method = {
+"name": &"print",
+"flags": 17,
+"args": [{
+"name": &"arg1",
+"usage": 131078
+}]
+}
+variable_arg_count = 0
+id = 3
+position = Vector2(650, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}, {
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}, {
+"pin_name": &"arg1",
+"flags": 2,
+"usage": 131078
+}])
+
+[resource]
+base_type = &"Node"
+brief_description = "Empty template suitable for all Objects"
+functions = Array[OScriptFunction]([SubResource("OScriptFunction_fn")])
+connections = Array[int]([0, 0, 2, 0, 1, 0, 2, 1, 2, 0, 3, 0, 2, 1, 3, 1])
+nodes = Array[OScriptNode]([SubResource("OScriptNodeEvent_evt"), SubResource("OScriptNodeMakeArray_mk"), SubResource("OScriptNodeForEach_fe"), SubResource("OScriptNodeCallBuiltinFunction_p1")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_gr")])

--- a/tests/scenes/features/for_each.tscn
+++ b/tests/scenes/features/for_each.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3 uid="uid://cforeach0001"]
+
+[ext_resource type="Script" uid="uid://bforeach0001" path="res://scenes/features/for_each.torch" id="1_for_e"]
+
+[node name="ForEach" type="Node"]
+script = ExtResource("1_for_e")

--- a/tests/scenes/features/for_each_with_break.out
+++ b/tests/scenes/features/for_each_with_break.out
@@ -1,0 +1,3 @@
+OSCRIPT_TEST_PASS
+a
+aborted

--- a/tests/scenes/features/for_each_with_break.torch
+++ b/tests/scenes/features/for_each_with_break.torch
@@ -1,0 +1,157 @@
+[orchestration type="OScript" load_steps=8 format=4 uid="uid://bforeach0003"]
+
+[obj type="OScriptFunction" id="OScriptFunction_fn"]
+guid = "A1000000-0000-4000-8000-00000000E003"
+method = {
+"name": &"_ready",
+"flags": 8
+}
+id = 0
+
+[obj type="OScriptGraph" id="OScriptGraph_gr"]
+graph_name = &"EventGraph"
+flags = 8
+nodes = Array[int]([0, 1, 2, 3, 4])
+functions = Array[int]([0])
+
+[obj type="OScriptNodeEvent" id="OScriptNodeEvent_evt"]
+function_id = "A1000000-0000-4000-8000-00000000E003"
+id = 0
+position = Vector2(0, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}])
+
+[obj type="OScriptNodeMakeArray" id="OScriptNodeMakeArray_mk"]
+id = 1
+position = Vector2(0, 200)
+pin_data = Array[Dictionary]([{
+"pin_name": &"Element_0",
+"flags": 2,
+"label": "[0]",
+"usage": 131078,
+"dv": "a"
+}, {
+"pin_name": &"Element_1",
+"flags": 2,
+"label": "[1]",
+"usage": 131078,
+"dv": "b"
+}, {
+"pin_name": &"Element_2",
+"flags": 2,
+"label": "[2]",
+"usage": 131078,
+"dv": "c"
+}, {
+"pin_name": &"array",
+"type": 28,
+"dir": 1,
+"flags": 2,
+"dv": []
+}])
+
+[obj type="OScriptNodeForEach" id="OScriptNodeForEach_fe"]
+with_break = true
+id = 2
+position = Vector2(300, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}, {
+"pin_name": &"array",
+"type": 28,
+"flags": 10,
+"dv": []
+}, {
+"pin_name": &"break",
+"flags": 516
+}, {
+"pin_name": &"loop_body",
+"dir": 1,
+"flags": 516
+}, {
+"pin_name": &"element",
+"dir": 1,
+"flags": 2,
+"usage": 131078
+}, {
+"pin_name": &"index",
+"type": 2,
+"dir": 1,
+"flags": 2,
+"dv": 0
+}, {
+"pin_name": &"completed",
+"dir": 1,
+"flags": 516
+}, {
+"pin_name": &"aborted",
+"dir": 1,
+"flags": 516
+}])
+
+[obj type="OScriptNodeCallBuiltinFunction" id="OScriptNodeCallBuiltinFunction_p1"]
+function_name = &"print"
+flags = 33
+method = {
+"name": &"print",
+"flags": 17,
+"args": [{
+"name": &"arg1",
+"usage": 131078
+}]
+}
+variable_arg_count = 0
+id = 3
+position = Vector2(650, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}, {
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}, {
+"pin_name": &"arg1",
+"flags": 2,
+"usage": 131078
+}])
+
+[obj type="OScriptNodeCallBuiltinFunction" id="OScriptNodeCallBuiltinFunction_p2"]
+function_name = &"print"
+flags = 33
+method = {
+"name": &"print",
+"flags": 17,
+"args": [{
+"name": &"arg1",
+"usage": 131078
+}]
+}
+variable_arg_count = 0
+id = 4
+position = Vector2(650, 300)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}, {
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}, {
+"pin_name": &"arg1",
+"flags": 2,
+"usage": 131078,
+"dv": "aborted"
+}])
+
+[resource]
+base_type = &"Node"
+brief_description = "Empty template suitable for all Objects"
+functions = Array[OScriptFunction]([SubResource("OScriptFunction_fn")])
+connections = Array[int]([0, 0, 2, 0, 1, 0, 2, 1, 2, 0, 3, 0, 2, 1, 3, 1, 3, 0, 2, 2, 2, 4, 4, 0])
+nodes = Array[OScriptNode]([SubResource("OScriptNodeEvent_evt"), SubResource("OScriptNodeMakeArray_mk"), SubResource("OScriptNodeForEach_fe"), SubResource("OScriptNodeCallBuiltinFunction_p1"), SubResource("OScriptNodeCallBuiltinFunction_p2")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_gr")])

--- a/tests/scenes/features/for_each_with_break.tscn
+++ b/tests/scenes/features/for_each_with_break.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3 uid="uid://cforeach0003"]
+
+[ext_resource type="Script" uid="uid://bforeach0003" path="res://scenes/features/for_each_with_break.torch" id="1_for_e"]
+
+[node name="ForEachWithBreak" type="Node"]
+script = ExtResource("1_for_e")

--- a/tests/scenes/features/for_each_with_index.out
+++ b/tests/scenes/features/for_each_with_index.out
@@ -1,0 +1,7 @@
+OSCRIPT_TEST_PASS
+a
+0
+b
+1
+c
+2

--- a/tests/scenes/features/for_each_with_index.torch
+++ b/tests/scenes/features/for_each_with_index.torch
@@ -1,0 +1,148 @@
+[orchestration type="OScript" load_steps=8 format=4 uid="uid://bforeach0002"]
+
+[obj type="OScriptFunction" id="OScriptFunction_fn"]
+guid = "A1000000-0000-4000-8000-00000000E002"
+method = {
+"name": &"_ready",
+"flags": 8
+}
+id = 0
+
+[obj type="OScriptGraph" id="OScriptGraph_gr"]
+graph_name = &"EventGraph"
+flags = 8
+nodes = Array[int]([0, 1, 2, 3, 4])
+functions = Array[int]([0])
+
+[obj type="OScriptNodeEvent" id="OScriptNodeEvent_evt"]
+function_id = "A1000000-0000-4000-8000-00000000E002"
+id = 0
+position = Vector2(0, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}])
+
+[obj type="OScriptNodeMakeArray" id="OScriptNodeMakeArray_mk"]
+id = 1
+position = Vector2(0, 200)
+pin_data = Array[Dictionary]([{
+"pin_name": &"Element_0",
+"flags": 2,
+"label": "[0]",
+"usage": 131078,
+"dv": "a"
+}, {
+"pin_name": &"Element_1",
+"flags": 2,
+"label": "[1]",
+"usage": 131078,
+"dv": "b"
+}, {
+"pin_name": &"Element_2",
+"flags": 2,
+"label": "[2]",
+"usage": 131078,
+"dv": "c"
+}, {
+"pin_name": &"array",
+"type": 28,
+"dir": 1,
+"flags": 2,
+"dv": []
+}])
+
+[obj type="OScriptNodeForEach" id="OScriptNodeForEach_fe"]
+id = 2
+position = Vector2(300, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}, {
+"pin_name": &"array",
+"type": 28,
+"flags": 10,
+"dv": []
+}, {
+"pin_name": &"loop_body",
+"dir": 1,
+"flags": 516
+}, {
+"pin_name": &"element",
+"dir": 1,
+"flags": 2,
+"usage": 131078
+}, {
+"pin_name": &"index",
+"type": 2,
+"dir": 1,
+"flags": 2,
+"dv": 0
+}, {
+"pin_name": &"completed",
+"dir": 1,
+"flags": 516
+}])
+
+[obj type="OScriptNodeCallBuiltinFunction" id="OScriptNodeCallBuiltinFunction_p1"]
+function_name = &"print"
+flags = 33
+method = {
+"name": &"print",
+"flags": 17,
+"args": [{
+"name": &"arg1",
+"usage": 131078
+}]
+}
+variable_arg_count = 0
+id = 3
+position = Vector2(650, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}, {
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}, {
+"pin_name": &"arg1",
+"flags": 2,
+"usage": 131078
+}])
+
+[obj type="OScriptNodeCallBuiltinFunction" id="OScriptNodeCallBuiltinFunction_p2"]
+function_name = &"print"
+flags = 33
+method = {
+"name": &"print",
+"flags": 17,
+"args": [{
+"name": &"arg1",
+"usage": 131078
+}]
+}
+variable_arg_count = 0
+id = 4
+position = Vector2(900, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}, {
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}, {
+"pin_name": &"arg1",
+"flags": 2,
+"usage": 131078
+}])
+
+[resource]
+base_type = &"Node"
+brief_description = "Empty template suitable for all Objects"
+functions = Array[OScriptFunction]([SubResource("OScriptFunction_fn")])
+connections = Array[int]([0, 0, 2, 0, 1, 0, 2, 1, 2, 0, 3, 0, 2, 1, 3, 1, 3, 0, 4, 0, 2, 2, 4, 1])
+nodes = Array[OScriptNode]([SubResource("OScriptNodeEvent_evt"), SubResource("OScriptNodeMakeArray_mk"), SubResource("OScriptNodeForEach_fe"), SubResource("OScriptNodeCallBuiltinFunction_p1"), SubResource("OScriptNodeCallBuiltinFunction_p2")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_gr")])

--- a/tests/scenes/features/for_each_with_index.tscn
+++ b/tests/scenes/features/for_each_with_index.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3 uid="uid://cforeach0002"]
+
+[ext_resource type="Script" uid="uid://bforeach0002" path="res://scenes/features/for_each_with_index.torch" id="1_for_e"]
+
+[node name="ForEachWithIndex" type="Node"]
+script = ExtResource("1_for_e")


### PR DESCRIPTION
Fixes GH-1670

## Description

This PR addresses a latent issue and introduces the Dictionary-based ForEach node.

The latent issue is that the Introspector, the class responsible for All Actions, sometimes reuses the same node template with different context values because it caches templates. Unfortunately, the bug was that the different context applied only when the node was added to the graph, but it did not affect the action item in the dialog window.

For example, searching for a node based on keywords driven by the context, when the same node may be used with different contexts (e.g., Break nodes or the new ForEach for Dictionaries), could return no search results.

The fix was to split configure (metadata) and initialize (pin allocation) into two steps. The introspector can now use the former without the cost of the latter, ensuring the action item is context-specific rather than using the context of the first cache request.

The second commit introduces the new Dictionary-based ForEach node, accepting a `DICTIONARY` input collection and outputs a `Variant` for both the key and value for each pair in the dictionary map.