### PR TITLE
GH-1609 Migrate and store plugin data in `.godot/editor/orchestrator`

### DIFF
--- a/src/common/file_utils.cpp
+++ b/src/common/file_utils.cpp
@@ -18,13 +18,172 @@
 
 #include "common/macros.h"
 
+#include <godot_cpp/classes/config_file.hpp>
+#include <godot_cpp/classes/dir_access.hpp>
 #include <godot_cpp/classes/editor_interface.hpp>
 #include <godot_cpp/classes/editor_paths.hpp>
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/dictionary.hpp>
 
 namespace FileUtils {
-    Ref<FileAccess> open_project_settings_file(const String& p_file_name, FileAccess::ModeFlags p_flags) {
-        const EditorPaths* ep = EI->get_editor_paths();
-        return FileAccess::open(ep->get_project_settings_dir().path_join(p_file_name), p_flags);
+    namespace {
+        /// Maps a ConfigFile backed cache written by earlier Orchestrator versions directly into the
+        /// Godot project settings directory onto its name within the dedicated cache directory.
+        struct LegacyCacheFile {
+            const char* legacy_name;
+            const char* name;
+        };
+
+        constexpr LegacyCacheFile LEGACY_CACHE_FILES[] = {
+            { "orchestrator_editor_cache.cfg", "editor_cache.cfg" },
+            { "orchestrator_metadata.cfg", "metadata.cfg" }
+        };
+
+        /// Maps a line based cache file name prefix written by earlier Orchestrator versions onto the
+        /// metadata section that now holds it. The text trailing the prefix was the caller supplied
+        /// suffix and becomes the key within that section. Action menu caches store a record per
+        /// entry rather than a single value, so they decode differently.
+        struct LegacyCacheList {
+            const char* legacy_prefix;
+            const char* section;
+            bool menu_records;
+        };
+
+        constexpr LegacyCacheList LEGACY_CACHE_LISTS[] = {
+            { "orchestrator_menu_favorites.", "action_favorites", true },
+            { "orchestrator_menu_recents.", "action_recents", true },
+            { "orchestrator_recent_history.", "search_recent_history", false },
+            { "orchestrator_favorites.", "search_favorites", false }
+        };
+
+        /// Returns the directory that holds all Orchestrator editor cache files, creating it when
+        /// it does not yet exist.
+        String _get_editor_cache_dir() {
+            const String path = EI->get_editor_paths()->get_project_settings_dir().path_join("orchestrator");
+            if (!DirAccess::dir_exists_absolute(path)) {
+                DirAccess::make_dir_recursive_absolute(path);
+            }
+            return path;
+        }
+
+        /// Returns whether the text trailing a legacy cache file prefix is a suffix that Orchestrator
+        /// wrote. Suffixes are always plain identifiers, which separates our files from Godot's own
+        /// <code>&lt;file&gt;-folding-&lt;md5&gt;.cfg</code> caches that can share the same prefix.
+        bool _is_cache_file_suffix(const String& p_suffix) {
+            return !p_suffix.contains(".") && !p_suffix.contains("-");
+        }
+
+        /// Reads a legacy line based cache, returning each unique non-empty line in file order.
+        PackedStringArray _read_legacy_values(const Ref<FileAccess>& p_file) {
+            PackedStringArray values;
+            for_each_line(p_file, [&](const String& line) {
+                if (const String trimmed = line.strip_edges(); !trimmed.is_empty()) {
+                    if (!values.has(trimmed)) {
+                        values.push_back(trimmed);
+                    }
+                }
+            });
+            return values;
+        }
+
+        /// Reads a legacy action menu cache. The format is a positive integer format version, a blank
+        /// line, then a four line record per entry holding the action, its description, its icon and a
+        /// blank separator.
+        Array _read_legacy_menu_records(const Ref<FileAccess>& p_file) {
+            PackedStringArray lines;
+            for_each_line(p_file, [&](const String& line) {
+                lines.push_back(line.strip_edges());
+            });
+
+            Array records;
+            if (lines.is_empty() || !lines[0].is_valid_int() || lines[0].to_int() <= 0) {
+                return records;
+            }
+
+            for (int index = 2; (index + 2) < lines.size(); index += 4) {
+                Dictionary record;
+                record["action"] = lines[index];
+                record["description"] = lines[index + 1];
+                record["icon"] = lines[index + 2];
+                records.push_back(record);
+            }
+            return records;
+        }
+
+        /// Moves the ConfigFile backed caches into the dedicated cache directory. These must be in
+        /// place before the line based caches are folded into the metadata file.
+        void _migrate_cache_files(const String& p_legacy_path, const String& p_cache_path) {
+            for (const LegacyCacheFile& legacy : LEGACY_CACHE_FILES) {
+                const String source = p_legacy_path.path_join(legacy.legacy_name);
+                const String target = p_cache_path.path_join(legacy.name);
+
+                if (!FileAccess::file_exists(source) || FileAccess::file_exists(target)) {
+                    continue;
+                }
+
+                DirAccess::rename_absolute(source, target);
+            }
+        }
+
+        /// Folds the line based favorite and history caches into sections of the metadata file,
+        /// discarding each legacy file once it has been read.
+        void _migrate_cache_lists(const String& p_legacy_path, const String& p_metadata_path) {
+            Ref<ConfigFile> metadata(memnew(ConfigFile));
+            metadata->load(p_metadata_path);
+
+            bool changed = false;
+            for (const String& file_name : DirAccess::get_files_at(p_legacy_path)) {
+                for (const LegacyCacheList& legacy : LEGACY_CACHE_LISTS) {
+                    if (!file_name.begins_with(legacy.legacy_prefix)) {
+                        continue;
+                    }
+
+                    const String suffix = file_name.substr(String(legacy.legacy_prefix).length());
+                    if (!_is_cache_file_suffix(suffix)) {
+                        break;
+                    }
+
+                    const String source = p_legacy_path.path_join(file_name);
+
+                    // A cache written without a suffix is unreachable because every dialog and menu
+                    // supplies one, so it is discarded rather than stored under an empty key. An
+                    // already migrated section wins, which keeps a repeated run from undoing edits.
+                    if (!suffix.is_empty() && !metadata->has_section_key(legacy.section, suffix)) {
+                        const Ref<FileAccess> file = FileAccess::open(source, FileAccess::READ);
+                        if (legacy.menu_records) {
+                            if (const Array records = _read_legacy_menu_records(file); !records.is_empty()) {
+                                metadata->set_value(legacy.section, suffix, records);
+                                changed = true;
+                            }
+                        } else {
+                            if (const PackedStringArray values = _read_legacy_values(file); !values.is_empty()) {
+                                metadata->set_value(legacy.section, suffix, values);
+                                changed = true;
+                            }
+                        }
+                    }
+
+                    DirAccess::remove_absolute(source);
+                    break;
+                }
+            }
+
+            if (changed) {
+                metadata->save(p_metadata_path);
+            }
+        }
+    }
+
+    String get_editor_cache_file(const String& p_file_name) {
+        return _get_editor_cache_dir().path_join(p_file_name);
+    }
+
+    void migrate_editor_cache_files() {
+        const String legacy_path = EI->get_editor_paths()->get_project_settings_dir();
+        const String cache_path = _get_editor_cache_dir();
+
+        _migrate_cache_files(legacy_path, cache_path);
+        _migrate_cache_lists(legacy_path, cache_path.path_join("metadata.cfg"));
     }
 
     void for_each_line(const Ref<FileAccess>& p_file, const std::function<void(const String&)>& p_callback) {

--- a/src/common/file_utils.h
+++ b/src/common/file_utils.h
@@ -22,11 +22,18 @@
 using namespace godot;
 
 namespace FileUtils {
-    /// Opens a file in the Godot project's <code>.godot</code> directory.
+    /// Returns the path to a file in Orchestrator's dedicated editor cache directory, creating
+    /// the directory when it does not yet exist.
     /// @param p_file_name the name of the file
-    /// @param p_flags the mode flags to use when opening the file
-    /// @return a reference to the file access object or an invalid reference if the file could not be opened
-    Ref<FileAccess> open_project_settings_file(const String& p_file_name, FileAccess::ModeFlags p_flags);
+    /// @return the absolute path to the file
+    String get_editor_cache_file(const String& p_file_name);
+
+    /// Relocates caches written by earlier Orchestrator versions directly into the Godot project
+    /// settings directory. The ConfigFile backed caches move into the dedicated editor cache
+    /// directory, while the line based favorite and history caches are folded into sections of the
+    /// metadata file and their files discarded. This is safe to call on every start-up; it does
+    /// nothing once no legacy files remain.
+    void migrate_editor_cache_files();
 
     /// For the specified file, reads each line and calls the specified callback function with the line.
     /// @param p_file the file to read

--- a/src/editor/actions/menu.cpp
+++ b/src/editor/actions/menu.cpp
@@ -17,7 +17,6 @@
 #include "editor/actions/menu.h"
 
 #include "common/callable_lambda.h"
-#include "common/file_utils.h"
 #include "common/macros.h"
 #include "common/scene_utils.h"
 #include "common/settings.h"
@@ -25,6 +24,7 @@
 #include "editor/actions/definition.h"
 #include "editor/actions/introspector.h"
 #include "editor/gui/filter_line_edit.h"
+#include "editor/plugins/orchestrator_editor_plugin.h"
 
 #include <godot_cpp/classes/editor_interface.hpp>
 #include <godot_cpp/classes/editor_settings.hpp>
@@ -609,75 +609,46 @@ void OrchestratorEditorActionMenu::_finish_search() {
     get_ok_button()->set_disabled(!_results->get_selected());
 }
 
-void OrchestratorEditorActionMenu::_load_file_into_list(const String& p_filename, ItemList* p_list) {
-    // User data is always store in an encoded way to make it easy to be reloaded.
-    // Format is as follows:
-    //
-    //      [format version]
-    //      [blank]
-    //      [fully qualified action item]
-    //      [description]
-    //      [icon]
-    //      [blank]
-    //      starts next action item...
-    //
+void OrchestratorEditorActionMenu::_load_list_from_metadata(const String& p_section, ItemList* p_list) {
+    // Each entry is stored as a record holding the fully qualified action, the description shown in
+    // the list and the name of its icon.
+    const Array records = OrchestratorPlugin::get_singleton()->get_metadata_value(p_section, _suffix, Array());
+    for (int i = 0; i < records.size(); i++) {
+        const Dictionary record = records[i];
+        const Ref<Texture2D> icon = _get_cached_icon(String(record.get("icon", "")));
 
-    PackedStringArray items;
-    const Ref<FileAccess> favorites = FileUtils::open_project_settings_file(p_filename, FileAccess::READ);
-    FileUtils::for_each_line(favorites, [&](const String& line) {
-        items.push_back(line.strip_edges());
-    });
-
-    if (!items.is_empty()) {
-        const int64_t format = items[0].is_valid_int() ? items[0].to_int() : 0;
-        if (format > 0) {
-            // For now there is no difference in formats, so it's merely a formality
-            for (int index = 2; (index + 2) < items.size(); index += 4) {
-                const String& fully_qualified_action = items[index];
-                const String& description = items[index + 1];
-                const String& icon_name = items[index + 2];
-                const Ref<Texture2D> icon = _get_cached_icon(icon_name);
-
-                const int32_t id = p_list->add_item(description, icon, true);
-                p_list->set_item_metadata(id, fully_qualified_action);
-            }
-        }
+        const int32_t id = p_list->add_item(String(record.get("description", "")), icon, true);
+        p_list->set_item_metadata(id, String(record.get("action", "")));
     }
 }
 
-void OrchestratorEditorActionMenu::_save_list_into_file(ItemList* p_list, const String& p_filename, int64_t p_max) {
-    PackedStringArray items;
-    items.push_back("1");
-    items.push_back("");
+void OrchestratorEditorActionMenu::_save_list_into_metadata(ItemList* p_list, const String& p_section, int64_t p_max) {
+    Array records;
     for (int i = 0; i < p_list->get_item_count(); i++) {
-        items.push_back(p_list->get_item_metadata(i));
-        items.push_back(p_list->get_item_text(i));
-        items.push_back(_get_cached_icon_name(p_list->get_item_icon(i)));
-        items.push_back("");
+        Dictionary record;
+        record["action"] = p_list->get_item_metadata(i);
+        record["description"] = p_list->get_item_text(i);
+        record["icon"] = _get_cached_icon_name(p_list->get_item_icon(i));
+        records.push_back(record);
 
         if (p_max > 0 && i + 1 >= p_max) {
             break;
         }
     }
 
-    const Ref<FileAccess> file = FileUtils::open_project_settings_file(p_filename, FileAccess::WRITE);
-    if (file.is_valid()) {
-        for (const String& line : items) {
-            file->store_line(line);
-        }
-    }
+    OrchestratorPlugin::get_singleton()->set_metadata_value(p_section, _suffix, records);
 }
 
 void OrchestratorEditorActionMenu::_load_user_data() {
-    _load_file_into_list(vformat("orchestrator_menu_favorites.%s", _suffix), _favorites);
-    _load_file_into_list(vformat("orchestrator_menu_recents.%s", _suffix), _recents);
+    _load_list_from_metadata("action_favorites", _favorites);
+    _load_list_from_metadata("action_recents", _recents);
 }
 
 void OrchestratorEditorActionMenu::_save_user_data() {
     constexpr int64_t RECENT_HISTORY_MAX_SIZE = 15;
 
-    _save_list_into_file(_favorites, vformat("orchestrator_menu_favorites.%s", _suffix));
-    _save_list_into_file(_recents, vformat("orchestrator_menu_recents.%s", _suffix), RECENT_HISTORY_MAX_SIZE);
+    _save_list_into_metadata(_favorites, "action_favorites");
+    _save_list_into_metadata(_recents, "action_recents", RECENT_HISTORY_MAX_SIZE);
 }
 
 String OrchestratorEditorActionMenu::_get_cached_icon_name(const Ref<Texture2D>& p_texture) {

--- a/src/editor/actions/menu.h
+++ b/src/editor/actions/menu.h
@@ -155,8 +155,8 @@ class OrchestratorEditorActionMenu : public ConfirmationDialog {
     void _update_search();
     void _finish_search();
 
-    void _load_file_into_list(const String& p_filename, ItemList* p_list);
-    void _save_list_into_file(ItemList* p_list, const String& p_filename, int64_t p_max = -1);
+    void _load_list_from_metadata(const String& p_section, ItemList* p_list);
+    void _save_list_into_metadata(ItemList* p_list, const String& p_section, int64_t p_max = -1);
 
     void _load_user_data();
     void _save_user_data();

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -18,6 +18,7 @@
 
 #include "common/callable_lambda.h"
 #include "common/dictionary_utils.h"
+#include "common/file_utils.h"
 #include "common/macros.h"
 #include "common/resource_utils.h"
 #include "common/scene_utils.h"
@@ -49,7 +50,6 @@
 #include <godot_cpp/classes/editor_file_system.hpp>
 #include <godot_cpp/classes/editor_inspector.hpp>
 #include <godot_cpp/classes/editor_interface.hpp>
-#include <godot_cpp/classes/editor_paths.hpp>
 #include <godot_cpp/classes/editor_settings.hpp>
 #include <godot_cpp/classes/engine.hpp>
 #include <godot_cpp/classes/file_system_dock.hpp>
@@ -1096,13 +1096,11 @@ void OrchestratorEditor::_mark_built_in_scripts_as_saved(const String& p_full_pa
 }
 
 PackedStringArray OrchestratorEditor::_get_recent_scripts() const { // NOLINT
-    const Ref<ConfigFile> metadata = OrchestratorPlugin::get_singleton()->get_metadata();
-    return metadata->get_value("recent_files", "orchestrations", PackedStringArray());
+    return OrchestratorPlugin::get_singleton()->get_metadata_value("recent_files", "orchestrations", PackedStringArray());
 }
 
 void OrchestratorEditor::_set_recent_scripts(const PackedStringArray& p_scripts) { // NOLINT
-    const Ref<ConfigFile> metadata = OrchestratorPlugin::get_singleton()->get_metadata();
-    metadata->set_value("recent_files", "orchestrations", p_scripts);
+    OrchestratorPlugin::get_singleton()->set_metadata_value("recent_files", "orchestrations", p_scripts);
 }
 
 void OrchestratorEditor::_add_recent_script(const String& p_path) {
@@ -1415,6 +1413,21 @@ Array OrchestratorEditor::_get_cached_breakpoints_for_script(const String& p_pat
     }
 
     return state["breakpoints"];
+}
+
+void OrchestratorEditor::_prune_editor_cache() {
+    // Cached state is only dropped when a file is removed or renamed through the FileSystem dock, so
+    // an orchestration deleted outside the editor leaves its section behind permanently. Built-in
+    // scripts are skipped because their paths do not name a standalone file.
+    for (const String& section : _editor_cache->get_sections()) {
+        if (!section.begins_with("res://") || section.contains("::")) {
+            continue;
+        }
+
+        if (!FileAccess::file_exists(section)) {
+            _editor_cache->erase_section(section);
+        }
+    }
 }
 
 void OrchestratorEditor::_window_changed(bool p_visible) {
@@ -2023,7 +2036,7 @@ void OrchestratorEditor::get_window_layout(const Ref<ConfigFile>& r_layout) {
         r_layout->set_value("Orchestrator", E.key, E.value);
     }
 
-    _editor_cache->save(EI->get_editor_paths()->get_project_settings_dir().path_join("orchestrator_editor_cache.cfg"));
+    _editor_cache->save(FileUtils::get_editor_cache_file("editor_cache.cfg"));
 }
 
 void OrchestratorEditor::set_window_layout(const Ref<ConfigFile>& p_layout) {
@@ -2518,7 +2531,8 @@ OrchestratorEditor::OrchestratorEditor(OrchestratorWindowWrapper* p_window_wrapp
     add_child(memnew(OrchestratorEditorConnectionsDock));
 
     _editor_cache.instantiate();
-    _editor_cache->load(EI->get_editor_paths()->get_project_settings_dir().path_join("orchestrator_editor_cache.cfg"));
+    _editor_cache->load(FileUtils::get_editor_cache_file("editor_cache.cfg"));
+    _prune_editor_cache();
 
     _restoring_layout = false;
     _pending_auto_reload = false;

--- a/src/editor/editor.h
+++ b/src/editor/editor.h
@@ -254,6 +254,8 @@ protected:
     void _clear_breakpoints();
     Array _get_cached_breakpoints_for_script(const String& p_path) const;
 
+    void _prune_editor_cache();
+
     void _window_changed(bool p_visible);
     void _tree_changed();
     void _split_dragged(float p_value);

--- a/src/editor/gui/search_dialog.cpp
+++ b/src/editor/gui/search_dialog.cpp
@@ -16,11 +16,11 @@
 //
 #include "editor/gui/search_dialog.h"
 
-#include "common/file_utils.h"
 #include "common/macros.h"
 #include "common/scene_utils.h"
 #include "core/godot/scene_string_names.h"
 #include "editor/gui/filter_line_edit.h"
+#include "editor/plugins/orchestrator_editor_plugin.h"
 
 #include <godot_cpp/classes/button.hpp>
 #include <godot_cpp/classes/editor_interface.hpp>
@@ -402,26 +402,12 @@ Ref<OrchestratorEditorSearchDialog::SearchItem> OrchestratorEditorSearchDialog::
     return {};
 }
 
-PackedStringArray OrchestratorEditorSearchDialog::_read_file_lines(const String& p_file_name) const {
-    PackedStringArray items;
-    const Ref<FileAccess> file = FileUtils::open_project_settings_file(p_file_name, FileAccess::READ);
-    FileUtils::for_each_line(file, [&](const String& line) {
-        if (const String trimmed = line.strip_edges(); !trimmed.is_empty()) {
-            if (!items.has(trimmed)) {
-                items.push_back(trimmed);
-            }
-        }
-    });
-    return items;
+PackedStringArray OrchestratorEditorSearchDialog::_read_cache_values(const String& p_section, const String& p_key) const {
+    return OrchestratorPlugin::get_singleton()->get_metadata_value(p_section, p_key, PackedStringArray());
 }
 
-void OrchestratorEditorSearchDialog::_write_file_lines(const String& p_file_name, const PackedStringArray& p_values) {
-    const Ref<FileAccess> file = FileUtils::open_project_settings_file(p_file_name, FileAccess::WRITE);
-    if (file.is_valid()) {
-        for (const String& item : p_values) {
-            file->store_line(item);
-        }
-    }
+void OrchestratorEditorSearchDialog::_write_cache_values(const String& p_section, const String& p_key, const PackedStringArray& p_values) {
+    OrchestratorPlugin::get_singleton()->set_metadata_value(p_section, p_key, p_values);
 }
 
 void OrchestratorEditorSearchDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String& p_current_type, const String& p_current_name) {

--- a/src/editor/gui/search_dialog.h
+++ b/src/editor/gui/search_dialog.h
@@ -108,15 +108,17 @@ protected:
     /// @return the search item reference, invalid reference if not found
     Ref<SearchItem> _get_search_item_by_name(const String& p_name) const;
 
-    /// Reads contents of the file line by line
-    /// @param p_file_name the file name
-    /// @return an array of recent items
-    PackedStringArray _read_file_lines(const String& p_file_name) const;
+    /// Reads a list of values from the editor metadata
+    /// @param p_section the metadata section
+    /// @param p_key the key within the section
+    /// @return the stored values, empty if the key is not set
+    PackedStringArray _read_cache_values(const String& p_section, const String& p_key) const;
 
-    /// Writes the array of items line-by-line to the given file
-    /// @param p_file_name the file name
+    /// Writes a list of values into the editor metadata
+    /// @param p_section the metadata section
+    /// @param p_key the key within the section
     /// @param p_values the values to write
-    void _write_file_lines(const String& p_file_name, const PackedStringArray& p_values);
+    void _write_cache_values(const String& p_section, const String& p_key, const PackedStringArray& p_values);
 
     /// Get all filters
     /// @return the possible filters

--- a/src/editor/gui/select_class_dialog.cpp
+++ b/src/editor/gui/select_class_dialog.cpp
@@ -202,7 +202,7 @@ Vector<Ref<OrchestratorEditorSearchDialog::SearchItem>> OrchestratorSelectClassS
 
 Vector<Ref<OrchestratorEditorSearchDialog::SearchItem>> OrchestratorSelectClassSearchDialog::_get_recent_items() const {
     Vector<Ref<SearchItem>> items;
-    for (const String& recent_item : _read_file_lines(vformat("orchestrator_recent_history.%s", _data_suffix))) {
+    for (const String& recent_item : _read_cache_values("search_recent_history", _data_suffix)) {
         const Ref<SearchItem> item = _get_search_item_by_name(recent_item);
         if (item.is_valid()) {
             items.push_back(item);
@@ -213,7 +213,7 @@ Vector<Ref<OrchestratorEditorSearchDialog::SearchItem>> OrchestratorSelectClassS
 
 Vector<Ref<OrchestratorEditorSearchDialog::SearchItem>> OrchestratorSelectClassSearchDialog::_get_favorite_items() const {
     Vector<Ref<SearchItem>> items;
-    for (const String& recent_item : _read_file_lines(vformat("orchestrator_favorites.%s", _data_suffix))) {
+    for (const String& recent_item : _read_cache_values("search_favorites", _data_suffix)) {
         const Ref<SearchItem> item = _get_search_item_by_name(recent_item);
         if (item.is_valid()) {
             items.push_back(item);
@@ -231,7 +231,7 @@ void OrchestratorSelectClassSearchDialog::_save_recent_items(const Vector<Ref<Se
         }
     }
 
-    _write_file_lines(vformat("orchestrator_recent_history.%s", _data_suffix), items);
+    _write_cache_values("search_recent_history", _data_suffix, items);
 }
 
 void OrchestratorSelectClassSearchDialog::_save_favorite_items(const Vector<Ref<SearchItem>>& p_favorites) {
@@ -243,7 +243,7 @@ void OrchestratorSelectClassSearchDialog::_save_favorite_items(const Vector<Ref<
         }
     }
 
-    _write_file_lines(vformat("orchestrator_favorites.%s", _data_suffix), items);
+    _write_cache_values("search_favorites", _data_suffix, items);
 }
 
 void OrchestratorSelectClassSearchDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const String& p_current_type, const String& p_current_name) {

--- a/src/editor/gui/select_type_dialog.cpp
+++ b/src/editor/gui/select_type_dialog.cpp
@@ -18,7 +18,6 @@
 
 #include "api/extension_db.h"
 #include "common/dictionary_utils.h"
-#include "common/file_utils.h"
 #include "common/property_utils.h"
 #include "common/scene_utils.h"
 #include "common/string_utils.h"
@@ -442,26 +441,19 @@ Vector<Ref<OrchestratorEditorSearchDialog::SearchItem>> OrchestratorSelectTypeSe
     Vector<Ref<SearchItem>> items;
 
     RBSet<String> recent_items;
-    const Ref<FileAccess> recents = FileUtils::open_project_settings_file(vformat("orchestrator_recent_history.%s", _data_suffix), FileAccess::READ);
-    FileUtils::for_each_line(recents, [&](const String& line) {
-        if (const String trimmed = line.strip_edges(); !trimmed.is_empty()) {
-            if (recent_items.has(trimmed)) {
-                return;
-            }
-
-            const String value = _decode_property_line(trimmed);
-            if (value.is_empty()) {
-                return;
-            }
-
-            recent_items.insert(value);
-
-            const Ref<SearchItem> search_item = _get_search_item_by_property(_string_to_property(value));
-            if (search_item.is_valid()) {
-                items.push_back(search_item);
-            }
+    for (const String& line : _read_cache_values("search_recent_history", _data_suffix)) {
+        const String value = _decode_property_line(line);
+        if (value.is_empty() || recent_items.has(value)) {
+            continue;
         }
-    });
+
+        recent_items.insert(value);
+
+        const Ref<SearchItem> search_item = _get_search_item_by_property(_string_to_property(value));
+        if (search_item.is_valid()) {
+            items.push_back(search_item);
+        }
+    }
 
     return items;
 }
@@ -469,48 +461,50 @@ Vector<Ref<OrchestratorEditorSearchDialog::SearchItem>> OrchestratorSelectTypeSe
 Vector<Ref<OrchestratorEditorSearchDialog::SearchItem>> OrchestratorSelectTypeSearchDialog::_get_favorite_items() const {
     Vector<Ref<SearchItem>> items;
 
-    const Ref<FileAccess> recents = FileUtils::open_project_settings_file(vformat("orchestrator_favorites.%s", _data_suffix), FileAccess::READ);
-    FileUtils::for_each_line(recents, [&](const String& line) {
-        if (const String trimmed = line.strip_edges(); !trimmed.is_empty()) {
-            const String value = _decode_property_line(trimmed);
-            if (value.is_empty()) {
-                return;
-            }
-
-            const Ref<SearchItem> search_item = _get_search_item_by_property(_string_to_property(value));
-            if (search_item.is_valid()) {
-                items.push_back(search_item);
-            }
+    for (const String& line : _read_cache_values("search_favorites", _data_suffix)) {
+        const String value = _decode_property_line(line);
+        if (value.is_empty()) {
+            continue;
         }
-    });
+
+        const Ref<SearchItem> search_item = _get_search_item_by_property(_string_to_property(value));
+        if (search_item.is_valid()) {
+            items.push_back(search_item);
+        }
+    }
 
     return items;
 }
 
 void OrchestratorSelectTypeSearchDialog::_save_recent_items(const Vector<Ref<SearchItem>>& p_recents) {
     RBSet<String> recent_items;
-    Ref<FileAccess> file = FileUtils::open_project_settings_file(vformat("orchestrator_recent_history.%s", _data_suffix), FileAccess::WRITE);
+
+    PackedStringArray values;
     for (const Ref<SearchItem>& item : p_recents) {
-        // Always have a single line per property
+        // Always have a single entry per property
         const String value = _property_to_string(item->property);
-        if (recent_items.has(value)) {
+        if (value.is_empty() || recent_items.has(value)) {
             continue;
         }
-        if (!value.is_empty()) {
-            file->store_line(value);
-        }
+
+        recent_items.insert(value);
+        values.push_back(value);
     }
+
+    _write_cache_values("search_recent_history", _data_suffix, values);
 }
 
 void OrchestratorSelectTypeSearchDialog::_save_favorite_items(const Vector<Ref<SearchItem>>& p_favorites) {
-    Ref<FileAccess> file = FileUtils::open_project_settings_file(vformat("orchestrator_favorites.%s", _data_suffix), FileAccess::WRITE);
+    PackedStringArray values;
     for (const Ref<SearchItem>& item : p_favorites) {
-        // Always have a single line per property
+        // Always have a single entry per property
         const String value = _property_to_string(item->property);
         if (!value.is_empty()) {
-            file->store_line(value);
+            values.push_back(value);
         }
     }
+
+    _write_cache_values("search_favorites", _data_suffix, values);
 }
 
 Vector<OrchestratorEditorSearchDialog::FilterOption> OrchestratorSelectTypeSearchDialog::_get_filters() const {
@@ -595,14 +589,11 @@ bool OrchestratorSelectTypeSearchDialog::_is_filtered(const Ref<SearchItem>& p_i
 }
 
 int OrchestratorSelectTypeSearchDialog::_get_default_filter() const {
-    Ref<ConfigFile> metadata = OrchestratorPlugin::get_singleton()->get_metadata();
-    return metadata->get_value("variable_type_search", "filter", 0);
+    return OrchestratorPlugin::get_singleton()->get_metadata_value("variable_type_search", "filter", 0);
 }
 
 void OrchestratorSelectTypeSearchDialog::_filter_type_changed(int p_index) {
-    Ref<ConfigFile> metadata = OrchestratorPlugin::get_singleton()->get_metadata();
-    metadata->set_value("variable_type_search", "filter", p_index);
-    OrchestratorPlugin::get_singleton()->save_metadata(metadata);
+    OrchestratorPlugin::get_singleton()->set_metadata_value("variable_type_search", "filter", p_index);
 }
 
 PropertyInfo OrchestratorSelectTypeSearchDialog::get_selected() const {

--- a/src/editor/plugins/orchestrator_editor_plugin.cpp
+++ b/src/editor/plugins/orchestrator_editor_plugin.cpp
@@ -16,6 +16,7 @@
 //
 #include "editor/plugins/orchestrator_editor_plugin.h"
 
+#include "common/file_utils.h"
 #include "common/macros.h"
 #include "common/resource_utils.h"
 #include "common/scene_utils.h"
@@ -38,7 +39,6 @@
 #include <godot_cpp/classes/control.hpp>
 #include <godot_cpp/classes/display_server.hpp>
 #include <godot_cpp/classes/dpi_texture.hpp>
-#include <godot_cpp/classes/editor_paths.hpp>
 #include <godot_cpp/classes/editor_settings.hpp>
 #include <godot_cpp/classes/input_event_key.hpp>
 #include <godot_cpp/classes/input_event_mouse_button.hpp>
@@ -50,8 +50,20 @@
 
 OrchestratorPlugin* OrchestratorPlugin::_plugin = nullptr;
 
+/// The layout version of the metadata file. Bump this whenever the sections or keys change shape so
+/// that a later release can recognise and migrate an older file.
+constexpr int64_t METADATA_FORMAT_VERSION = 1;
+
 String OrchestratorPlugin::_get_orchestrator_metedata_path() {
-    return EI->get_editor_paths()->get_project_settings_dir().path_join("orchestrator_metadata.cfg");
+    return FileUtils::get_editor_cache_file("metadata.cfg");
+}
+
+Ref<ConfigFile> OrchestratorPlugin::_get_metadata() {
+    if (_metadata.is_null()) {
+        _metadata.instantiate();
+        _metadata->load(_get_orchestrator_metedata_path());
+    }
+    return _metadata;
 }
 
 void OrchestratorPlugin::_focus_another_editor() {
@@ -191,18 +203,30 @@ void OrchestratorPlugin::_register_shortcuts() {
     oes->register_shortcut("debugger/continue", "Continue", KEY_F12, true);
 }
 
-bool OrchestratorPlugin::_is_plugin_just_installed() const {
+bool OrchestratorPlugin::_is_plugin_just_installed() {
     if (FileAccess::file_exists(_get_orchestrator_metedata_path())) {
         return false;
     }
 
-    Ref<FileAccess> file = FileAccess::open(_get_orchestrator_metedata_path(), FileAccess::WRITE);
-    if (file.is_valid()) {
-        file->close();
-        return true;
+    // Seed the metadata. The marker is the file's existence, so it must carry content; an empty file
+    // is indistinguishable from a cache that a clean-up pass discards.
+    _update_metadata_stamp();
+
+    // Only report a fresh install once the marker is on disk, otherwise a failed write would have
+    // every start-up request another restart.
+    return FileAccess::file_exists(_get_orchestrator_metedata_path());
+}
+
+void OrchestratorPlugin::_update_metadata_stamp() {
+    const int64_t format = get_metadata_value("meta", "format", 0);
+    if (format != METADATA_FORMAT_VERSION) {
+        set_metadata_value("meta", "format", METADATA_FORMAT_VERSION);
     }
 
-    return false;
+    const String version = get_metadata_value("meta", "version", "");
+    if (version != VERSION_NUMBER) {
+        set_metadata_value("meta", "version", VERSION_NUMBER);
+    }
 }
 
 void OrchestratorPlugin::_add_plugin_icon_to_editor_theme() {
@@ -453,14 +477,14 @@ Ref<Texture2D> OrchestratorPlugin::get_plugin_icon_hires() const {
     return ResourceLoader::get_singleton()->load("res://addons/orchestrator/icons/Orchestrator_Logo.svg");
 }
 
-Ref<ConfigFile> OrchestratorPlugin::get_metadata() {
-    Ref<ConfigFile> metadata(memnew(ConfigFile));
-    metadata->load(_get_orchestrator_metedata_path());
-    return metadata;
+Variant OrchestratorPlugin::get_metadata_value(const String& p_section, const String& p_key, const Variant& p_default) {
+    return _get_metadata()->get_value(p_section, p_key, p_default);
 }
 
-void OrchestratorPlugin::save_metadata(const Ref<ConfigFile>& p_metadata) {
-    p_metadata->save(_get_orchestrator_metedata_path());
+void OrchestratorPlugin::set_metadata_value(const String& p_section, const String& p_key, const Variant& p_value) {
+    const Ref<ConfigFile> metadata = _get_metadata();
+    metadata->set_value(p_section, p_key, p_value);
+    metadata->save(_get_orchestrator_metedata_path());
 }
 
 void OrchestratorPlugin::make_active() {
@@ -475,6 +499,9 @@ void OrchestratorPlugin::_notification(int p_what) {
             // Plugins only enter the tree once and this happens before the main view.
             // It's safe then to cache the plugin reference here.
             _plugin = this;
+
+            // Must run before anything reads a cache file, notably the editor panel below.
+            FileUtils::migrate_editor_cache_files();
 
             _register_plugins();
             _register_shortcuts();
@@ -516,6 +543,9 @@ void OrchestratorPlugin::_notification(int p_what) {
                 // dialog due to the order of operations.
                 callable_mp_this(request_editor_restart).call_deferred();
             } else {
+                // Runs after migration so an upgraded project is stamped, and refreshes the version
+                // once the user moves to a newer release.
+                _update_metadata_stamp();
                 _add_plugin_icon_to_editor_theme();
             }
             break;

--- a/src/editor/plugins/orchestrator_editor_plugin.h
+++ b/src/editor/plugins/orchestrator_editor_plugin.h
@@ -43,6 +43,7 @@ class OrchestratorPlugin : public EditorPlugin {
     Vector<Ref<EditorExportPlugin>> _export_plugins;
     Vector<Ref<EditorInspectorPlugin>> _inspector_plugins;
     Vector<Ref<EditorDebuggerPlugin>> _debugger_plugins;
+    Ref<ConfigFile> _metadata;
 
     template <typename T>
     struct PluginTraits;
@@ -75,6 +76,8 @@ class OrchestratorPlugin : public EditorPlugin {
 
     static String _get_orchestrator_metedata_path();
 
+    Ref<ConfigFile> _get_metadata();
+
     void _focus_another_editor();
     bool _is_exiting() const;
 
@@ -83,7 +86,11 @@ class OrchestratorPlugin : public EditorPlugin {
 
     void _register_shortcuts();
 
-    bool _is_plugin_just_installed() const;
+    bool _is_plugin_just_installed();
+
+    /// Records the layout the metadata file is written in and the plugin version that last touched
+    /// it, writing only the values that are missing or have changed.
+    void _update_metadata_stamp();
 
     void _add_plugin_icon_to_editor_theme();
 
@@ -131,8 +138,8 @@ public:
 
     Ref<Texture2D> get_plugin_icon_hires() const;
 
-    Ref<ConfigFile> get_metadata();
-    void save_metadata(const Ref<ConfigFile>& p_metadata);
+    Variant get_metadata_value(const String& p_section, const String& p_key, const Variant& p_default = Variant());
+    void set_metadata_value(const String& p_section, const String& p_key, const Variant& p_value);
 
     void make_active();
 


### PR DESCRIPTION
Fixes GH-1609

## Description

Migrates all Orchestrator metadata files from `.godot/editor` into `.godot/editor/orchestrator`. Additionally, various metadata files created as separate files (e.g., menu/search recent/favorites) are merged into a single `metadata.cfg` file.

> [!WARNING]
> Once files are migrated, the old files are removed. 
> 
> If a user rolls back to an earlier plugin version, the legacy files no longer exist. This should generally be acceptable as the metadata and cache files are designed to be temporary and hold state like viewport offset position, zoom levels, what files were previously open, what had previously been selected or marked as favorites. These files do not hold project-sensitive information that would otherwise _break_ a project.