### PR TITLE
GH-1810 Fix/avoid corruption duplicating event nodes

### DIFF
--- a/src/editor/graph/graph_panel.cpp
+++ b/src/editor/graph/graph_panel.cpp
@@ -245,7 +245,7 @@ void OrchestratorEditorGraphPanel::_connection_drag_ended() {
 
 void OrchestratorEditorGraphPanel::_copy_nodes_request() {
     const Vector<OrchestratorEditorGraphNode*> selected_nodes = get_selected<OrchestratorEditorGraphNode>();
-    if (!selected_nodes.is_empty() && !_can_duplicate_nodes(selected_nodes)) {
+    if (!selected_nodes.is_empty() && !_can_copy_nodes(selected_nodes)) {
         return;
     }
 
@@ -254,7 +254,7 @@ void OrchestratorEditorGraphPanel::_copy_nodes_request() {
 
 void OrchestratorEditorGraphPanel::_cut_nodes_request() {
     const Vector<OrchestratorEditorGraphNode*> selected = get_selected<OrchestratorEditorGraphNode>();
-    if (selected.is_empty() || !_can_duplicate_nodes(selected)) {
+    if (selected.is_empty() || !_can_copy_nodes(selected)) {
         return;
     }
 
@@ -817,10 +817,9 @@ void OrchestratorEditorGraphPanel::_expand_node(OrchestratorEditorGraphNode* p_n
     HashSet<int> nodes_to_duplicate;
     const Ref<OrchestrationGraph> function_graph = function->get_function_graph();
     for (const Ref<OrchestrationGraphNode>& node : function_graph->get_nodes()) {
-        const Ref<OScriptNodeFunctionEntry> entry = node;
         const Ref<OScriptNodeFunctionResult> result = node;
 
-        if (!entry.is_valid() && !result.is_valid() && node->can_duplicate()) {
+        if (!result.is_valid() && node->can_duplicate()) {
             const Rect2 node_rect = Rect2(node->get_position(), node->get_size());
             if (nodes_to_duplicate.is_empty()) {
                 nodes_area = node_rect;
@@ -2027,6 +2026,19 @@ bool OrchestratorEditorGraphPanel::_can_duplicate_nodes(const Vector<Orchestrato
         if (!node->_node->can_duplicate()) {
             if (p_error_dialog) {
                 const String message = vformat("Cannot duplicate node '%s' with ID %d", node->get_title(), node->get_id());
+                OrchestratorEditorDialogs::error(message);
+            }
+            return false;
+        }
+    }
+    return true;
+}
+
+bool OrchestratorEditorGraphPanel::_can_copy_nodes(const Vector<OrchestratorEditorGraphNode*>& p_nodes, bool p_error_dialog) {
+    for (OrchestratorEditorGraphNode* node : p_nodes) {
+        if (!node->_node->can_copy()) {
+            if (p_error_dialog) {
+                const String message = vformat("Cannot copy node '%s' with ID %d", node->get_title(), node->get_id());
                 OrchestratorEditorDialogs::error(message);
             }
             return false;

--- a/src/editor/graph/graph_panel.h
+++ b/src/editor/graph/graph_panel.h
@@ -263,6 +263,7 @@ private:
     void _show_drag_hint(const String& p_hint_text) const;
     bool _is_delete_confirmation_enabled();
     bool _can_duplicate_nodes(const Vector<OrchestratorEditorGraphNode*>& p_nodes, bool p_error_dialog = true);
+    bool _can_copy_nodes(const Vector<OrchestratorEditorGraphNode*>& p_nodes, bool p_error_dialog = true);
     void _set_scroll_offset_and_zoom(const Vector2& p_scroll_offset, float p_zoom = 1.f, const Callable& p_callback = Callable());
     void _schedule_restore();
     void _restore_edit_state();

--- a/src/orchestration/graph.cpp
+++ b/src/orchestration/graph.cpp
@@ -420,6 +420,13 @@ Ref<OScriptNode> OScriptGraph::duplicate_node(int p_node_id, const Vector2& p_de
         return nullptr;
     }
 
+    // Function entry and event nodes carry a function GUID, so an in-place copy would share the source's
+    // function rather than define its own. Refuse here so no caller can create that state.
+    if (!node->can_duplicate()) {
+        ERR_PRINT(vformat("Cannot duplicate node with id %d (%s).", p_node_id, node->get_class()));
+        return nullptr;
+    }
+
     // Duplicate node
     Ref<OScriptNode> duplicate = node->duplicate(p_duplicate_resources);
 

--- a/src/orchestration/node.h
+++ b/src/orchestration/node.h
@@ -388,9 +388,14 @@ public:
     /// @param p_pin the pin that was disconnected
     virtual void on_pin_disconnected(const Ref<OScriptNodePin>& p_pin);
 
-    /// Returns whether the node can be duplicated
+    /// Returns whether the node can be duplicated in place within its orchestration
     /// @return if the node can be duplicated
     virtual bool can_duplicate() const { return true; }
+
+    /// Returns whether the node can be copied or cut to the clipboard. Unlike duplication, whether
+    /// the node can then be pasted depends on the target graph, not this node.
+    /// @return if the node can be copied
+    virtual bool can_copy() const { return can_duplicate(); }
 
     /// Return whether the specified port is a loop-based port
     virtual bool is_loop_port(int p_port) const { return false; }

--- a/src/orchestration/nodes/event.h
+++ b/src/orchestration/nodes/event.h
@@ -49,7 +49,7 @@ public:
     String get_icon() const override { return "PlayStart"; }
     bool can_user_delete_node() const override { return true; }
     bool can_inspect_node_properties() const override { return true; }
-    bool can_duplicate() const override { return true; }
+    bool can_copy() const override { return true; }
     StringName resolve_type_class(const Ref<OScriptNodePin>& p_pin) const override;
     //~ End OScriptNode Interface
 

--- a/src/orchestration/orchestration.cpp
+++ b/src/orchestration/orchestration.cpp
@@ -237,6 +237,87 @@ void Orchestration::_fix_orphans() {
     }
 }
 
+void Orchestration::_fix_duplicate_event_nodes() {
+    // Orchestrations written by 2.4.x and 2.5.x allowed an event node to be duplicated in place, which bound two
+    // event nodes to a single function. Only the function's recorded owner ever compiled, so the other nodes are
+    // removed. When the owner cannot be resolved, the function and every event node bound to it are dropped so
+    // the user can re-place the event. Event nodes whose function no longer exists are dropped too.
+    //
+    // This repair ships in 2.4, 2.5 and 2.6 and should be removed once support for 2.4 and 2.5 is dropped.
+    // It runs before _fix_orphans so that the connections of the removed nodes are pruned there.
+    const String path = get_orchestration_path();
+    String hint;
+    if (_self && OS::get_singleton()->has_feature("editor")) {
+        hint = " Please save orchestration '" + _self->get_path() + "' to apply changes.";
+    }
+
+    HashSet<int> removals;
+    Vector<StringName> dropped_functions;
+
+    for (const KeyValue<StringName, Ref<OScriptFunction>>& E : _functions) {
+        const Ref<OScriptFunction>& function = E.value;
+        if (!function.is_valid()) {
+            continue;
+        }
+
+        Vector<int> event_ids;
+        for (const KeyValue<int, Ref<OScriptNode>>& N : _nodes) {
+            const Ref<OScriptNodeEvent> event = N.value;
+            if (event.is_valid() && event->get_function() == function) {
+                event_ids.push_back(N.key);
+            }
+        }
+
+        if (event_ids.is_empty()) {
+            continue;
+        }
+
+        const int owner_id = function->get_owning_node_id();
+        if (event_ids.has(owner_id)) {
+            for (const int event_id : event_ids) {
+                if (event_id != owner_id) {
+                    WARN_PRINT(vformat(
+                        "Script '%s': Removed event node %d, a duplicate of node %d for function '%s'.%s",
+                        path, event_id, owner_id, E.key, hint));
+                    removals.insert(event_id);
+                }
+            }
+        } else {
+            for (const int event_id : event_ids) {
+                removals.insert(event_id);
+            }
+            dropped_functions.push_back(E.key);
+
+            WARN_PRINT(vformat(
+                "Script '%s': Removed function '%s' and its event node(s), the owner node %d could not be resolved. "
+                "Please re-place the event node.%s",
+                path, E.key, owner_id, hint));
+        }
+    }
+
+    for (const KeyValue<int, Ref<OScriptNode>>& N : _nodes) {
+        const Ref<OScriptNodeEvent> event = N.value;
+        if (event.is_valid() && !event->get_function().is_valid() && !removals.has(N.key)) {
+            WARN_PRINT(vformat(
+                "Script '%s': Removed event node %d, its function no longer exists. Please re-place the event node.%s",
+                path, N.key, hint));
+            removals.insert(N.key);
+        }
+    }
+
+    for (const StringName& function_name : dropped_functions) {
+        _functions.erase(function_name);
+    }
+
+    for (const int node_id : removals) {
+        const Ref<OScriptNode> node = _nodes[node_id];
+        for (const KeyValue<StringName, Ref<OScriptGraph>>& G : _graphs) {
+            G.value->remove_node(node);
+        }
+        _nodes.erase(node_id);
+    }
+}
+
 void Orchestration::_connect_nodes(int p_source_id, int p_source_port, int p_target_id, int p_target_port) {
     ERR_FAIL_COND_MSG(_has_instances(), "Cannot connect nodes, instances exist.");
 
@@ -456,6 +537,8 @@ void Orchestration::post_initialize() {
     for (const KeyValue<StringName, Ref<OScriptGraph>>& G : _graphs) {
         G.value->post_initialize();
     }
+
+    _fix_duplicate_event_nodes();
 
     // Sanitize attached nodes
     // In 2.5.0 deleting nodes while attached did not clean-up attachments

--- a/src/orchestration/orchestration.cpp
+++ b/src/orchestration/orchestration.cpp
@@ -208,8 +208,7 @@ void Orchestration::_fix_orphans() {
             continue;
         }
 
-        const String path = _self ? _self->get_path() : _script_path;
-        WARN_PRINT(vformat("Removed orphan node %d (%s) from script %s.", E.key, E.value->get_class(), path));
+        WARN_PRINT(vformat("Removed orphan node %d (%s) from script %s.", E.key, E.value->get_class(), get_orchestration_path()));
         orphans.push_back(E.key);
     }
 
@@ -364,10 +363,12 @@ void Orchestration::_update_all_self_nodes() {
 }
 
 String Orchestration::get_orchestration_path() const {
-    if (_self) {
+    // The outer resource has no path until loading completes, so fall back to the path recorded by the
+    // parser for messages emitted during post_initialize, and for orchestrations parsed without a script.
+    if (_self && !_self->get_path().is_empty()) {
         return _self->get_path();
     }
-    return {};
+    return _script_path;
 }
 
 StringName Orchestration::get_instance_class_type() const {
@@ -1522,17 +1523,21 @@ PackedStringArray Orchestration::get_custom_signal_names() const {
 
 void Orchestration::copy_state(const Ref<Orchestration>& p_other) {
     set_block_signals(true);
+
     set_global_name(p_other->get_global_name());
     set_icon_path(p_other->get_icon_path());
     set_description(p_other->get_description());
     set_brief_description(p_other->get_brief_description());
     set_base_type(p_other->get_base_type());
+
+    _script_path = p_other->_script_path;
     _set_nodes_internal(p_other->_get_nodes_internal());
     _set_connections_internal(p_other->_get_connections_internal());
     _set_graphs_internal(p_other->_get_graphs_internal());
     _set_functions_internal(p_other->_get_functions_internal());
     _set_variables_internal(p_other->_get_variables_internal());
     _set_signals_internal(p_other->_get_signals_internal());
+
     set_block_signals(false);
 
     // During the above setters, the model is being replaced with the on-disk snapshot.

--- a/src/orchestration/orchestration.h
+++ b/src/orchestration/orchestration.h
@@ -130,6 +130,11 @@ protected:
     /// @note This should generally not be an issue, except during development, but its a great sanity check
     virtual void _fix_orphans();
 
+    /// Removes event nodes that share a function with another event node, or whose function no longer
+    /// exists, as written by 2.4.x and 2.5.x.
+    /// @note Ships in 2.4, 2.5 and 2.6; remove once support for 2.4 and 2.5 is dropped.
+    void _fix_duplicate_event_nodes();
+
     /// Get whether there are any instances of this orchestration
     /// @return true if there are existing instances, false otherwise
     virtual bool _has_instances() const { return false; }

--- a/tests/run_integration_tests.py
+++ b/tests/run_integration_tests.py
@@ -44,6 +44,11 @@ MAX_JOBS = 4
 scenes_dir = (Path(__file__).parent / "scenes").resolve()
 
 use_color = sys.stdout.isatty()
+
+# When stdout is a pipe rather than a terminal, e.g. under a CI runner, Python block-buffers it and
+# nothing appears until the process exits. Line-buffer it so each scene's result shows as it completes.
+sys.stdout.reconfigure(line_buffering=True)
+
 GREEN  = "\033[32m"
 RED    = "\033[31m"
 YELLOW = "\033[33m"
@@ -154,25 +159,23 @@ def validate_output(source, result, elapsed):
     directive = lines[0].strip()
     expected = "\n".join(lines[1:]).strip()
 
-    if directive == "OSCRIPT_TEST_PASS":
-        stderr = result.stderr.strip()
-        if stderr:
-            return "FAIL", format_result("FAIL", elapsed, source) + \
-                f"\nExpected empty stderr, but got:\n----------\n{stderr}\n"
-        actual = result.stdout.strip()
-    elif directive == "OSCRIPT_TEST_FAILURE":
-        actual = result.stderr.strip()
-        # Godot did not add backtrace support until Godot 4.5+
-        if version == "4.4":
-            actual = strip_backtrace(actual)
-            expected = strip_backtrace(expected)
-
-        actual = normalize_cpp_lines(actual)
-        expected = normalize_cpp_lines(expected)
-
-    else:
+    if directive not in ("OSCRIPT_TEST_PASS", "OSCRIPT_TEST_FAILURE"):
         return "ERROR", format_result("ERROR", elapsed, source) + \
             f"\n  Unknown directive '{directive}' in {out_file}"
+
+    # The scene's stdout and stderr are captured as one stream, so the .out file records prints,
+    # warnings and errors in the order the scene emitted them, as the GDScript test suite does.
+    # A passing scene is therefore silent unless its .out file lists the warnings it is expected
+    # to emit, e.g. load-time repairs of a deliberately corrupted fixture.
+    actual = result.stdout.strip()
+
+    # Godot did not add backtrace support until Godot 4.5+
+    if version == "4.4":
+        actual = strip_backtrace(actual)
+        expected = strip_backtrace(expected)
+
+    actual = normalize_cpp_lines(actual)
+    expected = normalize_cpp_lines(expected)
 
     if actual == expected:
         return "PASS", format_result("PASS", elapsed, source)
@@ -243,7 +246,10 @@ def run_scene(scene_file):
                 *frame_args,
                 "--scene",
                 str(scene_file)],
-            capture_output=True,
+            # Merge stderr into stdout so the expectation sees the scene's output in emission order.
+            # Godot flushes each print, so the merged pipe preserves the true interleaving.
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
             check=True,
             text=True)
     except subprocess.CalledProcessError as e:
@@ -252,8 +258,6 @@ def run_scene(scene_file):
         text += f"\n  exit code {e.returncode}"
         if e.stdout.strip():
             text += "\n" + truncate(e.stdout.strip())
-        if e.stderr.strip():
-            text += "\n" + truncate(e.stderr.strip())
         return "CRASH", text + "\n"
 
     elapsed = time.monotonic() - start

--- a/tests/scenes/features/duplicate_event_node_repair.out
+++ b/tests/scenes/features/duplicate_event_node_repair.out
@@ -1,0 +1,10 @@
+OSCRIPT_TEST_PASS
+WARNING: Script 'res://scenes/features/duplicate_event_node_repair.torch': Removed event node 3, a duplicate of node 0 for function '_ready'.
+     at: _fix_duplicate_event_nodes (src/orchestration/orchestration.cpp)
+WARNING: Removing orphan connection for 3:0-4:0, either the source or target node no longer exists.
+     at: _fix_orphans (src/orchestration/orchestration.cpp)
+WARNING: Script 'res://scenes/features/duplicate_event_node_repair.torch': Removed event node 3, a duplicate of node 0 for function '_ready'.
+     at: _fix_duplicate_event_nodes (src/orchestration/orchestration.cpp)
+WARNING: Removing orphan connection for 3:0-4:0, either the source or target node no longer exists.
+     at: _fix_orphans (src/orchestration/orchestration.cpp)
+owner

--- a/tests/scenes/features/duplicate_event_node_repair.torch
+++ b/tests/scenes/features/duplicate_event_node_repair.torch
@@ -1,0 +1,102 @@
+[orchestration type="OScript" load_steps=7 format=3 uid="uid://b7k2m4p1q8r3d"]
+
+[obj type="OScriptFunction" id="OScriptFunction_ready"]
+guid = "1C7A2E4B-5D3F-4A6C-9B8E-0F1D2C3B4A59"
+method = {
+"name": &"_ready",
+"flags": 8
+}
+id = 0
+
+[obj type="OScriptGraph" id="OScriptGraph_event"]
+graph_name = &"EventGraph"
+flags = 8
+nodes = Array[int]([0, 1, 3, 4])
+functions = Array[int]([0, 3])
+
+[obj type="OScriptNodeEvent" id="OScriptNodeEvent_owner"]
+function_id = "1C7A2E4B-5D3F-4A6C-9B8E-0F1D2C3B4A59"
+id = 0
+size = Vector2(29, 41)
+position = Vector2(160, 220)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}])
+
+[obj type="OScriptNodeCallBuiltinFunction" id="OScriptNodeCallBuiltinFunction_owner"]
+function_name = &"print"
+flags = 33
+method = {
+"name": &"print",
+"flags": 17,
+"args": [{
+"name": &"arg1",
+"usage": 131078
+}]
+}
+variable_arg_count = 0
+id = 1
+size = Vector2(29, 41)
+position = Vector2(360, 220)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}, {
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}, {
+"pin_name": &"arg1",
+"flags": 2,
+"usage": 131078,
+"dv": "owner"
+}])
+
+[obj type="OScriptNodeEvent" id="OScriptNodeEvent_duplicate"]
+function_id = "1C7A2E4B-5D3F-4A6C-9B8E-0F1D2C3B4A59"
+id = 3
+size = Vector2(29, 41)
+position = Vector2(160, 420)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}])
+
+[obj type="OScriptNodeCallBuiltinFunction" id="OScriptNodeCallBuiltinFunction_duplicate"]
+function_name = &"print"
+flags = 33
+method = {
+"name": &"print",
+"flags": 17,
+"args": [{
+"name": &"arg1",
+"usage": 131078
+}]
+}
+variable_arg_count = 0
+id = 4
+size = Vector2(29, 41)
+position = Vector2(360, 420)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}, {
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}, {
+"pin_name": &"arg1",
+"flags": 2,
+"usage": 131078,
+"dv": "duplicate"
+}])
+
+[resource]
+base_type = &"Node"
+functions = Array[OScriptFunction]([SubResource("OScriptFunction_ready")])
+connections = Array[int]([0, 0, 1, 0, 3, 0, 4, 0])
+nodes = Array[OScriptNode]([SubResource("OScriptNodeEvent_owner"), SubResource("OScriptNodeCallBuiltinFunction_owner"), SubResource("OScriptNodeEvent_duplicate"), SubResource("OScriptNodeCallBuiltinFunction_duplicate")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_event")])

--- a/tests/scenes/features/duplicate_event_node_repair.tscn
+++ b/tests/scenes/features/duplicate_event_node_repair.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3 uid="uid://c5n8w2t6h1v4y"]
+
+[ext_resource type="Script" uid="uid://b7k2m4p1q8r3d" path="res://scenes/features/duplicate_event_node_repair.torch" id="1_dupev"]
+
+[node name="DuplicateEventNodeRepair" type="Node"]
+script = ExtResource("1_dupev")

--- a/tests/scenes/features/duplicate_event_node_repair_unresolved_owner.out
+++ b/tests/scenes/features/duplicate_event_node_repair_unresolved_owner.out
@@ -1,0 +1,9 @@
+OSCRIPT_TEST_PASS
+WARNING: Script 'res://scenes/features/duplicate_event_node_repair_unresolved_owner.torch': Removed function '_ready' and its event node(s), the owner node 99 could not be resolved. Please re-place the event node.
+     at: _fix_duplicate_event_nodes (src/orchestration/orchestration.cpp)
+WARNING: Removing orphan connection for 0:0-1:0, either the source or target node no longer exists.
+     at: _fix_orphans (src/orchestration/orchestration.cpp)
+WARNING: Script 'res://scenes/features/duplicate_event_node_repair_unresolved_owner.torch': Removed function '_ready' and its event node(s), the owner node 99 could not be resolved. Please re-place the event node.
+     at: _fix_duplicate_event_nodes (src/orchestration/orchestration.cpp)
+WARNING: Removing orphan connection for 0:0-1:0, either the source or target node no longer exists.
+     at: _fix_orphans (src/orchestration/orchestration.cpp)

--- a/tests/scenes/features/duplicate_event_node_repair_unresolved_owner.torch
+++ b/tests/scenes/features/duplicate_event_node_repair_unresolved_owner.torch
@@ -1,0 +1,62 @@
+[orchestration type="OScript" load_steps=5 format=3 uid="uid://d2f6h9k3m7p1s"]
+
+[obj type="OScriptFunction" id="OScriptFunction_ready"]
+guid = "2D8B3F5C-6E4A-4B7D-8C9F-1A2E3D4C5B6A"
+method = {
+"name": &"_ready",
+"flags": 8
+}
+id = 99
+
+[obj type="OScriptGraph" id="OScriptGraph_event"]
+graph_name = &"EventGraph"
+flags = 8
+nodes = Array[int]([0, 1])
+functions = Array[int]([0])
+
+[obj type="OScriptNodeEvent" id="OScriptNodeEvent_orphan"]
+function_id = "2D8B3F5C-6E4A-4B7D-8C9F-1A2E3D4C5B6A"
+id = 0
+size = Vector2(29, 41)
+position = Vector2(160, 220)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}])
+
+[obj type="OScriptNodeCallBuiltinFunction" id="OScriptNodeCallBuiltinFunction_orphan"]
+function_name = &"print"
+flags = 33
+method = {
+"name": &"print",
+"flags": 17,
+"args": [{
+"name": &"arg1",
+"usage": 131078
+}]
+}
+variable_arg_count = 0
+id = 1
+size = Vector2(29, 41)
+position = Vector2(360, 220)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}, {
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}, {
+"pin_name": &"arg1",
+"flags": 2,
+"usage": 131078,
+"dv": "unresolved"
+}])
+
+[resource]
+base_type = &"Node"
+functions = Array[OScriptFunction]([SubResource("OScriptFunction_ready")])
+connections = Array[int]([0, 0, 1, 0])
+nodes = Array[OScriptNode]([SubResource("OScriptNodeEvent_orphan"), SubResource("OScriptNodeCallBuiltinFunction_orphan")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_event")])

--- a/tests/scenes/features/duplicate_event_node_repair_unresolved_owner.tscn
+++ b/tests/scenes/features/duplicate_event_node_repair_unresolved_owner.tscn
@@ -1,0 +1,6 @@
+[gd_scene format=3 uid="uid://e4g8j1n5q9t2w"]
+
+[ext_resource type="Script" uid="uid://d2f6h9k3m7p1s" path="res://scenes/features/duplicate_event_node_repair_unresolved_owner.torch" id="1_unres"]
+
+[node name="DuplicateEventNodeRepairUnresolvedOwner" type="Node"]
+script = ExtResource("1_unres")


### PR DESCRIPTION
Fixes GH-1810

## Description

Prevents duplicating event nodes and adds a cleanup pass for existing corrupted files. Added tests.