### PR TITLE
GH-1807 Upgrade to Emscripten 4.0.20

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 
 env:
-  EM_VERSION: 4.0.11
+  EM_VERSION: 4.0.20
   EM_INSTALL_DIR: "${{ github.workspace }}/.emsdk"
 
 jobs:


### PR DESCRIPTION
Fixes GH-1807

## Description

Godot has updated its 4.7 templates to use Emscripten 4.0.20. 