### PR TITLE
GH-1556 Don't update a node's position while dragged

### DIFF
--- a/src/editor/graph/graph_node.cpp
+++ b/src/editor/graph/graph_node.cpp
@@ -674,7 +674,12 @@ void OrchestratorEditorGraphNode::update() {
     _create_pin_widgets();
     _create_add_button_widgets();
 
-    if (get_position_offset() != _node->get_position()) {
+    // While the selection is being dragged, the widget's offset is authoritative: the model only learns
+    // the new position when "dragged" fires on release. Resetting from the model here, e.g. because a
+    // self node was reconstructed mid-drag, would snap this node back mid-selection move.
+    const OrchestratorEditorGraphPanel* graph = get_graph();
+    const bool moving_selection = graph && graph->is_moving_selection();
+    if (!moving_selection && get_position_offset() != _node->get_position()) {
         set_position_offset(_node->get_position());
     }
 

--- a/src/editor/graph/graph_panel.h
+++ b/src/editor/graph/graph_panel.h
@@ -368,6 +368,8 @@ public:
 
     int64_t get_selection_count();
 
+    bool is_moving_selection() const { return _moving_selection; }
+
     Rect2 get_bounds_for_nodes(bool p_only_selected, bool p_padding = 0.f);
     Rect2 get_bounds_for_nodes(const Vector<OrchestratorEditorGraphNode*>& p_nodes, bool p_padding = 0.f);
 


### PR DESCRIPTION
Fixes GH-1556

## Description

In some situations, when a node's update callback fires while the node is being dragged, it can snap back to its old position.