### PR TITLE
GH-1818 Always spawn event nodes in event graphs

### DIFF
--- a/src/editor/graph/graph_panel.cpp
+++ b/src/editor/graph/graph_panel.cpp
@@ -1962,6 +1962,13 @@ void OrchestratorEditorGraphPanel::_action_menu_selection(const Ref<Orchestrator
         case OrchestratorEditorActionDefinition::ACTION_EVENT: {
             ERR_FAIL_COND_MSG(!p_action->method.has_value(), "Handle event has no method");
 
+            // Events live in event graphs only. This panel cannot see other graphs, so the owning
+            // editor resolves the event graph and spawns there, see script_editor_view.
+            if (!_graph->get_flags().has_flag(OrchestrationGraph::GF_EVENT)) {
+                emit_signal("event_spawn_requested", DictionaryUtils::from_method(p_action->method.value()));
+                break;
+            }
+
             NodeSpawnOptions options;
             options.node_class = OScriptNodeEvent::get_class_static();
             options.context.method = p_action->method;
@@ -3783,6 +3790,9 @@ void OrchestratorEditorGraphPanel::_bind_methods() {
 
     // Used to notify parent type to focus & edit the function
     ADD_SIGNAL(MethodInfo("edit_function_requested", PropertyInfo(Variant::STRING, "function_name")));
+
+    // Used to notify parent type to spawn the event in an event graph when this panel is not one
+    ADD_SIGNAL(MethodInfo("event_spawn_requested", PropertyInfo(Variant::DICTIONARY, "method")));
 
     ADD_SIGNAL(MethodInfo("breakpoint_changed", PropertyInfo(Variant::INT, "node_id"), PropertyInfo(Variant::BOOL, "enabled")));
     ADD_SIGNAL(MethodInfo("breakpoint_added", PropertyInfo(Variant::INT, "node_id")));

--- a/src/editor/script_editor_view.cpp
+++ b/src/editor/script_editor_view.cpp
@@ -19,6 +19,7 @@
 #include "actions/registry.h"
 #include "api/extension_db.h"
 #include "common/callable_lambda.h"
+#include "common/dictionary_utils.h"
 #include "common/macros.h"
 #include "common/name_utils.h"
 #include "common/scene_utils.h"
@@ -79,6 +80,7 @@ OrchestratorEditorGraphPanel* OrchestratorScriptGraphEditorView::_create_graph_t
 
     tab_panel->connect("validate_script", callable_mp_this(_queue_validate_script));
     tab_panel->connect("focus_requested", callable_mp_this(_focus_object));
+    tab_panel->connect("event_spawn_requested", callable_mp_this(_event_spawn_requested));
 
     // Wire up component callbacks
     _components->notify_graph_opened(tab_panel);
@@ -413,6 +415,21 @@ void OrchestratorScriptGraphEditorView::_focus_object(Object* p_object) {
             callable_mp_this(_scroll_to_graph_node).bind(function->get_owning_node_id()).call_deferred();
         }
     }
+}
+
+void OrchestratorScriptGraphEditorView::_event_spawn_requested(const Dictionary& p_method) {
+    // Raised by a panel whose graph is not an event graph, so the event goes to the default EventGraph
+    OrchestratorEditorGraphPanel* editor = _get_graph_tab("EventGraph");
+    ERR_FAIL_NULL_MSG(editor, "Cannot spawn the event, the EventGraph tab does not exist.");
+
+    _focus_graph_tab(editor);
+
+    NodeSpawnOptions options;
+    options.context.method = DictionaryUtils::to_method(p_method);
+    options.position = editor->get_scroll_offset() + (editor->get_size() / 2.0);
+    options.center_on_spawn = true;
+
+    editor->spawn_node<OScriptNodeEvent>(options);
 }
 
 void OrchestratorScriptGraphEditorView::_toggle_bookmark_for_selected_nodes() {

--- a/src/editor/script_editor_view.h
+++ b/src/editor/script_editor_view.h
@@ -134,6 +134,7 @@ protected:
     void _scroll_to_graph_node(int p_node_id);
 
     void _focus_object(Object* p_object);
+    void _event_spawn_requested(const Dictionary& p_method);
 
     void _toggle_bookmark_for_selected_nodes();
     void _remove_all_bookmarks();


### PR DESCRIPTION
Fixes GH-1818

## Description

When using the function override path, the plugin always worked by ensuring that the event node was either spawned into the currently focused event graph or redirected to the base `EventGraph` if a non-event graph had focus. However, when picking the event node from the action dialog when using right-click, that wasn't the case.

Both code paths now honor the same rules.