### PR TITLE
GH-1820 Add individual constants to action dialog

### DIFF
--- a/src/editor/actions/definition.cpp
+++ b/src/editor/actions/definition.cpp
@@ -16,6 +16,12 @@
 //
 #include "editor/actions/definition.h"
 
+String OrchestratorEditorActionDefinition::make_sort_key(const String& p_category, const String& p_name) {
+    // Lower-cased so ordering follows the capitalized text the menu displays, not declaration casing
+    const String separator = String::chr(1);
+    return (p_category.replace("/", separator) + separator + p_name).to_lower();
+}
+
 OrchestratorEditorActionBuilder& OrchestratorEditorActionBuilder::tooltip(const String& p_tooltip) {
     _action->tooltip = p_tooltip;
     return *this;
@@ -119,12 +125,14 @@ OrchestratorEditorActionBuilder::OrchestratorEditorActionBuilder(const String& p
     _action.instantiate();
     _action->category = p_category;
     _action->name = "";
+    _action->sort_key = OrchestratorEditorActionDefinition::make_sort_key(p_category, "");
 }
 
 OrchestratorEditorActionBuilder::OrchestratorEditorActionBuilder(const String& p_category, const String& p_name) {
     _action.instantiate();
     _action->category = p_category;
     _action->name = p_name;
+    _action->sort_key = OrchestratorEditorActionDefinition::make_sort_key(p_category, p_name);
 }
 
 

--- a/src/editor/actions/definition.h
+++ b/src/editor/actions/definition.h
@@ -82,6 +82,17 @@ public:
     std::optional<Vector<Variant::Type>> inputs;        //! Operators pass their input types
     std::optional<Vector<Variant::Type>> outputs;       //! Operators pass their output types
     bool executions = false;                            //! Whether the action has execution pins
+
+    // Precomputed menu ordering key, see OrchestratorEditorActionDefinitionComparator
+    String sort_key;
+
+    /// Builds the key that orders an action among its menu siblings. The category separator is
+    /// replaced by a character below every printable one so that a sub-category, compared by its
+    /// own name, interleaves alphabetically with the leaves beside it rather than trailing them.
+    /// @param p_category the action category path
+    /// @param p_name the action name
+    /// @return the sort key
+    static String make_sort_key(const String& p_category, const String& p_name);
 };
 
 struct OrchestratorEditorActionDefinitionComparator {
@@ -97,10 +108,11 @@ struct OrchestratorEditorActionDefinitionComparator {
         if (!b_valid)
             return false;
 
-        if (a->category == b->category)
-            return a->name < b->name;
+        // Only at the top level do uncategorized actions trail every category
+        if (a->category.is_empty() != b->category.is_empty())
+            return !a->category.is_empty();
 
-        return a->category < b->category;
+        return a->sort_key < b->sort_key;
     }
 };
 

--- a/src/editor/actions/introspector.cpp
+++ b/src/editor/actions/introspector.cpp
@@ -140,6 +140,40 @@ void OrchestratorEditorIntrospector::_register_global_class_static_methods(const
     }
 }
 
+void OrchestratorEditorIntrospector::_register_constant(const String& p_node_type, const String& p_category, const String& p_owner,
+    const String& p_constant_name, const Variant& p_value, const Dictionary& p_data, ActionSet& r_actions) {
+
+    r_actions.insert(
+        _script_node_builder(p_node_type, p_category, p_constant_name, p_data)
+        .tooltip(vformat("%s.%s = %s", p_owner, p_constant_name, p_value))
+        .keywords(_build_member_keywords(p_constant_name, p_owner))
+        .no_capitalize(true)
+        .build());
+}
+
+void OrchestratorEditorIntrospector::_register_class_constants(const String& p_class_name, ActionSet& r_actions) {
+    // Only constants the class declares itself; inherited ones are listed under their declaring class.
+    // Enum members are registered as integer constants, so this covers both.
+    const PackedStringArray constant_names = ClassDB::class_get_integer_constant_list(p_class_name, true);
+    if (constant_names.is_empty()) {
+        return;
+    }
+
+    const String category = vformat("Constants/%s", p_class_name);
+    _create_categories_from_path(r_actions, category, p_class_name);
+
+    // Singletons keep their dedicated node so the inspector offers the singleton class list.
+    const String node_type = Engine::get_singleton()->has_singleton(p_class_name)
+        ? OScriptNodeSingletonConstant::get_class_static()
+        : OScriptNodeClassConstant::get_class_static();
+
+    for (const String& constant_name : constant_names) {
+        const int64_t value = ClassDB::class_get_integer_constant(p_class_name, constant_name);
+        const Dictionary data = DictionaryUtils::of({ { "class_name", p_class_name }, { "constant", constant_name } });
+        _register_constant(node_type, category, p_class_name, constant_name, value, data, r_actions);
+    }
+}
+
 OrchestratorEditorIntrospector::ActionBuilder OrchestratorEditorIntrospector::_script_node_builder(
     const String& p_node_type, const String& p_category, const String& p_name, const Dictionary& p_data) {
 
@@ -360,19 +394,23 @@ void OrchestratorEditorIntrospector::_get_actions_for_class(const String& p_clas
         r_actions.insert(
             _script_node_builder<OScriptNodeNew>(
                 methods_category,
-                "Create New Instance",
+                vformat("Create New %s Instance", p_class_name),
                 DictionaryUtils::of({ { "class_name", p_class_name } }))
             .target_class(p_class_name)
             .tooltip(vformat("Creates a new instance of '%s'.", p_class_name))
+            .keywords(Array::make("create", "new", p_class_name))
+            .no_capitalize(true)
             .build());
 
         r_actions.insert(
             _script_node_builder<OScriptNodeFree>(
                 methods_category,
-                "Free Instance",
+                vformat("Free %s Instance", p_class_name),
                 DictionaryUtils::of({ { "class_name", p_class_name } }))
             .target_class(p_class_name)
             .tooltip(vformat("Free the memory used by the '%s' instance.", p_class_name))
+            .keywords(Array::make("free", "delete", p_class_name))
+            .no_capitalize(true)
             .build());
     }
 
@@ -699,6 +737,25 @@ void OrchestratorEditorIntrospector::generate_actions_from_script_nodes(ActionSe
     r_actions.insert(_script_node_builder<OScriptNodeClassConstant>("Constants", "Class Constant").build());
     r_actions.insert(_script_node_builder<OScriptNodeSingletonConstant>("Constants", "Singleton Constant").build());
 
+    // Every global enum value is searchable by name, spawning a preconfigured global constant node
+    const String global_constants_category = "@GlobalScope/Constants";
+    for (const String& constant_name : ExtensionDB::get_global_enum_value_names()) {
+        const EnumValue enum_value = ExtensionDB::get_global_enum_value(constant_name);
+        const EnumInfo enum_info = ExtensionDB::get_global_enum_by_value(constant_name);
+        const Dictionary data = DictionaryUtils::of({ { "constant", constant_name } });
+        _register_constant(OScriptNodeGlobalConstant::get_class_static(), global_constants_category,
+            vformat("@GlobalScope.%s", enum_info.name), constant_name, enum_value.value, data, r_actions);
+    }
+
+    // Math constants belong to the scripting language rather than to any Godot class
+    const String math_constants_category = "@OScript/Constants";
+    for (const String& constant_name : ExtensionDB::get_math_constant_names()) {
+        const ConstantInfo constant = ExtensionDB::get_math_constant(constant_name);
+        const Dictionary data = DictionaryUtils::of({ { "constant", constant_name } });
+        _register_constant(OScriptNodeMathConstant::get_class_static(), math_constants_category,
+            "@OScript", constant_name, constant.value, data, r_actions);
+    }
+
     // Data
     r_actions.insert(_script_node_builder<OScriptNodeArrayGet>("Types/Array/Operators", "Get at Index", array_data)
         .inputs(Variant::ARRAY, Variant::INT).outputs(Variant::NIL).build());
@@ -851,7 +908,7 @@ void OrchestratorEditorIntrospector::generate_actions_from_script_nodes(ActionSe
             continue;
         }
 
-        r_actions.insert(_script_node_builder<OScriptNodeCallBuiltinFunction>("@OScript", mi.name, language_functions[i]).build());
+        r_actions.insert(_script_node_builder<OScriptNodeCallBuiltinFunction>("@OScript/Methods", mi.name, language_functions[i]).build());
     }
 }
 
@@ -873,6 +930,18 @@ void OrchestratorEditorIntrospector::generate_actions_from_variant_types(ActionS
         _create_categories_from_path(r_actions, category, type_icon);
 
         const Dictionary type_dict = DictionaryUtils::of({ { "type", type.type } });
+
+        // Type constants, i.e. Vector2.ZERO or Color.RED, spawning a preconfigured type constant node
+        if (!type.constants.is_empty()) {
+            const String constants_category = vformat("Constants/%s", type_name);
+            _create_categories_from_path(r_actions, constants_category, type_icon);
+
+            for (const ConstantInfo& constant : type.constants) {
+                const Dictionary data = DictionaryUtils::of({ { "type", type.type }, { "constant", constant.name } });
+                _register_constant(OScriptNodeTypeConstant::get_class_static(), constants_category,
+                    type_name, constant.name, constant.value, data, r_actions);
+            }
+        }
 
         // Local variables are only permitted in function graphs
         r_actions.insert(
@@ -1123,6 +1192,11 @@ void OrchestratorEditorIntrospector::generate_actions_from_autoloads(ActionSet& 
 
 void OrchestratorEditorIntrospector::generate_actions_from_native_classes(ActionSet& r_actions) {
     for (const String& class_name : ClassDB::get_class_list()) {
+        // Exclude classes that are prefixed with Orchestrator and OScript, as _get_actions_for_class does.
+        if (class_name.begins_with("Orchestrator") || class_name.begins_with("OScript")) {
+            continue;
+        }
+
         _get_actions_for_class(
             class_name,
             class_name,
@@ -1130,6 +1204,8 @@ void OrchestratorEditorIntrospector::generate_actions_from_native_classes(Action
             ClassDB::class_get_property_list(class_name, true),
             ClassDB::class_get_signal_list(class_name, true),
             r_actions);
+
+        _register_class_constants(class_name, r_actions);
     }
 }
 
@@ -1155,6 +1231,21 @@ void OrchestratorEditorIntrospector::generate_actions_from_script_global_classes
         // Also register static methods from parent type as accessible via the script type.
         const String base_type = ScriptServer::get_global_class(global_name).base_type;
         _register_static_methods(base_type, global_name, static_category_name, r_actions);
+
+        // Script-declared constants and enum values, spawning a class constant node scoped to the script class
+        const ScriptServer::GlobalClass global_class = ScriptServer::get_global_class(global_name);
+        const PackedStringArray constant_names = global_class.get_integer_constant_list();
+        if (!constant_names.is_empty()) {
+            const String constants_category = vformat("Constants/%s", global_name);
+            _create_categories_from_path(r_actions, constants_category, global_class.base_type);
+
+            for (const String& constant_name : constant_names) {
+                const int64_t value = global_class.get_integer_constant(constant_name);
+                const Dictionary data = DictionaryUtils::of({ { "class_name", global_name }, { "constant", constant_name } });
+                _register_constant(OScriptNodeClassConstant::get_class_static(), constants_category,
+                    global_name, constant_name, value, data, r_actions);
+            }
+        }
     }
 }
 

--- a/src/editor/actions/introspector.h
+++ b/src/editor/actions/introspector.h
@@ -54,6 +54,9 @@ class OrchestratorEditorIntrospector {
     static void _register_static_methods(const String& p_lookup_class, const String& p_register_class, const String& p_category, ActionSet& r_actions);
     static void _register_global_class_static_methods(const String& p_class_name, const String& p_category, ActionSet& r_actions);
 
+    static void _register_constant(const String& p_node_type, const String& p_category, const String& p_owner, const String& p_constant_name, const Variant& p_value, const Dictionary& p_data, ActionSet& r_actions);
+    static void _register_class_constants(const String& p_class_name, ActionSet& r_actions);
+
 public:
 
     // registrar.filter->target_object->get_target()

--- a/src/orchestration/nodes/constants.cpp
+++ b/src/orchestration/nodes/constants.cpp
@@ -25,7 +25,7 @@
 #include <godot_cpp/classes/engine.hpp>
 
 OScriptNodeConstant::OScriptNodeConstant() {
-    _flags = CATALOGABLE | EXPERIMENTAL;
+    _flags = CATALOGABLE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -134,6 +134,13 @@ PackedStringArray OScriptNodeGlobalConstant::get_keywords() const {
     return PackedStringArray();
 }
 
+void OScriptNodeGlobalConstant::configure(const OScriptNodeInitContext& p_context) {
+    super::configure(p_context);
+
+    const Dictionary data = p_context.user_data.value_or(Dictionary());
+    _constant_name = data.get("constant", StringName());
+}
+
 void OScriptNodeGlobalConstant::initialize(const OScriptNodeInitContext& p_context) {
     _constant_name = _get_default_constant_name();
     super::initialize(p_context);
@@ -190,6 +197,13 @@ String OScriptNodeMathConstant::get_icon() const {
 
 PackedStringArray OScriptNodeMathConstant::get_keywords() const {
     return ExtensionDB::get_math_constant_names();
+}
+
+void OScriptNodeMathConstant::configure(const OScriptNodeInitContext& p_context) {
+    super::configure(p_context);
+
+    const Dictionary data = p_context.user_data.value_or(Dictionary());
+    _constant_name = data.get("constant", "One");
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -328,9 +342,24 @@ String OScriptNodeTypeConstant::get_icon() const {
     return "MemberConstant";
 }
 
+void OScriptNodeTypeConstant::configure(const OScriptNodeInitContext& p_context) {
+    super::configure(p_context);
+
+    const Dictionary data = p_context.user_data.value_or(Dictionary());
+    _type = VariantUtils::to_type(data.get("type", Variant::NIL));
+    _constant_name = data.get("constant", "");
+}
+
 void OScriptNodeTypeConstant::initialize(const OScriptNodeInitContext& p_context) {
-    _type = _types[0];
-    _constant_name = _type_constants[_type].begin()->key;
+    // Fall back to the first type and its first constant when the spawn data named neither or named
+    // something this type does not define.
+    if (!_type_constants.has(_type)) {
+        _type = _types[0];
+    }
+
+    if (!_type_constants[_type].has(_constant_name)) {
+        _constant_name = _type_constants[_type].begin()->key;
+    }
     super::initialize(p_context);
 }
 
@@ -468,6 +497,18 @@ String OScriptNodeClassConstantBase::get_help_topic() const {
 
 String OScriptNodeClassConstantBase::get_icon() const {
     return "MemberConstant";
+}
+
+void OScriptNodeClassConstantBase::configure(const OScriptNodeInitContext& p_context) {
+    super::configure(p_context);
+
+    // Each subclass seeds its own default class in its constructor, so only spawn data that names
+    // a class overrides it.
+    const Dictionary data = p_context.user_data.value_or(Dictionary());
+    if (data.has("class_name")) {
+        _class_name = data["class_name"];
+    }
+    _constant_name = data.get("constant", "");
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/orchestration/nodes/constants.h
+++ b/src/orchestration/nodes/constants.h
@@ -69,6 +69,7 @@ public:
     String get_help_topic() const override;
     String get_icon() const override;
     PackedStringArray get_keywords() const override;
+    void configure(const OScriptNodeInitContext& p_context) override;
     void initialize(const OScriptNodeInitContext& p_context) override;
     //~ End OScriptNodeInterface
 
@@ -98,6 +99,7 @@ public:
     String get_help_topic() const override;
     String get_icon() const override;
     PackedStringArray get_keywords() const override;
+    void configure(const OScriptNodeInitContext& p_context) override;
     //~ End OScriptNodeInterface
 
     String get_constant_name() const { return _constant_name; }
@@ -138,6 +140,7 @@ public:
     String get_node_title() const override;
     String get_help_topic() const override;
     String get_icon() const override;
+    void configure(const OScriptNodeInitContext& p_context) override;
     void initialize(const OScriptNodeInitContext& p_context) override;
     //~ End OScriptNodeInterface
 
@@ -188,6 +191,7 @@ public:
     String get_node_title() const override;
     String get_help_topic() const override;
     String get_icon() const override;
+    void configure(const OScriptNodeInitContext& p_context) override;
     //~ End OScriptNodeInterface
 
     String get_constant_class_name() const { return _class_name; }

--- a/src/orchestration/nodes/memory.cpp
+++ b/src/orchestration/nodes/memory.cpp
@@ -110,7 +110,7 @@ void OScriptNodeNew::configure(const OScriptNodeInitContext& p_context) {
 }
 
 OScriptNodeNew::OScriptNodeNew() {
-    _flags.set_flag(EXPERIMENTAL);
+    _flags.set_flag(NONE);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -146,5 +146,5 @@ String OScriptNodeFree::get_icon() const {
 }
 
 OScriptNodeFree::OScriptNodeFree() {
-    _flags.set_flag(EXPERIMENTAL);
+    _flags.set_flag(NONE);
 }


### PR DESCRIPTION
Fixes GH-1820

## Description

This PR introduces several improvements, including:
* Adds individual constants as searchable, selectable items in the all actions dialog
* Changes the "Create New Instance" and "Free Instance" text to include class names for class-specific `.new()`/`.free)`
* Adjusts the sort key for actions so that the entries appear in more natural sort ordering
* Drops experimental from constants and memory-based nodes