### PR TITLE
GH-1355 Clipboard to support operations across scripts/editors

### DIFF
--- a/src/common/resource_utils.cpp
+++ b/src/common/resource_utils.cpp
@@ -69,4 +69,23 @@ namespace ResourceUtils {
         return properties;
     }
 
+    Variant get_storage_property(const Dictionary& p_properties, const StringName& p_class, const StringName& p_name) {
+        if (p_properties.has(p_name)) {
+            return p_properties[p_name];
+        }
+        return GDE::ClassDB::get_property_default_value(p_class, p_name);
+    }
+
+    void apply_storage_properties(const Ref<Resource>& p_resource, const Dictionary& p_properties, const Vector<StringName>& p_excluded) {
+        ERR_FAIL_COND(p_resource.is_null());
+
+        const Array keys = p_properties.keys();
+        for (int i = 0; i < keys.size(); i++) {
+            const StringName key = keys[i];
+            if (!p_excluded.has(key)) {
+                p_resource->set(key, p_properties[key]);
+            }
+        }
+    }
+
 }

--- a/src/common/resource_utils.cpp
+++ b/src/common/resource_utils.cpp
@@ -17,6 +17,7 @@
 #include "common/resource_utils.h"
 
 #include "common/dictionary_utils.h"
+#include "core/godot/object/class_db.h"
 
 #include <godot_cpp/classes/file_access.hpp>
 
@@ -41,7 +42,28 @@ namespace ResourceUtils {
                 continue;
             }
 
-            properties[property.name] = p_resource->get(property.name);
+            const Variant value = p_resource->get(property.name);
+
+            // Same rules as the script serializers: a value equal to the class default is not persisted,
+            // nor is a null object unless the property asks for it.
+            const Variant default_value = GDE::ClassDB::get_property_default_value(p_resource->get_class(), property.name);
+            if (default_value.get_type() != Variant::NIL) {
+                bool valid = false;
+                Variant result = false;
+                Variant::evaluate(Variant::OP_EQUAL, value, default_value, result, valid);
+                if (valid && result) {
+                    continue;
+                }
+            }
+
+            if (property.type == Variant::OBJECT) {
+                const Object* object = Object::cast_to<Object>(value);
+                if (!object && !(property.usage & PROPERTY_USAGE_STORE_IF_NULL)) {
+                    continue;
+                }
+            }
+
+            properties[property.name] = value;
         }
 
         return properties;

--- a/src/common/resource_utils.cpp
+++ b/src/common/resource_utils.cpp
@@ -16,12 +16,35 @@
 //
 #include "common/resource_utils.h"
 
+#include "common/dictionary_utils.h"
+
 #include <godot_cpp/classes/file_access.hpp>
 
 namespace ResourceUtils {
 
     bool is_file(const String& p_path) {
         return p_path.begins_with("res://") && p_path.find("::") == -1;
+    }
+
+    Dictionary get_storage_properties(const Ref<Resource>& p_resource) {
+        Dictionary properties;
+        ERR_FAIL_COND_V(p_resource.is_null(), properties);
+
+        const TypedArray<Dictionary> property_list = p_resource->get_property_list();
+        for (int i = 0; i < property_list.size(); i++) {
+            const PropertyInfo property = DictionaryUtils::to_property(property_list[i]);
+            if (!(property.usage & PROPERTY_USAGE_STORAGE)) {
+                continue;
+            }
+
+            if (property.name.match("script") || property.name.begins_with("resource_") || property.name.begins_with("metadata/")) {
+                continue;
+            }
+
+            properties[property.name] = p_resource->get(property.name);
+        }
+
+        return properties;
     }
 
 }

--- a/src/common/resource_utils.h
+++ b/src/common/resource_utils.h
@@ -26,4 +26,10 @@ namespace ResourceUtils {
     /// @return true if it is a file path; false otherwise
     bool is_file(const String& p_path);
 
+    /// Collects the persisted state of a resource, the same properties the script serializers write.
+    /// Resource base properties, the script, and transient metadata are excluded.
+    /// @param p_resource the resource
+    /// @return property name to value map, in property list order
+    Dictionary get_storage_properties(const Ref<Resource>& p_resource);
+
 }

--- a/src/common/resource_utils.h
+++ b/src/common/resource_utils.h
@@ -33,4 +33,18 @@ namespace ResourceUtils {
     /// @return property name to value map, in property list order
     Dictionary get_storage_properties(const Ref<Resource>& p_resource);
 
+    /// Reads a property from a map produced by <code>get_storage_properties</code>, falling back to the
+    /// class default when the map omits it.
+    /// @param p_properties the property map
+    /// @param p_class the class the map was collected from
+    /// @param p_name the property name
+    /// @return the stored value, or the class default
+    Variant get_storage_property(const Dictionary& p_properties, const StringName& p_class, const StringName& p_name);
+
+    /// Applies a map produced by <code>get_storage_properties</code> to a resource.
+    /// @param p_resource the resource
+    /// @param p_properties the property map
+    /// @param p_excluded property names that are not applied
+    void apply_storage_properties(const Ref<Resource>& p_resource, const Dictionary& p_properties, const Vector<StringName>& p_excluded = Vector<StringName>());
+
 }

--- a/src/common/resource_utils.h
+++ b/src/common/resource_utils.h
@@ -27,7 +27,8 @@ namespace ResourceUtils {
     bool is_file(const String& p_path);
 
     /// Collects the persisted state of a resource, the same properties the script serializers write.
-    /// Resource base properties, the script, and transient metadata are excluded.
+    /// Resource base properties, the script, and transient metadata are excluded, as are values that
+    /// equal the class default, so consumers must treat an absent property as the default.
     /// @param p_resource the resource
     /// @return property name to value map, in property list order
     Dictionary get_storage_properties(const Ref<Resource>& p_resource);

--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -30,6 +30,7 @@
 #include "editor/actions/registry.h"
 #include "editor/editor_view.h"
 #include "editor/getting_started.h"
+#include "editor/graph/graph_clipboard.h"
 #include "editor/gui/about_dialog.h"
 #include "editor/gui/dialogs_helper.h"
 #include "editor/gui/editor_log_event_router.h"
@@ -2779,5 +2780,6 @@ OrchestratorEditor::OrchestratorEditor(OrchestratorWindowWrapper* p_window_wrapp
 }
 
 OrchestratorEditor::~OrchestratorEditor() {
+    OrchestratorEditorGraphClipboard::free_resources();
     memdelete(_theme_manager);
 }

--- a/src/editor/graph/graph_clipboard.cpp
+++ b/src/editor/graph/graph_clipboard.cpp
@@ -28,18 +28,73 @@
 #include "orchestration/nodes/operator_node.h"
 #include "orchestration/nodes/variables.h"
 #include "orchestration/orchestration.h"
+#include "orchestration/serialization/format.h"
 
-Dictionary* OrchestratorEditorGraphClipboard::_payload = nullptr;
+#include <godot_cpp/classes/display_server.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+namespace {
+    constexpr const char* PAYLOAD_MAGIC = "orchestrator/clipboard";
+    constexpr const char* PAYLOAD_HEADER = "; orchestrator/clipboard";
+}
+
+OrchestratorEditorGraphClipboard::Buffer* OrchestratorEditorGraphClipboard::_buffer = nullptr;
 
 bool OrchestratorEditorGraphClipboard::ClipboardResult::had_skipped_nodes() const {
     return !skipped_functions.is_empty() || !skipped_events.is_empty() || !skipped_variables.is_empty() || !skipped_signals.is_empty();
 }
 
-Dictionary& OrchestratorEditorGraphClipboard::_get_payload() {
-    if (!_payload) {
-        _payload = memnew(Dictionary);
+void OrchestratorEditorGraphClipboard::_write_payload(const Dictionary& p_payload) {
+    if (!_buffer) {
+        _buffer = memnew(Buffer);
     }
-    return *_payload;
+
+    _buffer->payload = p_payload;
+    _buffer->text = String(PAYLOAD_HEADER) + "\n" + UtilityFunctions::var_to_str(p_payload);
+
+    if (DisplayServer* display_server = DisplayServer::get_singleton()) {
+        display_server->clipboard_set(_buffer->text);
+    }
+}
+
+bool OrchestratorEditorGraphClipboard::_read_payload(Dictionary& r_payload) {
+    DisplayServer* display_server = DisplayServer::get_singleton();
+    const String text = display_server ? display_server->clipboard_get() : String();
+
+    // Nothing on the OS clipboard, or no OS clipboard at all, falls back to what this editor last copied
+    if (text.is_empty()) {
+        if (_buffer && !_buffer->payload.is_empty()) {
+            r_payload = _buffer->payload;
+            return true;
+        }
+        return false;
+    }
+
+    // Something other than a payload is on the clipboard, there is nothing to paste
+    if (!text.begins_with(PAYLOAD_HEADER)) {
+        return false;
+    }
+
+    // Text this editor produced needs no parsing
+    if (_buffer && text == _buffer->text) {
+        r_payload = _buffer->payload;
+        return true;
+    }
+
+    // The header is a parser comment, so the text is parsed as a whole
+    const Variant parsed = UtilityFunctions::str_to_var(text);
+    ERR_FAIL_COND_V_MSG(parsed.get_type() != Variant::DICTIONARY, false, "The clipboard payload could not be parsed.");
+
+    const Dictionary payload = parsed;
+    ERR_FAIL_COND_V_MSG(String(payload.get("magic", String())) != PAYLOAD_MAGIC, false, "The clipboard text is not an Orchestrator payload.");
+
+    const Dictionary graph = payload.get("graph", Dictionary());
+    const uint32_t format = graph.get("format", OrchestrationFormat::FORMAT_VERSION);
+    ERR_FAIL_COND_V_MSG(format > OrchestrationFormat::FORMAT_VERSION, false,
+        vformat("The clipboard payload was created by a newer version of Orchestrator (%s).", String(payload.get("plugin", String()))));
+
+    r_payload = payload;
+    return true;
 }
 
 void OrchestratorEditorGraphClipboard::_apply_properties(const Ref<Resource>& p_resource, const Dictionary& p_properties, const Vector<StringName>& p_excluded) {
@@ -111,14 +166,16 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
         result.added_nodes.insert(script_node->get_id());
     }
 
-    Dictionary& payload = _get_payload();
-    payload["magic"] = "orchestrator/clipboard";
+    Dictionary payload;
+    payload["magic"] = PAYLOAD_MAGIC;
     payload["plugin"] = VERSION_FULL_BUILD;
     payload["graph"] = p_source->export_nodes(node_ids);
     payload["functions"] = functions;
     payload["events"] = events;
     payload["variables"] = variables;
     payload["signals"] = signals;
+
+    _write_payload(payload);
 
     return result;
 }
@@ -127,14 +184,14 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
     const Ref<OrchestrationGraph>& p_target, const Vector2& p_offset, bool p_snapping_enabled, int p_snapping_distance) {
 
     ClipboardResult result;
-    if (!_payload || _payload->is_empty()) {
+
+    Dictionary payload;
+    if (!_read_payload(payload)) {
         return result;
     }
 
     Orchestration* orchestration = p_target->get_orchestration();
     ERR_FAIL_NULL_V(orchestration, result);
-
-    const Dictionary& payload = *_payload;
 
     // Properties that identify a resource within its source orchestration, or that the target
     // consumes when it creates the resource. Everything else in a declaration is applied as-is.
@@ -370,14 +427,15 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
 }
 
 void OrchestratorEditorGraphClipboard::clear() {
-    if (_payload) {
-        _payload->clear();
+    if (_buffer) {
+        _buffer->payload.clear();
+        _buffer->text = String();
     }
 }
 
 void OrchestratorEditorGraphClipboard::free_resources() {
-    if (_payload) {
-        memdelete(_payload);
-        _payload = nullptr;
+    if (_buffer) {
+        memdelete(_buffer);
+        _buffer = nullptr;
     }
 }

--- a/src/editor/graph/graph_clipboard.cpp
+++ b/src/editor/graph/graph_clipboard.cpp
@@ -27,6 +27,7 @@
 #include "orchestration/nodes/comment.h"
 #include "orchestration/nodes/emit_signal.h"
 #include "orchestration/nodes/event.h"
+#include "orchestration/nodes/function_result.h"
 #include "orchestration/nodes/operator_node.h"
 #include "orchestration/nodes/variables.h"
 #include "orchestration/orchestration.h"
@@ -57,7 +58,8 @@ bool OrchestratorEditorGraphClipboard::ClipboardResult::is_empty() const {
 }
 
 bool OrchestratorEditorGraphClipboard::ClipboardResult::had_skipped_nodes() const {
-    return !skipped_functions.is_empty() || !skipped_events.is_empty() || !skipped_variables.is_empty() || !skipped_signals.is_empty();
+    return !skipped_functions.is_empty() || !skipped_events.is_empty() || !skipped_variables.is_empty()
+        || !skipped_signals.is_empty() || !skipped_nodes.is_empty();
 }
 
 bool OrchestratorEditorGraphClipboard::ClipboardResult::had_renamed_declarations() const {
@@ -96,6 +98,9 @@ String OrchestratorEditorGraphClipboard::ClipboardResult::get_summary() const {
         }
         for (const KeyValue<StringName, String>& E : skipped_signals) {
             summary += vformat("* Signal %s: %s\n", E.key, E.value);
+        }
+        for (const KeyValue<uint64_t, String>& E : skipped_nodes) {
+            summary += vformat("* Node %d: %s\n", E.key, E.value);
         }
     }
 
@@ -795,6 +800,15 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
             }
 
             remap[id] = node->get_id();
+            continue;
+        }
+
+        // A return node rebinds to the function owning the graph it lands in when it is placed, see
+        // OScriptNodeFunctionResult::post_placed_new_node, but it cannot exist outside a function graph at all.
+        if (ClassDB::is_parent_class(class_name, OScriptNodeFunctionResult::get_class_static())
+                && !p_target->get_flags().has_flag(OrchestrationGraph::GF_FUNCTION)) {
+            result.skipped_nodes[id] = "Return nodes can only be pasted into function graphs.";
+            skipped.insert(id);
             continue;
         }
 

--- a/src/editor/graph/graph_clipboard.cpp
+++ b/src/editor/graph/graph_clipboard.cpp
@@ -21,6 +21,8 @@
 #include "common/property_utils.h"
 #include "common/resource_utils.h"
 #include "common/version.h"
+#include "core/godot/object/class_db.h"
+#include "orchestration/function.h"
 #include "orchestration/nodes/call_function.h"
 #include "orchestration/nodes/comment.h"
 #include "orchestration/nodes/emit_signal.h"
@@ -29,6 +31,8 @@
 #include "orchestration/nodes/variables.h"
 #include "orchestration/orchestration.h"
 #include "orchestration/serialization/format.h"
+#include "orchestration/signals.h"
+#include "orchestration/variable.h"
 
 #include <godot_cpp/classes/display_server.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
@@ -95,6 +99,14 @@ bool OrchestratorEditorGraphClipboard::_read_payload(Dictionary& r_payload) {
 
     r_payload = payload;
     return true;
+}
+
+Variant OrchestratorEditorGraphClipboard::_get_declared(const Dictionary& p_properties, const StringName& p_class, const StringName& p_name) {
+    // Declarations omit values equal to the class default, see ResourceUtils::get_storage_properties
+    if (p_properties.has(p_name)) {
+        return p_properties[p_name];
+    }
+    return GDE::ClassDB::get_property_default_value(p_class, p_name);
 }
 
 void OrchestratorEditorGraphClipboard::_apply_properties(const Ref<Resource>& p_resource, const Dictionary& p_properties, const Vector<StringName>& p_excluded) {
@@ -205,11 +217,11 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
     for (int i = 0; i < function_names.size(); i++) {
         const StringName name = function_names[i];
         const Dictionary declaration = functions[name];
-        const MethodInfo method = DictionaryUtils::to_method(declaration.get("method", Dictionary()));
+        const MethodInfo method = DictionaryUtils::to_method(_get_declared(declaration, OScriptFunction::get_class_static(), "method"));
 
         const Ref<OScriptFunction> target_function = orchestration->find_function(name);
         if (!target_function.is_valid()) {
-            const bool user_defined = declaration.get("user_defined", false);
+            const bool user_defined = _get_declared(declaration, OScriptFunction::get_class_static(), "user_defined");
             const Ref<OScriptFunction> function = orchestration->create_function(method, user_defined);
             if (!function.is_valid()) {
                 result.skipped_functions[name] = "Failed to create function.";
@@ -232,7 +244,7 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
 
         const Ref<OScriptFunction> target_function = orchestration->find_function(name);
         if (target_function.is_valid()) {
-            const MethodInfo method = DictionaryUtils::to_method(declaration.get("method", Dictionary()));
+            const MethodInfo method = DictionaryUtils::to_method(_get_declared(declaration, OScriptFunction::get_class_static(), "method"));
             if (!MethodUtils::has_same_signature(method, target_function->get_method_info())) {
                 result.skipped_events[name] = "Event function signatures do not match.";
             }
@@ -251,7 +263,7 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
             const Ref<OScriptVariable> variable = orchestration->create_variable(name);
             ERR_CONTINUE(!variable.is_valid());
             _apply_properties(variable, properties, variable_identity);
-        } else if (!PropertyUtils::are_equal(DictionaryUtils::to_property(properties.get("info", Dictionary())), target_variable->get_info())) {
+        } else if (!PropertyUtils::are_equal(DictionaryUtils::to_property(_get_declared(properties, OScriptVariable::get_class_static(), "info")), target_variable->get_info())) {
             result.skipped_variables[name] = "Variable declarations do not match.";
         }
     }
@@ -268,7 +280,7 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
             const Ref<OScriptSignal> signal = orchestration->create_custom_signal(name);
             ERR_CONTINUE(!signal.is_valid());
             _apply_properties(signal, properties, signal_identity);
-        } else if (!MethodUtils::has_same_signature(DictionaryUtils::to_method(properties.get("method", Dictionary())), target_signal->get_method_info())) {
+        } else if (!MethodUtils::has_same_signature(DictionaryUtils::to_method(_get_declared(properties, OScriptSignal::get_class_static(), "method")), target_signal->get_method_info())) {
             result.skipped_signals[name] = "Signal signatures do not match.";
         }
     }
@@ -329,8 +341,8 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
             const Dictionary declaration = events[name];
 
             OScriptNodeInitContext context;
-            context.method = DictionaryUtils::to_method(declaration.get("method", Dictionary()));
-            context.user_data = DictionaryUtils::of({ { "user_defined", declaration.get("user_defined", false) } });
+            context.method = DictionaryUtils::to_method(_get_declared(declaration, OScriptFunction::get_class_static(), "method"));
+            context.user_data = DictionaryUtils::of({ { "user_defined", _get_declared(declaration, OScriptFunction::get_class_static(), "user_defined") } });
 
             const Vector2 position = Vector2(properties.get("position", Vector2())) + offset;
             const Ref<OScriptNode> node = p_target->create_node<OScriptNodeEvent>(context, position);

--- a/src/editor/graph/graph_clipboard.cpp
+++ b/src/editor/graph/graph_clipboard.cpp
@@ -18,10 +18,10 @@
 
 #include "common/dictionary_utils.h"
 #include "common/method_utils.h"
+#include "common/name_utils.h"
 #include "common/property_utils.h"
 #include "common/resource_utils.h"
 #include "common/version.h"
-#include "core/godot/object/class_db.h"
 #include "orchestration/function.h"
 #include "orchestration/nodes/call_function.h"
 #include "orchestration/nodes/comment.h"
@@ -40,12 +40,66 @@
 namespace {
     constexpr const char* PAYLOAD_MAGIC = "orchestrator/clipboard";
     constexpr const char* PAYLOAD_HEADER = "; orchestrator/clipboard";
+
+    // Properties that identify a resource within its source orchestration, or that the target consumes
+    // when it creates the resource. Everything else in a declaration is applied as-is. Built on demand:
+    // a StringName at static-init time is constructed before the extension is initialized and crashes
+    // the plugin on load.
+    Vector<StringName> function_identity() { return { "guid", "id", "method", "user_defined", "graph" }; }
+    Vector<StringName> variable_identity() { return { "name" }; }
+    Vector<StringName> signal_identity() { return { "signal_name" }; }
 }
 
 OrchestratorEditorGraphClipboard::Buffer* OrchestratorEditorGraphClipboard::_buffer = nullptr;
 
+bool OrchestratorEditorGraphClipboard::ClipboardResult::is_empty() const {
+    return added_nodes.is_empty() && added_functions.is_empty() && added_variables.is_empty() && added_signals.is_empty();
+}
+
 bool OrchestratorEditorGraphClipboard::ClipboardResult::had_skipped_nodes() const {
     return !skipped_functions.is_empty() || !skipped_events.is_empty() || !skipped_variables.is_empty() || !skipped_signals.is_empty();
+}
+
+bool OrchestratorEditorGraphClipboard::ClipboardResult::had_renamed_declarations() const {
+    return !renamed_functions.is_empty() || !renamed_variables.is_empty() || !renamed_signals.is_empty();
+}
+
+String OrchestratorEditorGraphClipboard::ClipboardResult::get_summary() const {
+    String summary;
+
+    if (had_renamed_declarations()) {
+        summary += "The following items were pasted under a new name:\n\n";
+        for (const KeyValue<StringName, StringName>& E : renamed_functions) {
+            summary += vformat("* Function %s was pasted as %s\n", E.key, E.value);
+        }
+        for (const KeyValue<StringName, StringName>& E : renamed_variables) {
+            summary += vformat("* Variable %s was pasted as %s\n", E.key, E.value);
+        }
+        for (const KeyValue<StringName, StringName>& E : renamed_signals) {
+            summary += vformat("* Signal %s was pasted as %s\n", E.key, E.value);
+        }
+    }
+
+    if (had_skipped_nodes()) {
+        if (!summary.is_empty()) {
+            summary += "\n";
+        }
+        summary += "Several nodes were not pasted due to the following reasons:\n\n";
+        for (const KeyValue<StringName, String>& E : skipped_functions) {
+            summary += vformat("* Function %s: %s\n", E.key, E.value);
+        }
+        for (const KeyValue<StringName, String>& E : skipped_events) {
+            summary += vformat("* Event %s: %s\n", E.key, E.value);
+        }
+        for (const KeyValue<StringName, String>& E : skipped_variables) {
+            summary += vformat("* Variable %s: %s\n", E.key, E.value);
+        }
+        for (const KeyValue<StringName, String>& E : skipped_signals) {
+            summary += vformat("* Signal %s: %s\n", E.key, E.value);
+        }
+    }
+
+    return summary;
 }
 
 void OrchestratorEditorGraphClipboard::_write_payload(const Dictionary& p_payload) {
@@ -92,8 +146,7 @@ bool OrchestratorEditorGraphClipboard::_read_payload(Dictionary& r_payload) {
     const Dictionary payload = parsed;
     ERR_FAIL_COND_V_MSG(String(payload.get("magic", String())) != PAYLOAD_MAGIC, false, "The clipboard text is not an Orchestrator payload.");
 
-    const Dictionary graph = payload.get("graph", Dictionary());
-    const uint32_t format = graph.get("format", OrchestrationFormat::FORMAT_VERSION);
+    const uint32_t format = payload.get("format", OrchestrationFormat::FORMAT_VERSION);
     ERR_FAIL_COND_V_MSG(format > OrchestrationFormat::FORMAT_VERSION, false,
         vformat("The clipboard payload was created by a newer version of Orchestrator (%s).", String(payload.get("plugin", String()))));
 
@@ -101,20 +154,364 @@ bool OrchestratorEditorGraphClipboard::_read_payload(Dictionary& r_payload) {
     return true;
 }
 
-Variant OrchestratorEditorGraphClipboard::_get_declared(const Dictionary& p_properties, const StringName& p_class, const StringName& p_name) {
-    // Declarations omit values equal to the class default, see ResourceUtils::get_storage_properties
-    if (p_properties.has(p_name)) {
-        return p_properties[p_name];
+Dictionary OrchestratorEditorGraphClipboard::_create_payload(const Dictionary& p_functions, const Dictionary& p_events,
+    const Dictionary& p_variables, const Dictionary& p_signals, const Dictionary& p_graph) {
+
+    Dictionary payload;
+    payload["magic"] = PAYLOAD_MAGIC;
+    payload["plugin"] = VERSION_FULL_BUILD;
+    payload["format"] = OrchestrationFormat::FORMAT_VERSION;
+    if (!p_graph.is_empty()) {
+        payload["graph"] = p_graph;
     }
-    return GDE::ClassDB::get_property_default_value(p_class, p_name);
+    payload["functions"] = p_functions;
+    payload["events"] = p_events;
+    payload["variables"] = p_variables;
+    payload["signals"] = p_signals;
+
+    return payload;
 }
 
-void OrchestratorEditorGraphClipboard::_apply_properties(const Ref<Resource>& p_resource, const Dictionary& p_properties, const Vector<StringName>& p_excluded) {
-    const Array keys = p_properties.keys();
-    for (int i = 0; i < keys.size(); i++) {
-        const StringName key = keys[i];
-        if (!p_excluded.has(key)) {
-            p_resource->set(key, p_properties[key]);
+void OrchestratorEditorGraphClipboard::_collect_function_closure(Orchestration* p_source, const StringName& p_name,
+    Dictionary& r_functions, Dictionary& r_variables, Dictionary& r_signals) {
+
+    Vector<StringName> worklist;
+    worklist.push_back(p_name);
+
+    while (!worklist.is_empty()) {
+        const StringName name = worklist[worklist.size() - 1];
+        worklist.remove_at(worklist.size() - 1);
+
+        if (r_functions.has(name)) {
+            continue;
+        }
+
+        const Ref<OScriptFunction> function = p_source->find_function(name);
+        if (!function.is_valid()) {
+            continue;
+        }
+
+        // Only user functions have a body of their own; anything else travels as a declaration
+        if (!function->is_user_defined()) {
+            r_functions[name] = ResourceUtils::get_storage_properties(function);
+            continue;
+        }
+
+        const Dictionary data = p_source->export_function(name);
+        r_functions[name] = data;
+
+        if (data.has("graph")) {
+            _collect_references(p_source, data["graph"], worklist, r_variables, r_signals);
+        }
+    }
+}
+
+void OrchestratorEditorGraphClipboard::_collect_references(Orchestration* p_source, const Dictionary& p_graph,
+    Vector<StringName>& r_worklist, Dictionary& r_variables, Dictionary& r_signals) {
+
+    const Array entries = p_graph.get("nodes", Array());
+    for (int i = 0; i < entries.size(); i++) {
+        const Dictionary entry = entries[i];
+        const String class_name = entry.get("class", String());
+        const Dictionary properties = entry.get("properties", Dictionary());
+
+        if (ClassDB::is_parent_class(class_name, OScriptNodeCallScriptFunction::get_class_static())) {
+            r_worklist.push_back(properties.get("function_name", String()));
+        } else if (ClassDB::is_parent_class(class_name, OScriptNodeVariable::get_class_static())) {
+            const StringName name = properties.get("variable_name", String());
+            if (!r_variables.has(name)) {
+                const Ref<OScriptVariable> variable = p_source->get_variable(name);
+                if (variable.is_valid()) {
+                    r_variables[name] = ResourceUtils::get_storage_properties(variable);
+                }
+            }
+        } else if (ClassDB::is_parent_class(class_name, OScriptNodeEmitSignal::get_class_static())) {
+            const StringName name = properties.get("signal_name", String());
+            if (!r_signals.has(name)) {
+                const Ref<OScriptSignal> signal = p_source->find_custom_signal(name);
+                if (signal.is_valid()) {
+                    r_signals[name] = ResourceUtils::get_storage_properties(signal);
+                }
+            }
+        }
+    }
+}
+
+Vector<Dictionary> OrchestratorEditorGraphClipboard::_get_node_entries(const Dictionary& p_payload) {
+    Vector<Dictionary> result;
+
+    const Dictionary graph = p_payload.get("graph", Dictionary());
+    const Array entries = graph.get("nodes", Array());
+    for (int i = 0; i < entries.size(); i++) {
+        result.push_back(entries[i]);
+    }
+
+    const Dictionary functions = p_payload.get("functions", Dictionary());
+    const Array names = functions.keys();
+    for (int i = 0; i < names.size(); i++) {
+        const Dictionary declaration = functions[names[i]];
+        const Dictionary body = declaration.get("graph", Dictionary());
+        const Array body_entries = body.get("nodes", Array());
+        for (int j = 0; j < body_entries.size(); j++) {
+            result.push_back(body_entries[j]);
+        }
+    }
+
+    return result;
+}
+
+String OrchestratorEditorGraphClipboard::_describe_function(const Dictionary& p_declaration) {
+    const MethodInfo method = DictionaryUtils::to_method(ResourceUtils::get_storage_property(p_declaration, OScriptFunction::get_class_static(), "method"));
+    return MethodUtils::get_signature(method);
+}
+
+String OrchestratorEditorGraphClipboard::_describe_variable(const Dictionary& p_declaration) {
+    const PropertyInfo info = DictionaryUtils::to_property(ResourceUtils::get_storage_property(p_declaration, OScriptVariable::get_class_static(), "info"));
+    return PropertyUtils::get_property_type_name(info);
+}
+
+String OrchestratorEditorGraphClipboard::_describe_signal(const Dictionary& p_declaration) {
+    const MethodInfo method = DictionaryUtils::to_method(ResourceUtils::get_storage_property(p_declaration, OScriptSignal::get_class_static(), "method"));
+    return MethodUtils::get_signature(method);
+}
+
+void OrchestratorEditorGraphClipboard::_rename_function(Dictionary& p_payload, const StringName& p_old_name, const StringName& p_new_name) {
+    Dictionary functions = p_payload.get("functions", Dictionary());
+    if (!functions.has(p_old_name)) {
+        return;
+    }
+
+    Dictionary declaration = functions[p_old_name];
+    functions.erase(p_old_name);
+
+    Dictionary method = declaration.get("method", Dictionary());
+    method["name"] = p_new_name;
+    declaration["method"] = method;
+    functions[p_new_name] = declaration;
+
+    // Every call to the function, in the selection and in any carried body, follows the new name
+    for (const Dictionary& entry : _get_node_entries(p_payload)) {
+        const String class_name = entry.get("class", String());
+        if (!ClassDB::is_parent_class(class_name, OScriptNodeCallScriptFunction::get_class_static())) {
+            continue;
+        }
+
+        Dictionary properties = entry.get("properties", Dictionary());
+        if (StringName(properties.get("function_name", String())) != p_old_name) {
+            continue;
+        }
+
+        properties["function_name"] = p_new_name;
+        if (properties.has("method")) {
+            Dictionary call_method = properties["method"];
+            if (call_method.has("name")) {
+                call_method["name"] = p_new_name;
+            }
+        }
+    }
+}
+
+void OrchestratorEditorGraphClipboard::_rename_variable(Dictionary& p_payload, const StringName& p_old_name, const StringName& p_new_name) {
+    Dictionary variables = p_payload.get("variables", Dictionary());
+    if (!variables.has(p_old_name)) {
+        return;
+    }
+
+    Dictionary declaration = variables[p_old_name];
+    variables.erase(p_old_name);
+
+    if (declaration.has("name")) {
+        declaration["name"] = p_new_name;
+    }
+    if (declaration.has("info")) {
+        Dictionary info = declaration["info"];
+        if (info.has("name")) {
+            info["name"] = p_new_name;
+        }
+    }
+    variables[p_new_name] = declaration;
+
+    for (const Dictionary& entry : _get_node_entries(p_payload)) {
+        const String class_name = entry.get("class", String());
+        if (!ClassDB::is_parent_class(class_name, OScriptNodeVariable::get_class_static())) {
+            continue;
+        }
+
+        Dictionary properties = entry.get("properties", Dictionary());
+        if (StringName(properties.get("variable_name", String())) == p_old_name) {
+            properties["variable_name"] = p_new_name;
+        }
+    }
+}
+
+void OrchestratorEditorGraphClipboard::_rename_signal(Dictionary& p_payload, const StringName& p_old_name, const StringName& p_new_name) {
+    Dictionary signals = p_payload.get("signals", Dictionary());
+    if (!signals.has(p_old_name)) {
+        return;
+    }
+
+    Dictionary declaration = signals[p_old_name];
+    signals.erase(p_old_name);
+
+    Dictionary method = declaration.get("method", Dictionary());
+    method["name"] = p_new_name;
+    declaration["method"] = method;
+    if (declaration.has("signal_name")) {
+        declaration["signal_name"] = p_new_name;
+    }
+    signals[p_new_name] = declaration;
+
+    for (const Dictionary& entry : _get_node_entries(p_payload)) {
+        const String class_name = entry.get("class", String());
+        if (!ClassDB::is_parent_class(class_name, OScriptNodeEmitSignal::get_class_static())) {
+            continue;
+        }
+
+        Dictionary properties = entry.get("properties", Dictionary());
+        if (StringName(properties.get("signal_name", String())) == p_old_name) {
+            properties["signal_name"] = p_new_name;
+        }
+    }
+}
+
+void OrchestratorEditorGraphClipboard::_apply_resolutions(Orchestration* p_target, Dictionary& p_payload,
+    const Vector<Resolution>& p_resolutions, ClipboardResult& r_result) {
+
+    // Unique names must avoid every identifier in the target, and the names chosen here
+    PackedStringArray used = p_target->get_function_names();
+    used.append_array(p_target->get_variable_names());
+    used.append_array(p_target->get_custom_signal_names());
+
+    for (const Resolution& resolution : p_resolutions) {
+        if (!resolution.rename) {
+            switch (resolution.kind) {
+                case Conflict::FUNCTION: {
+                    r_result.skipped_functions[resolution.name] = "Skipped by user.";
+                    break;
+                }
+                case Conflict::VARIABLE: {
+                    r_result.skipped_variables[resolution.name] = "Skipped by user.";
+                    break;
+                }
+                case Conflict::SIGNAL: {
+                    r_result.skipped_signals[resolution.name] = "Skipped by user.";
+                    break;
+                }
+            }
+            continue;
+        }
+
+        const StringName new_name = NameUtils::create_unique_name(resolution.name, used);
+        used.push_back(new_name);
+
+        switch (resolution.kind) {
+            case Conflict::FUNCTION: {
+                _rename_function(p_payload, resolution.name, new_name);
+                r_result.renamed_functions[resolution.name] = new_name;
+                break;
+            }
+            case Conflict::VARIABLE: {
+                _rename_variable(p_payload, resolution.name, new_name);
+                r_result.renamed_variables[resolution.name] = new_name;
+                break;
+            }
+            case Conflict::SIGNAL: {
+                _rename_signal(p_payload, resolution.name, new_name);
+                r_result.renamed_signals[resolution.name] = new_name;
+                break;
+            }
+        }
+    }
+}
+
+void OrchestratorEditorGraphClipboard::_paste_declarations(Orchestration* p_target, Dictionary& p_payload,
+    const Vector<Resolution>& p_resolutions, ClipboardResult& r_result) {
+
+    _apply_resolutions(p_target, p_payload, p_resolutions, r_result);
+
+    // Variables and signals first, function bodies resolve them by name as their nodes initialize
+    const Dictionary variables = p_payload.get("variables", Dictionary());
+    const Array variable_names = variables.keys();
+    for (int i = 0; i < variable_names.size(); i++) {
+        const StringName name = variable_names[i];
+        if (r_result.skipped_variables.has(name)) {
+            continue;
+        }
+
+        const Dictionary properties = variables[name];
+        const Ref<OScriptVariable> target_variable = p_target->get_variable(name);
+        if (target_variable.is_null()) {
+            const Ref<OScriptVariable> variable = p_target->create_variable(name);
+            ERR_CONTINUE(!variable.is_valid());
+            ResourceUtils::apply_storage_properties(variable, properties, variable_identity());
+            r_result.added_variables.insert(name);
+        } else if (!PropertyUtils::are_equal(DictionaryUtils::to_property(ResourceUtils::get_storage_property(properties, OScriptVariable::get_class_static(), "info")), target_variable->get_info())) {
+            r_result.skipped_variables[name] = "Variable declarations do not match.";
+        }
+    }
+
+    const Dictionary signals = p_payload.get("signals", Dictionary());
+    const Array signal_names = signals.keys();
+    for (int i = 0; i < signal_names.size(); i++) {
+        const StringName name = signal_names[i];
+        if (r_result.skipped_signals.has(name)) {
+            continue;
+        }
+
+        const Dictionary properties = signals[name];
+        const Ref<OScriptSignal> target_signal = p_target->find_custom_signal(name);
+        if (target_signal.is_null()) {
+            const Ref<OScriptSignal> signal = p_target->create_custom_signal(name);
+            ERR_CONTINUE(!signal.is_valid());
+            ResourceUtils::apply_storage_properties(signal, properties, signal_identity());
+            r_result.added_signals.insert(name);
+        } else if (!MethodUtils::has_same_signature(DictionaryUtils::to_method(ResourceUtils::get_storage_property(properties, OScriptSignal::get_class_static(), "method")), target_signal->get_method_info())) {
+            r_result.skipped_signals[name] = "Signal signatures do not match.";
+        }
+    }
+
+    // Function declarations next, all of them before any function body, so calls between them can be bound
+    const Dictionary functions = p_payload.get("functions", Dictionary());
+    const Array function_names = functions.keys();
+    for (int i = 0; i < function_names.size(); i++) {
+        const StringName name = function_names[i];
+        if (r_result.skipped_functions.has(name)) {
+            continue;
+        }
+
+        const Dictionary declaration = functions[name];
+        const Ref<OScriptFunction> target_function = p_target->find_function(name);
+        if (!target_function.is_valid()) {
+            const Ref<OScriptFunction> function = p_target->import_function(declaration, name);
+            if (!function.is_valid()) {
+                r_result.skipped_functions[name] = "Failed to create function.";
+            } else {
+                r_result.added_functions.insert(name);
+            }
+        } else if (!MethodUtils::has_same_signature(DictionaryUtils::to_method(ResourceUtils::get_storage_property(declaration, OScriptFunction::get_class_static(), "method")), target_function->get_method_info())) {
+            r_result.skipped_functions[name] = "Function signatures do not match.";
+        }
+    }
+
+    // Every function that will exist now does, so call nodes anywhere in the payload can be bound to it
+    for (const Dictionary& entry : _get_node_entries(p_payload)) {
+        const String class_name = entry.get("class", String());
+        if (!ClassDB::is_parent_class(class_name, OScriptNodeCallScriptFunction::get_class_static())) {
+            continue;
+        }
+
+        Dictionary properties = entry.get("properties", Dictionary());
+        const Ref<OScriptFunction> target_function = p_target->find_function(StringName(properties.get("function_name", String())));
+        if (target_function.is_valid()) {
+            properties["guid"] = target_function->get_guid().to_string();
+        }
+    }
+
+    // Bodies last, into the functions created above; an existing function keeps its own body
+    for (const StringName& name : r_result.added_functions) {
+        const Dictionary declaration = functions[name];
+        if (declaration.has("graph")) {
+            p_target->import_function_body(name, declaration["graph"]);
         }
     }
 }
@@ -136,6 +533,11 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
     clear();
 
     ClipboardResult result;
+    ERR_FAIL_COND_V(p_source.is_null(), result);
+
+    Orchestration* orchestration = p_source->get_orchestration();
+    ERR_FAIL_NULL_V(orchestration, result);
+
     Dictionary functions;
     Dictionary events;
     Dictionary variables;
@@ -157,7 +559,8 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
             const Ref<OScriptFunction> function = call_script->get_function();
             ERR_CONTINUE_MSG(function.is_null(), vformat("Cannot copy call function node %d; its function no longer exists.", script_node->get_id()));
 
-            functions[function->get_function_name()] = ResourceUtils::get_storage_properties(function);
+            // The called function travels with its body, and everything the body needs
+            _collect_function_closure(orchestration, function->get_function_name(), functions, variables, signals);
         }
 
         if (const Ref<OScriptNodeVariable>& variable_node = script_node; variable_node.is_valid()) {
@@ -178,24 +581,112 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
         result.added_nodes.insert(script_node->get_id());
     }
 
-    Dictionary payload;
-    payload["magic"] = PAYLOAD_MAGIC;
-    payload["plugin"] = VERSION_FULL_BUILD;
-    payload["graph"] = p_source->export_nodes(node_ids);
-    payload["functions"] = functions;
-    payload["events"] = events;
-    payload["variables"] = variables;
-    payload["signals"] = signals;
-
-    _write_payload(payload);
+    _write_payload(_create_payload(functions, events, variables, signals, p_source->export_nodes(node_ids)));
 
     return result;
 }
 
-OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboard::paste(
-    const Ref<OrchestrationGraph>& p_target, const Vector2& p_offset, bool p_snapping_enabled, int p_snapping_distance) {
+void OrchestratorEditorGraphClipboard::copy_function(Orchestration* p_source, const StringName& p_name) {
+    clear();
+    ERR_FAIL_NULL(p_source);
+
+    Dictionary functions;
+    Dictionary variables;
+    Dictionary signals;
+    _collect_function_closure(p_source, p_name, functions, variables, signals);
+    ERR_FAIL_COND_MSG(functions.is_empty(), "No function exists with the name: " + p_name);
+
+    _write_payload(_create_payload(functions, Dictionary(), variables, signals));
+}
+
+void OrchestratorEditorGraphClipboard::copy_variable(Orchestration* p_source, const StringName& p_name) {
+    clear();
+    ERR_FAIL_NULL(p_source);
+
+    const Ref<OScriptVariable> variable = p_source->get_variable(p_name);
+    ERR_FAIL_COND_MSG(variable.is_null(), "No variable exists with the name: " + p_name);
+
+    Dictionary variables;
+    variables[p_name] = ResourceUtils::get_storage_properties(variable);
+
+    _write_payload(_create_payload(Dictionary(), Dictionary(), variables, Dictionary()));
+}
+
+void OrchestratorEditorGraphClipboard::copy_signal(Orchestration* p_source, const StringName& p_name) {
+    clear();
+    ERR_FAIL_NULL(p_source);
+
+    const Ref<OScriptSignal> signal = p_source->find_custom_signal(p_name);
+    ERR_FAIL_COND_MSG(signal.is_null(), "No signal exists with the name: " + p_name);
+
+    Dictionary signals;
+    signals[p_name] = ResourceUtils::get_storage_properties(signal);
+
+    _write_payload(_create_payload(Dictionary(), Dictionary(), Dictionary(), signals));
+}
+
+Vector<OrchestratorEditorGraphClipboard::Conflict> OrchestratorEditorGraphClipboard::plan(Orchestration* p_target) {
+    Vector<Conflict> conflicts;
+    ERR_FAIL_NULL_V(p_target, conflicts);
+
+    Dictionary payload;
+    if (!_read_payload(payload)) {
+        return conflicts;
+    }
+
+    const Dictionary functions = payload.get("functions", Dictionary());
+    const Array function_names = functions.keys();
+    for (int i = 0; i < function_names.size(); i++) {
+        const StringName name = function_names[i];
+        const Dictionary declaration = functions[name];
+
+        const Ref<OScriptFunction> target_function = p_target->find_function(name);
+        if (target_function.is_valid()) {
+            const MethodInfo method = DictionaryUtils::to_method(ResourceUtils::get_storage_property(declaration, OScriptFunction::get_class_static(), "method"));
+            if (!MethodUtils::has_same_signature(method, target_function->get_method_info())) {
+                conflicts.push_back({ Conflict::FUNCTION, name, _describe_function(declaration), MethodUtils::get_signature(target_function->get_method_info()) });
+            }
+        }
+    }
+
+    const Dictionary variables = payload.get("variables", Dictionary());
+    const Array variable_names = variables.keys();
+    for (int i = 0; i < variable_names.size(); i++) {
+        const StringName name = variable_names[i];
+        const Dictionary declaration = variables[name];
+
+        const Ref<OScriptVariable> target_variable = p_target->get_variable(name);
+        if (target_variable.is_valid()) {
+            const PropertyInfo info = DictionaryUtils::to_property(ResourceUtils::get_storage_property(declaration, OScriptVariable::get_class_static(), "info"));
+            if (!PropertyUtils::are_equal(info, target_variable->get_info())) {
+                conflicts.push_back({ Conflict::VARIABLE, name, _describe_variable(declaration), PropertyUtils::get_property_type_name(target_variable->get_info()) });
+            }
+        }
+    }
+
+    const Dictionary signals = payload.get("signals", Dictionary());
+    const Array signal_names = signals.keys();
+    for (int i = 0; i < signal_names.size(); i++) {
+        const StringName name = signal_names[i];
+        const Dictionary declaration = signals[name];
+
+        const Ref<OScriptSignal> target_signal = p_target->find_custom_signal(name);
+        if (target_signal.is_valid()) {
+            const MethodInfo method = DictionaryUtils::to_method(ResourceUtils::get_storage_property(declaration, OScriptSignal::get_class_static(), "method"));
+            if (!MethodUtils::has_same_signature(method, target_signal->get_method_info())) {
+                conflicts.push_back({ Conflict::SIGNAL, name, _describe_signal(declaration), MethodUtils::get_signature(target_signal->get_method_info()) });
+            }
+        }
+    }
+
+    return conflicts;
+}
+
+OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboard::paste(const Ref<OrchestrationGraph>& p_target,
+    const Vector2& p_offset, bool p_snapping_enabled, int p_snapping_distance, const Vector<Resolution>& p_resolutions) {
 
     ClipboardResult result;
+    ERR_FAIL_COND_V(p_target.is_null(), result);
 
     Dictionary payload;
     if (!_read_payload(payload)) {
@@ -205,37 +696,21 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
     Orchestration* orchestration = p_target->get_orchestration();
     ERR_FAIL_NULL_V(orchestration, result);
 
-    // Properties that identify a resource within its source orchestration, or that the target
-    // consumes when it creates the resource. Everything else in a declaration is applied as-is.
-    const Vector<StringName> function_identity = { "guid", "id", "method", "user_defined" };
-    const Vector<StringName> variable_identity = { "name" };
-    const Vector<StringName> signal_identity = { "signal_name" };
+    // The payload is worked on as a deep copy, renames and reference rewrites must not alter the buffer
+    Dictionary working = payload.duplicate(true);
 
-    // Pass 1 - Verify Functions
-    const Dictionary functions = payload.get("functions", Dictionary());
-    const Array function_names = functions.keys();
-    for (int i = 0; i < function_names.size(); i++) {
-        const StringName name = function_names[i];
-        const Dictionary declaration = functions[name];
-        const MethodInfo method = DictionaryUtils::to_method(_get_declared(declaration, OScriptFunction::get_class_static(), "method"));
+    _paste_declarations(orchestration, working, p_resolutions, result);
 
-        const Ref<OScriptFunction> target_function = orchestration->find_function(name);
-        if (!target_function.is_valid()) {
-            const bool user_defined = _get_declared(declaration, OScriptFunction::get_class_static(), "user_defined");
-            const Ref<OScriptFunction> function = orchestration->create_function(method, user_defined);
-            if (!function.is_valid()) {
-                result.skipped_functions[name] = "Failed to create function.";
-            } else {
-                _apply_properties(function, declaration, function_identity);
-            }
-        } else if (!MethodUtils::has_same_signature(method, target_function->get_method_info())) {
-            result.skipped_functions[name] = "Function signatures do not match.";
-        }
+    // A payload copied from the components panel carries no graph nodes, the declarations were the paste
+    const Dictionary graph = working.get("graph", Dictionary());
+    const Array entries = graph.get("nodes", Array());
+    if (entries.is_empty()) {
+        return result;
     }
 
-    // Pass 2 - Verify Events
+    // Verify events; their function may already exist in the target with a different signature
     HashMap<String, StringName> event_names;
-    const Dictionary events = payload.get("events", Dictionary());
+    const Dictionary events = working.get("events", Dictionary());
     const Array event_keys = events.keys();
     for (int i = 0; i < event_keys.size(); i++) {
         const StringName name = event_keys[i];
@@ -244,54 +719,16 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
 
         const Ref<OScriptFunction> target_function = orchestration->find_function(name);
         if (target_function.is_valid()) {
-            const MethodInfo method = DictionaryUtils::to_method(_get_declared(declaration, OScriptFunction::get_class_static(), "method"));
+            const MethodInfo method = DictionaryUtils::to_method(ResourceUtils::get_storage_property(declaration, OScriptFunction::get_class_static(), "method"));
             if (!MethodUtils::has_same_signature(method, target_function->get_method_info())) {
                 result.skipped_events[name] = "Event function signatures do not match.";
             }
         }
     }
 
-    // Pass 3 - Create missing variables
-    const Dictionary variables = payload.get("variables", Dictionary());
-    const Array variable_names = variables.keys();
-    for (int i = 0; i < variable_names.size(); i++) {
-        const StringName name = variable_names[i];
-        const Dictionary properties = variables[name];
-
-        const Ref<OScriptVariable> target_variable = orchestration->get_variable(name);
-        if (target_variable.is_null()) {
-            const Ref<OScriptVariable> variable = orchestration->create_variable(name);
-            ERR_CONTINUE(!variable.is_valid());
-            _apply_properties(variable, properties, variable_identity);
-        } else if (!PropertyUtils::are_equal(DictionaryUtils::to_property(_get_declared(properties, OScriptVariable::get_class_static(), "info")), target_variable->get_info())) {
-            result.skipped_variables[name] = "Variable declarations do not match.";
-        }
-    }
-
-    // Pass 4 - Create missing signals
-    const Dictionary signals = payload.get("signals", Dictionary());
-    const Array signal_names = signals.keys();
-    for (int i = 0; i < signal_names.size(); i++) {
-        const StringName name = signal_names[i];
-        const Dictionary properties = signals[name];
-
-        const Ref<OScriptSignal> target_signal = orchestration->find_custom_signal(name);
-        if (target_signal.is_null()) {
-            const Ref<OScriptSignal> signal = orchestration->create_custom_signal(name);
-            ERR_CONTINUE(!signal.is_valid());
-            _apply_properties(signal, properties, signal_identity);
-        } else if (!MethodUtils::has_same_signature(DictionaryUtils::to_method(_get_declared(properties, OScriptSignal::get_class_static(), "method")), target_signal->get_method_info())) {
-            result.skipped_signals[name] = "Signal signatures do not match.";
-        }
-    }
-
-    // Pass 5 - Compute Paste Offset
-    // The graph data is worked on as a deep copy, the reference rewrites below must not alter the payload
-    const Dictionary graph = Dictionary(payload.get("graph", Dictionary())).duplicate(true);
-    const Array entries = graph.get("nodes", Array());
-
+    // Compute the paste offset from the first node
     Vector2 offset = p_offset;
-    if (!entries.is_empty()) {
+    {
         const Dictionary first = entries[0];
         const Dictionary properties = first.get("properties", Dictionary());
         offset -= Vector2(properties.get("position", Vector2()));
@@ -301,7 +738,7 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
         offset = offset.snapped(Vector2(p_snapping_distance, p_snapping_distance));
     }
 
-    // Pass 6 - Resolve references against the target and create event nodes
+    // Resolve node references against the target and create event nodes
     HashMap<uint64_t, uint64_t> remap;
     HashSet<int> skipped;
     for (int i = 0; i < entries.size(); i++) {
@@ -341,8 +778,8 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
             const Dictionary declaration = events[name];
 
             OScriptNodeInitContext context;
-            context.method = DictionaryUtils::to_method(_get_declared(declaration, OScriptFunction::get_class_static(), "method"));
-            context.user_data = DictionaryUtils::of({ { "user_defined", _get_declared(declaration, OScriptFunction::get_class_static(), "user_defined") } });
+            context.method = DictionaryUtils::to_method(ResourceUtils::get_storage_property(declaration, OScriptFunction::get_class_static(), "method"));
+            context.user_data = DictionaryUtils::of({ { "user_defined", ResourceUtils::get_storage_property(declaration, OScriptFunction::get_class_static(), "user_defined") } });
 
             const Vector2 position = Vector2(properties.get("position", Vector2())) + offset;
             const Ref<OScriptNode> node = p_target->create_node<OScriptNodeEvent>(context, position);
@@ -354,24 +791,20 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
             // The node created the function, carry over the rest of its declaration
             const Ref<OScriptFunction> function = orchestration->find_function(name);
             if (function.is_valid()) {
-                _apply_properties(function, declaration, function_identity);
+                ResourceUtils::apply_storage_properties(function, declaration, function_identity());
             }
 
             remap[id] = node->get_id();
             continue;
         }
 
+        // Nodes that reference a declaration the paste could not provide are left out
         if (ClassDB::is_parent_class(class_name, OScriptNodeCallScriptFunction::get_class_static())) {
-            // The function GUID belongs to the source orchestration and is rewritten to the target's function.
-            // If the function doesn't exist (or has a different signature) in the target, skip the node.
             const StringName name = properties.get("function_name", String());
-            const Ref<OScriptFunction> target_function = orchestration->find_function(name);
-            if (result.skipped_functions.has(name) || !target_function.is_valid()) {
+            if (result.skipped_functions.has(name) || !orchestration->find_function(name).is_valid()) {
                 skipped.insert(id);
                 continue;
             }
-
-            properties["guid"] = target_function->get_guid().to_string();
         } else if (ClassDB::is_parent_class(class_name, OScriptNodeVariable::get_class_static())) {
             const StringName name = properties.get("variable_name", String());
             if (result.skipped_variables.has(name)) {
@@ -387,12 +820,29 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
         }
     }
 
-    // Pass 7 - Import nodes, connections, knots, pin types and comment attachments
+    // Import nodes, connections, knots, pin types and comment attachments
     p_target->import_nodes(graph, offset, remap, skipped);
 
     for (const KeyValue<uint64_t, uint64_t>& E : remap) {
         result.added_nodes.insert(E.value);
     }
+
+    return result;
+}
+
+OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboard::paste_declarations(Orchestration* p_target,
+    const Vector<Resolution>& p_resolutions) {
+
+    ClipboardResult result;
+    ERR_FAIL_NULL_V(p_target, result);
+
+    Dictionary payload;
+    if (!_read_payload(payload)) {
+        return result;
+    }
+
+    Dictionary working = payload.duplicate(true);
+    _paste_declarations(p_target, working, p_resolutions, result);
 
     return result;
 }

--- a/src/editor/graph/graph_clipboard.cpp
+++ b/src/editor/graph/graph_clipboard.cpp
@@ -19,6 +19,8 @@
 #include "common/dictionary_utils.h"
 #include "common/method_utils.h"
 #include "common/property_utils.h"
+#include "common/resource_utils.h"
+#include "common/version.h"
 #include "orchestration/nodes/call_function.h"
 #include "orchestration/nodes/comment.h"
 #include "orchestration/nodes/emit_signal.h"
@@ -27,23 +29,38 @@
 #include "orchestration/nodes/variables.h"
 #include "orchestration/orchestration.h"
 
-OrchestratorEditorGraphClipboard::Buffer OrchestratorEditorGraphClipboard::_buffer;
-
-bool OrchestratorEditorGraphClipboard::Buffer::is_empty() const {
-    return nodes.is_empty();
-}
-
-void OrchestratorEditorGraphClipboard::Buffer::clear() {
-    nodes.clear();
-    connections.clear();
-    variables.clear();
-    functions.clear();
-    events.clear();
-    signals.clear();
-}
+Dictionary* OrchestratorEditorGraphClipboard::_payload = nullptr;
 
 bool OrchestratorEditorGraphClipboard::ClipboardResult::had_skipped_nodes() const {
     return !skipped_functions.is_empty() || !skipped_events.is_empty() || !skipped_variables.is_empty() || !skipped_signals.is_empty();
+}
+
+Dictionary& OrchestratorEditorGraphClipboard::_get_payload() {
+    if (!_payload) {
+        _payload = memnew(Dictionary);
+    }
+    return *_payload;
+}
+
+void OrchestratorEditorGraphClipboard::_apply_properties(const Ref<Resource>& p_resource, const Dictionary& p_properties, const Vector<StringName>& p_excluded) {
+    const Array keys = p_properties.keys();
+    for (int i = 0; i < keys.size(); i++) {
+        const StringName key = keys[i];
+        if (!p_excluded.has(key)) {
+            p_resource->set(key, p_properties[key]);
+        }
+    }
+}
+
+void OrchestratorEditorGraphClipboard::_remap_comment_attachments(const Ref<OrchestrationGraph>& p_graph,
+    const HashSet<uint64_t>& p_node_ids, const HashMap<uint64_t, uint64_t>& p_remap) {
+
+    for (const uint64_t node_id : p_node_ids) {
+        const Ref<OScriptNodeComment> comment = p_graph->get_orchestration()->get_node(node_id);
+        if (comment.is_valid()) {
+            comment->remap_attached_nodes(p_remap);
+        }
+    }
 }
 
 OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboard::copy(
@@ -52,66 +69,56 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
     clear();
 
     ClipboardResult result;
-    HashSet<uint64_t> node_ids;
+    Dictionary functions;
+    Dictionary events;
+    Dictionary variables;
+    Dictionary signals;
+    Vector<int> node_ids;
+
     for (const Ref<OrchestrationGraphNode>& script_node : p_nodes) {
         ERR_CONTINUE(script_node.is_null());
 
         // A node whose referenced function, variable, or signal no longer resolves cannot be reproduced on paste,
-        // so it is left out of the buffer rather than dereferenced.
-        Ref<OScriptFunction> event_function;
-        Ref<OScriptFunction> called_function;
-        Ref<OScriptVariable> variable;
-        Ref<OScriptSignal> signal;
-
+        // so it is left out of the payload rather than dereferenced.
         if (const Ref<OScriptNodeEvent>& event = script_node; event.is_valid()) {
-            event_function = event->get_function();
-            ERR_CONTINUE_MSG(event_function.is_null(), vformat("Cannot copy event node %d; its function no longer exists.", script_node->get_id()));
+            const Ref<OScriptFunction> function = event->get_function();
+            ERR_CONTINUE_MSG(function.is_null(), vformat("Cannot copy event node %d; its function no longer exists.", script_node->get_id()));
+
+            // The persisted guid links the exported node back to this declaration on paste
+            events[function->get_function_name()] = ResourceUtils::get_storage_properties(function);
         } else if (const Ref<OScriptNodeCallScriptFunction>& call_script = script_node; call_script.is_valid()) {
-            called_function = call_script->get_function();
-            ERR_CONTINUE_MSG(called_function.is_null(), vformat("Cannot copy call function node %d; its function no longer exists.", script_node->get_id()));
+            const Ref<OScriptFunction> function = call_script->get_function();
+            ERR_CONTINUE_MSG(function.is_null(), vformat("Cannot copy call function node %d; its function no longer exists.", script_node->get_id()));
+
+            functions[function->get_function_name()] = ResourceUtils::get_storage_properties(function);
         }
 
         if (const Ref<OScriptNodeVariable>& variable_node = script_node; variable_node.is_valid()) {
-            variable = variable_node->get_variable();
+            const Ref<OScriptVariable> variable = variable_node->get_variable();
             ERR_CONTINUE_MSG(variable.is_null(), vformat("Cannot copy variable node %d; its variable no longer exists.", script_node->get_id()));
+
+            variables[variable->get_variable_name()] = ResourceUtils::get_storage_properties(variable);
         }
 
         if (const Ref<OScriptNodeEmitSignal>& signal_node = script_node; signal_node.is_valid()) {
-            signal = signal_node->get_signal();
+            const Ref<OScriptSignal> signal = signal_node->get_signal();
             ERR_CONTINUE_MSG(signal.is_null(), vformat("Cannot copy emit signal node %d; its signal no longer exists.", script_node->get_id()));
+
+            signals[signal->get_signal_name()] = ResourceUtils::get_storage_properties(signal);
         }
 
-        CopyItem item;
-        item.id = script_node->get_id();
-        item.position = script_node->get_position();
-        item.node = p_source->copy_node(item.id, true);
-
-        node_ids.insert(item.id);
-        result.added_nodes.insert(item.id);
-        _buffer.nodes.push_back(item);
-
-        if (event_function.is_valid()) {
-            _buffer.events[event_function->get_function_name()] = event_function->duplicate();
-        }
-
-        if (called_function.is_valid()) {
-            _buffer.functions[called_function->get_function_name()] = called_function->duplicate();
-        }
-
-        if (variable.is_valid()) {
-            _buffer.variables[variable->get_variable_name()] = variable->duplicate();
-        }
-
-        if (signal.is_valid()) {
-            _buffer.signals[signal->get_signal_name()] = signal->duplicate();
-        }
+        node_ids.push_back(script_node->get_id());
+        result.added_nodes.insert(script_node->get_id());
     }
 
-    for (const OScriptConnection& C : p_source->get_orchestration()->get_connections()) {
-        if (node_ids.has(C.from_node) && node_ids.has(C.to_node)) {
-            _buffer.connections.push_back(C.id);
-        }
-    }
+    Dictionary& payload = _get_payload();
+    payload["magic"] = "orchestrator/clipboard";
+    payload["plugin"] = VERSION_FULL_BUILD;
+    payload["graph"] = p_source->export_nodes(node_ids);
+    payload["functions"] = functions;
+    payload["events"] = events;
+    payload["variables"] = variables;
+    payload["signals"] = signals;
 
     return result;
 }
@@ -120,167 +127,203 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
     const Ref<OrchestrationGraph>& p_target, const Vector2& p_offset, bool p_snapping_enabled, int p_snapping_distance) {
 
     ClipboardResult result;
+    if (!_payload || _payload->is_empty()) {
+        return result;
+    }
+
+    Orchestration* orchestration = p_target->get_orchestration();
+    ERR_FAIL_NULL_V(orchestration, result);
+
+    const Dictionary& payload = *_payload;
+
+    // Properties that identify a resource within its source orchestration, or that the target
+    // consumes when it creates the resource. Everything else in a declaration is applied as-is.
+    const Vector<StringName> function_identity = { "guid", "id", "method", "user_defined" };
+    const Vector<StringName> variable_identity = { "name" };
+    const Vector<StringName> signal_identity = { "signal_name" };
 
     // Pass 1 - Verify Functions
-    for (const KeyValue<StringName, Ref<OScriptFunction>>& E : _buffer.functions) {
-        const Ref<OScriptFunction> target_function = p_target->get_orchestration()->find_function(E.key);
+    const Dictionary functions = payload.get("functions", Dictionary());
+    const Array function_names = functions.keys();
+    for (int i = 0; i < function_names.size(); i++) {
+        const StringName name = function_names[i];
+        const Dictionary declaration = functions[name];
+        const MethodInfo method = DictionaryUtils::to_method(declaration.get("method", Dictionary()));
+
+        const Ref<OScriptFunction> target_function = orchestration->find_function(name);
         if (!target_function.is_valid()) {
-            const Ref<OScriptFunction> function = p_target->get_orchestration()->create_function(
-                E.value->get_method_info(), E.value->is_user_defined());
+            const bool user_defined = declaration.get("user_defined", false);
+            const Ref<OScriptFunction> function = orchestration->create_function(method, user_defined);
             if (!function.is_valid()) {
-                result.skipped_functions[E.key] = "Failed to create function.";
+                result.skipped_functions[name] = "Failed to create function.";
+            } else {
+                _apply_properties(function, declaration, function_identity);
             }
-        } else if (!MethodUtils::has_same_signature(E.value->get_method_info(), target_function->get_method_info())) {
-            result.skipped_functions[E.key] = "Function signatures do not match.";
+        } else if (!MethodUtils::has_same_signature(method, target_function->get_method_info())) {
+            result.skipped_functions[name] = "Function signatures do not match.";
         }
     }
 
     // Pass 2 - Verify Events
-    for (const KeyValue<StringName, Ref<OScriptFunction>>& E : _buffer.events) {
-        const Ref<OScriptFunction> target_function = p_target->get_orchestration()->find_function(E.key);
+    HashMap<String, StringName> event_names;
+    const Dictionary events = payload.get("events", Dictionary());
+    const Array event_keys = events.keys();
+    for (int i = 0; i < event_keys.size(); i++) {
+        const StringName name = event_keys[i];
+        const Dictionary declaration = events[name];
+        event_names[declaration.get("guid", String())] = name;
+
+        const Ref<OScriptFunction> target_function = orchestration->find_function(name);
         if (target_function.is_valid()) {
-            if (!MethodUtils::has_same_signature(E.value->get_method_info(), target_function->get_method_info())) {
-                result.skipped_events[E.key] = "Event function signatures do not match.";
+            const MethodInfo method = DictionaryUtils::to_method(declaration.get("method", Dictionary()));
+            if (!MethodUtils::has_same_signature(method, target_function->get_method_info())) {
+                result.skipped_events[name] = "Event function signatures do not match.";
             }
         }
     }
 
     // Pass 3 - Create missing variables
-    for (const KeyValue<StringName, Ref<OScriptVariable>>& E : _buffer.variables) {
-        const Ref<OScriptVariable> target_variable = p_target->get_orchestration()->get_variable(E.key);
+    const Dictionary variables = payload.get("variables", Dictionary());
+    const Array variable_names = variables.keys();
+    for (int i = 0; i < variable_names.size(); i++) {
+        const StringName name = variable_names[i];
+        const Dictionary properties = variables[name];
+
+        const Ref<OScriptVariable> target_variable = orchestration->get_variable(name);
         if (target_variable.is_null()) {
-            const Ref<OScriptVariable> variable = p_target->get_orchestration()->create_variable(E.key);
+            const Ref<OScriptVariable> variable = orchestration->create_variable(name);
             ERR_CONTINUE(!variable.is_valid());
-            variable->copy_persistent_state(E.value);
-        } else if (!PropertyUtils::are_equal(E.value->get_info(), target_variable->get_info())) {
-            result.skipped_variables[E.key] = "Variable declarations do not match.";
+            _apply_properties(variable, properties, variable_identity);
+        } else if (!PropertyUtils::are_equal(DictionaryUtils::to_property(properties.get("info", Dictionary())), target_variable->get_info())) {
+            result.skipped_variables[name] = "Variable declarations do not match.";
         }
     }
 
     // Pass 4 - Create missing signals
-    for (const KeyValue<StringName, Ref<OScriptSignal>>& E : _buffer.signals) {
-        const Ref<OScriptSignal> target_signal = p_target->get_orchestration()->find_custom_signal(E.key);
+    const Dictionary signals = payload.get("signals", Dictionary());
+    const Array signal_names = signals.keys();
+    for (int i = 0; i < signal_names.size(); i++) {
+        const StringName name = signal_names[i];
+        const Dictionary properties = signals[name];
+
+        const Ref<OScriptSignal> target_signal = orchestration->find_custom_signal(name);
         if (target_signal.is_null()) {
-            const Ref<OScriptSignal> signal = p_target->get_orchestration()->create_custom_signal(E.key);
+            const Ref<OScriptSignal> signal = orchestration->create_custom_signal(name);
             ERR_CONTINUE(!signal.is_valid());
-            signal->copy_persistent_state(E.value);
-        } else if (!MethodUtils::has_same_signature(E.value->get_method_info(), target_signal->get_method_info())) {
-            result.skipped_signals[E.key] = "Signal signatures do not match.";
+            _apply_properties(signal, properties, signal_identity);
+        } else if (!MethodUtils::has_same_signature(DictionaryUtils::to_method(properties.get("method", Dictionary())), target_signal->get_method_info())) {
+            result.skipped_signals[name] = "Signal signatures do not match.";
         }
     }
 
     // Pass 5 - Compute Paste Offset
+    // The graph data is worked on as a deep copy, the reference rewrites below must not alter the payload
+    const Dictionary graph = Dictionary(payload.get("graph", Dictionary())).duplicate(true);
+    const Array entries = graph.get("nodes", Array());
+
     Vector2 offset = p_offset;
-    if (!_buffer.nodes.is_empty()) {
-        offset -= _buffer.nodes.get(0).position;
+    if (!entries.is_empty()) {
+        const Dictionary first = entries[0];
+        const Dictionary properties = first.get("properties", Dictionary());
+        offset -= Vector2(properties.get("position", Vector2()));
     }
 
     if (p_snapping_enabled) {
         offset = offset.snapped(Vector2(p_snapping_distance, p_snapping_distance));
     }
 
-    // Pass 6 - Create Nodes
-    HashMap<uint64_t, uint64_t> connection_remap;
-    for (const CopyItem& item : _buffer.nodes) {
+    // Pass 6 - Resolve references against the target and create event nodes
+    HashMap<uint64_t, uint64_t> remap;
+    HashSet<int> skipped;
+    for (int i = 0; i < entries.size(); i++) {
+        const Dictionary entry = entries[i];
+        const int id = entry.get("id", -1);
+        const String class_name = entry.get("class", String());
+        Dictionary properties = entry.get("properties", Dictionary());
 
-        Ref<OrchestrationGraphNode> new_node;
-        const Ref<OrchestrationGraphNode>& node = item.node;
+        if (ClassDB::is_parent_class(class_name, OScriptNodeEvent::get_class_static())) {
+            const String guid = properties.get("function_id", String());
+            if (!event_names.has(guid)) {
+                skipped.insert(id);
+                continue;
+            }
 
-        const Ref<OScriptNodeEvent> event = node;
-        if (event.is_valid()) {
-            const Ref<OScriptFunction> event_function = event->get_function();
-            if (!event_function.is_valid() || result.skipped_events.has(event_function->get_function_name())) {
+            const StringName name = event_names[guid];
+            if (result.skipped_events.has(name)) {
+                skipped.insert(id);
                 continue;
             }
 
             // Event nodes can only be placed inside event graphs
             if (!p_target->get_flags().has_flag(OrchestrationGraph::GF_EVENT)) {
-                result.skipped_events[event_function->get_function_name()] = "Cannot paste event nodes into non-event graphs.";
+                result.skipped_events[name] = "Cannot paste event nodes into non-event graphs.";
+                skipped.insert(id);
                 continue;
             }
 
-            const Ref<OScriptFunction> target_function = p_target->get_orchestration()->find_function(event_function->get_function_name());
-            if (target_function.is_valid()) {
-                result.skipped_events[event_function->get_function_name()] = "An event node already exists with the same name.";
+            if (orchestration->find_function(name).is_valid()) {
+                result.skipped_events[name] = "An event node already exists with the same name.";
+                skipped.insert(id);
                 continue;
             }
+
+            // This creates the node and its matching event function signature, so the event is seeded
+            // into the remap rather than imported as data.
+            const Dictionary declaration = events[name];
 
             OScriptNodeInitContext context;
-            context.method = event_function->get_method_info();
-            context.user_data = DictionaryUtils::of({ { "user_defined", event_function->is_user_defined() } });
+            context.method = DictionaryUtils::to_method(declaration.get("method", Dictionary()));
+            context.user_data = DictionaryUtils::of({ { "user_defined", declaration.get("user_defined", false) } });
 
-            // This creates the node and its matching event function signature
-            // Event nodes require this special handling versus the pasting.
-            new_node = p_target->create_node<OScriptNodeEvent>(context, item.position + offset);
+            const Vector2 position = Vector2(properties.get("position", Vector2())) + offset;
+            const Ref<OScriptNode> node = p_target->create_node<OScriptNodeEvent>(context, position);
+            if (!node.is_valid()) {
+                skipped.insert(id);
+                continue;
+            }
 
-        } else {
-            // Call-script-function nodes need their function GUID remapped to the target orchestration.
+            // The node created the function, carry over the rest of its declaration
+            const Ref<OScriptFunction> function = orchestration->find_function(name);
+            if (function.is_valid()) {
+                _apply_properties(function, declaration, function_identity);
+            }
+
+            remap[id] = node->get_id();
+            continue;
+        }
+
+        if (ClassDB::is_parent_class(class_name, OScriptNodeCallScriptFunction::get_class_static())) {
+            // The function GUID belongs to the source orchestration and is rewritten to the target's function.
             // If the function doesn't exist (or has a different signature) in the target, skip the node.
-            const Ref<OScriptNodeCallScriptFunction> call_script_func = node;
-            if (call_script_func.is_valid()) {
-                const Ref<OScriptFunction> called_function = call_script_func->get_function();
-                if (called_function.is_null()) {
-                    continue;
-                }
-
-                const StringName function_name = called_function->get_function_name();
-                if (result.skipped_functions.has(function_name)) {
-                    continue;
-                }
-
-                const Ref<OScriptFunction> target_function = p_target->get_orchestration()->find_function(function_name);
-                if (!target_function.is_valid()) {
-                    continue;
-                }
-
-                call_script_func->set("guid", target_function->get_guid().to_string());
+            const StringName name = properties.get("function_name", String());
+            const Ref<OScriptFunction> target_function = orchestration->find_function(name);
+            if (result.skipped_functions.has(name) || !target_function.is_valid()) {
+                skipped.insert(id);
+                continue;
             }
 
-            // Variable and signal nodes whose referenced resource was incompatible are skipped.
-            const Ref<OScriptNodeVariable> variable_node = node;
-            if (variable_node.is_valid()) {
-                const Ref<OScriptVariable> variable = variable_node->get_variable();
-                if (variable.is_null() || result.skipped_variables.has(variable->get_variable_name())) {
-                    continue;
-                }
+            properties["guid"] = target_function->get_guid().to_string();
+        } else if (ClassDB::is_parent_class(class_name, OScriptNodeVariable::get_class_static())) {
+            const StringName name = properties.get("variable_name", String());
+            if (result.skipped_variables.has(name)) {
+                skipped.insert(id);
+                continue;
             }
-
-            const Ref<OScriptNodeEmitSignal> signal_node = node;
-            if (signal_node.is_valid()) {
-                const Ref<OScriptSignal> signal = signal_node->get_signal();
-                if (signal.is_null() || result.skipped_signals.has(signal->get_signal_name())) {
-                    continue;
-                }
+        } else if (ClassDB::is_parent_class(class_name, OScriptNodeEmitSignal::get_class_static())) {
+            const StringName name = properties.get("signal_name", String());
+            if (result.skipped_signals.has(name)) {
+                skipped.insert(id);
+                continue;
             }
-
-            new_node = p_target->paste_node(node, item.position + offset);
-        }
-
-        ERR_CONTINUE(!new_node.is_valid());
-        connection_remap[item.id] = new_node->get_id();
-        result.added_nodes.insert(new_node->get_id());
-    }
-
-    // Pass 7 - Create connections
-    for (const uint64_t id : _buffer.connections) {
-        const OScriptConnection C(id);
-        const uint64_t source_node = connection_remap[C.from_node];
-        const uint64_t target_node = connection_remap[C.to_node];
-
-        if (result.added_nodes.has(source_node) && result.added_nodes.has(target_node)) {
-            p_target->link(source_node, C.from_port, target_node, C.to_port);
         }
     }
 
-    // Pass 8 - Restore pin types if pasted PromotableOperator nodes have connections
-    for (const CopyItem& item : _buffer.nodes) {
-        const int new_node_id = connection_remap[item.node->get_id()];
-        const Ref<OrchestrationGraphNode> new_node = p_target->get_orchestration()->get_node(new_node_id);
-        OScriptNodePromotableOperator::copy_pin_types(item.node, new_node);
-    }
+    // Pass 7 - Import nodes, connections, knots, pin types and comment attachments
+    p_target->import_nodes(graph, offset, remap, skipped);
 
-    // Pass 9 - Pasted comments still reference the copied nodes' original ids
-    _remap_comment_attachments(p_target, result.added_nodes, connection_remap);
+    for (const KeyValue<uint64_t, uint64_t>& E : remap) {
+        result.added_nodes.insert(E.value);
+    }
 
     return result;
 }
@@ -327,16 +370,14 @@ OrchestratorEditorGraphClipboard::ClipboardResult OrchestratorEditorGraphClipboa
 }
 
 void OrchestratorEditorGraphClipboard::clear() {
-    _buffer.clear();
+    if (_payload) {
+        _payload->clear();
+    }
 }
 
-void OrchestratorEditorGraphClipboard::_remap_comment_attachments(const Ref<OrchestrationGraph>& p_graph,
-    const HashSet<uint64_t>& p_node_ids, const HashMap<uint64_t, uint64_t>& p_remap) {
-
-    for (const uint64_t node_id : p_node_ids) {
-        const Ref<OScriptNodeComment> comment = p_graph->get_orchestration()->get_node(node_id);
-        if (comment.is_valid()) {
-            comment->remap_attached_nodes(p_remap);
-        }
+void OrchestratorEditorGraphClipboard::free_resources() {
+    if (_payload) {
+        memdelete(_payload);
+        _payload = nullptr;
     }
 }

--- a/src/editor/graph/graph_clipboard.h
+++ b/src/editor/graph/graph_clipboard.h
@@ -93,6 +93,7 @@ public:
         HashMap<StringName, String> skipped_events;
         HashMap<StringName, String> skipped_variables;
         HashMap<StringName, String> skipped_signals;
+        HashMap<uint64_t, String> skipped_nodes;   //! Keyed by the node's id in the payload
 
         /// Whether nothing at all was pasted
         bool is_empty() const;

--- a/src/editor/graph/graph_clipboard.h
+++ b/src/editor/graph/graph_clipboard.h
@@ -39,13 +39,25 @@
 /// Declarations carry every persisted property of the resource, see ResourceUtils::get_storage_properties.
 /// On paste the properties that identify the resource within its source orchestration are excluded and
 /// everything else is applied, so a property added to a resource later is carried without changes here.
+///
+/// The payload travels on the OS clipboard as text: a header line followed by the dictionary in
+/// <code>var_to_str</code> form. The header begins with <code>;</code>, which the variant parser treats as
+/// a comment, so the text round-trips through any text editor and pastes into another editor instance.
+/// The OS clipboard is authoritative on paste. The last payload written is kept in memory for headless
+/// runs and to skip re-parsing text this editor produced.
 class OrchestratorEditorGraphClipboard {
 
     // Allocated on first use. A static Dictionary is constructed before the extension is initialized
-    // and crashes the plugin on load, so the payload lives behind a pointer.
-    static Dictionary* _payload;
+    // and crashes the plugin on load, so the buffer lives behind a pointer.
+    struct Buffer {
+        Dictionary payload;
+        String text;
+    };
 
-    static Dictionary& _get_payload();
+    static Buffer* _buffer;
+
+    static void _write_payload(const Dictionary& p_payload);
+    static bool _read_payload(Dictionary& r_payload);
     static void _apply_properties(const Ref<Resource>& p_resource, const Dictionary& p_properties, const Vector<StringName>& p_excluded);
     static void _remap_comment_attachments(const Ref<OrchestrationGraph>& p_graph, const HashSet<uint64_t>& p_node_ids, const HashMap<uint64_t, uint64_t>& p_remap);
 
@@ -64,8 +76,9 @@ public:
     ClipboardResult paste(const Ref<OrchestrationGraph>& p_target, const Vector2& p_offset, bool p_snapping_enabled, int p_snapping_distance);
     ClipboardResult duplicate(const Vector<Ref<OrchestrationGraphNode>>& p_nodes, const Ref<OrchestrationGraph>& p_graph, const Vector2& p_offset);
 
+    /// Clears the in-memory payload. The OS clipboard is left as-is.
     void clear();
 
-    /// Releases the shared payload, called when the editor is torn down
+    /// Releases the in-memory payload, called when the editor is torn down
     static void free_resources();
 };

--- a/src/editor/graph/graph_clipboard.h
+++ b/src/editor/graph/graph_clipboard.h
@@ -18,34 +18,35 @@
 
 #include "orchestration/graph.h"
 #include "orchestration/node.h"
-#include "orchestration/signals.h"
-#include "orchestration/variable.h"
 
 #include <godot_cpp/templates/hash_set.hpp>
 
 /// Manages the clipboard state for <code>OrchestratorEditorGraphPanel</code>.
+///
+/// The clipboard holds data rather than live nodes, so it has no ties to the orchestration the nodes
+/// were copied from. The payload is a dictionary with the following layout:
+///
+/// <pre>
+/// magic       "orchestrator/clipboard"
+/// plugin      the plugin version that produced the payload
+/// graph       exported nodes, see OScriptGraph::export_nodes
+/// functions   name -> persisted function properties, for every called script function
+/// events      name -> persisted function properties, for every event node
+/// variables   name -> persisted variable properties
+/// signals     name -> persisted signal properties
+/// </pre>
+///
+/// Declarations carry every persisted property of the resource, see ResourceUtils::get_storage_properties.
+/// On paste the properties that identify the resource within its source orchestration are excluded and
+/// everything else is applied, so a property added to a resource later is carried without changes here.
 class OrchestratorEditorGraphClipboard {
 
-    struct CopyItem {
-        int id;
-        Ref<OrchestrationGraphNode> node;
-        Vector2 position;
-    };
+    // Allocated on first use. A static Dictionary is constructed before the extension is initialized
+    // and crashes the plugin on load, so the payload lives behind a pointer.
+    static Dictionary* _payload;
 
-    struct Buffer {
-        List<CopyItem> nodes;
-        List<uint64_t> connections;
-        HashMap<StringName, Ref<OScriptVariable>> variables;
-        HashMap<StringName, Ref<OScriptFunction>> functions;
-        HashMap<StringName, Ref<OScriptFunction>> events;
-        HashMap<StringName, Ref<OScriptSignal>> signals;
-
-        bool is_empty() const;
-        void clear();
-    };
-
-    static Buffer _buffer;
-
+    static Dictionary& _get_payload();
+    static void _apply_properties(const Ref<Resource>& p_resource, const Dictionary& p_properties, const Vector<StringName>& p_excluded);
     static void _remap_comment_attachments(const Ref<OrchestrationGraph>& p_graph, const HashSet<uint64_t>& p_node_ids, const HashMap<uint64_t, uint64_t>& p_remap);
 
 public:
@@ -64,4 +65,7 @@ public:
     ClipboardResult duplicate(const Vector<Ref<OrchestrationGraphNode>>& p_nodes, const Ref<OrchestrationGraph>& p_graph, const Vector2& p_offset);
 
     void clear();
+
+    /// Releases the shared payload, called when the editor is torn down
+    static void free_resources();
 };

--- a/src/editor/graph/graph_clipboard.h
+++ b/src/editor/graph/graph_clipboard.h
@@ -21,7 +21,10 @@
 
 #include <godot_cpp/templates/hash_set.hpp>
 
-/// Manages the clipboard state for <code>OrchestratorEditorGraphPanel</code>.
+/// Forward declarations
+class Orchestration;
+
+/// Manages the clipboard state for the graph and component panels.
 ///
 /// The clipboard holds data rather than live nodes, so it has no ties to the orchestration the nodes
 /// were copied from. The payload is a dictionary with the following layout:
@@ -29,24 +32,78 @@
 /// <pre>
 /// magic       "orchestrator/clipboard"
 /// plugin      the plugin version that produced the payload
-/// graph       exported nodes, see OScriptGraph::export_nodes
-/// functions   name -> persisted function properties, for every called script function
+/// format      the script format version, see OrchestrationFormat
+/// graph       exported nodes, see OScriptGraph::export_nodes; absent when only declarations were copied
+/// functions   name -> persisted function properties, plus "graph" holding the body of user functions
 /// events      name -> persisted function properties, for every event node
 /// variables   name -> persisted variable properties
 /// signals     name -> persisted signal properties
 /// </pre>
 ///
+/// Copying a graph selection walks the closure of every called user function: the bodies of those
+/// functions, the functions they call in turn, and the variables and signals any of them reference.
+///
 /// Declarations carry every persisted property of the resource, see ResourceUtils::get_storage_properties.
 /// On paste the properties that identify the resource within its source orchestration are excluded and
 /// everything else is applied, so a property added to a resource later is carried without changes here.
+///
+/// Paste is two steps. <code>plan</code> reports declarations that exist in the target with a different
+/// definition, and <code>paste</code> takes the user's resolution for each: paste under a unique name, or
+/// skip. Without a resolution a conflicting declaration is skipped. A missing declaration is created and a
+/// matching one is reused.
 ///
 /// The payload travels on the OS clipboard as text: a header line followed by the dictionary in
 /// <code>var_to_str</code> form. The header begins with <code>;</code>, which the variant parser treats as
 /// a comment, so the text round-trips through any text editor and pastes into another editor instance.
 /// The OS clipboard is authoritative on paste. The last payload written is kept in memory for headless
-/// runs and to skip re-parsing text this editor produced.
+/// runs and to skip reparsing text this editor produced.
 class OrchestratorEditorGraphClipboard {
 
+public:
+    /// A declaration in the payload that exists in the target with a different definition
+    struct Conflict {
+        enum Kind {
+            FUNCTION,
+            VARIABLE,
+            SIGNAL
+        };
+
+        Kind kind;
+        StringName name;
+        String source;   //! The definition in the payload
+        String target;   //! The definition in the target orchestration
+    };
+
+    /// The user's decision for a conflict
+    struct Resolution {
+        Conflict::Kind kind;
+        StringName name;
+        bool rename = false;   //! Paste under a unique name when true, skip otherwise
+    };
+
+    struct ClipboardResult {
+        HashSet<uint64_t> added_nodes;
+        HashSet<StringName> added_functions;
+        HashSet<StringName> added_variables;
+        HashSet<StringName> added_signals;
+        HashMap<StringName, StringName> renamed_functions;
+        HashMap<StringName, StringName> renamed_variables;
+        HashMap<StringName, StringName> renamed_signals;
+        HashMap<StringName, String> skipped_functions;
+        HashMap<StringName, String> skipped_events;
+        HashMap<StringName, String> skipped_variables;
+        HashMap<StringName, String> skipped_signals;
+
+        /// Whether nothing at all was pasted
+        bool is_empty() const;
+        bool had_skipped_nodes() const;
+        bool had_renamed_declarations() const;
+
+        /// Builds the user-facing summary of renamed and skipped declarations, empty if there are none
+        String get_summary() const;
+    };
+
+private:
     // Allocated on first use. A static Dictionary is constructed before the extension is initialized
     // and crashes the plugin on load, so the buffer lives behind a pointer.
     struct Buffer {
@@ -58,23 +115,44 @@ class OrchestratorEditorGraphClipboard {
 
     static void _write_payload(const Dictionary& p_payload);
     static bool _read_payload(Dictionary& r_payload);
-    static Variant _get_declared(const Dictionary& p_properties, const StringName& p_class, const StringName& p_name);
-    static void _apply_properties(const Ref<Resource>& p_resource, const Dictionary& p_properties, const Vector<StringName>& p_excluded);
+    static Dictionary _create_payload(const Dictionary& p_functions, const Dictionary& p_events, const Dictionary& p_variables, const Dictionary& p_signals, const Dictionary& p_graph = Dictionary());
+
+    static void _collect_function_closure(Orchestration* p_source, const StringName& p_name, Dictionary& r_functions, Dictionary& r_variables, Dictionary& r_signals);
+    static void _collect_references(Orchestration* p_source, const Dictionary& p_graph, Vector<StringName>& r_worklist, Dictionary& r_variables, Dictionary& r_signals);
+    static Vector<Dictionary> _get_node_entries(const Dictionary& p_payload);
+
+    static String _describe_function(const Dictionary& p_declaration);
+    static String _describe_variable(const Dictionary& p_declaration);
+    static String _describe_signal(const Dictionary& p_declaration);
+
+    static void _rename_function(Dictionary& p_payload, const StringName& p_old_name, const StringName& p_new_name);
+    static void _rename_variable(Dictionary& p_payload, const StringName& p_old_name, const StringName& p_new_name);
+    static void _rename_signal(Dictionary& p_payload, const StringName& p_old_name, const StringName& p_new_name);
+    static void _apply_resolutions(Orchestration* p_target, Dictionary& p_payload, const Vector<Resolution>& p_resolutions, ClipboardResult& r_result);
+
+    static void _paste_declarations(Orchestration* p_target, Dictionary& p_payload, const Vector<Resolution>& p_resolutions, ClipboardResult& r_result);
     static void _remap_comment_attachments(const Ref<OrchestrationGraph>& p_graph, const HashSet<uint64_t>& p_node_ids, const HashMap<uint64_t, uint64_t>& p_remap);
 
 public:
-    struct ClipboardResult {
-        HashSet<uint64_t> added_nodes;
-        HashMap<StringName, String> skipped_functions;
-        HashMap<StringName, String> skipped_events;
-        HashMap<StringName, String> skipped_variables;
-        HashMap<StringName, String> skipped_signals;
-
-        bool had_skipped_nodes() const;
-    };
-
+    /// Copies a graph selection, with the closure of every user function the selection calls
     ClipboardResult copy(const Vector<Ref<OrchestrationGraphNode>>& p_nodes, const Ref<OrchestrationGraph>& p_source);
-    ClipboardResult paste(const Ref<OrchestrationGraph>& p_target, const Vector2& p_offset, bool p_snapping_enabled, int p_snapping_distance);
+
+    /// Copies a function declaration, its body, and the closure of everything the body references
+    void copy_function(Orchestration* p_source, const StringName& p_name);
+    /// Copies a variable declaration
+    void copy_variable(Orchestration* p_source, const StringName& p_name);
+    /// Copies a signal declaration
+    void copy_signal(Orchestration* p_source, const StringName& p_name);
+
+    /// Reports the declarations in the clipboard that conflict with the target. An empty result means
+    /// paste can proceed without asking the user anything.
+    Vector<Conflict> plan(Orchestration* p_target);
+
+    /// Pastes the declarations and then the graph nodes into the target graph
+    ClipboardResult paste(const Ref<OrchestrationGraph>& p_target, const Vector2& p_offset, bool p_snapping_enabled, int p_snapping_distance, const Vector<Resolution>& p_resolutions = Vector<Resolution>());
+    /// Pastes only the declarations, functions with their bodies, into the target. Graph nodes are ignored.
+    ClipboardResult paste_declarations(Orchestration* p_target, const Vector<Resolution>& p_resolutions = Vector<Resolution>());
+
     ClipboardResult duplicate(const Vector<Ref<OrchestrationGraphNode>>& p_nodes, const Ref<OrchestrationGraph>& p_graph, const Vector2& p_offset);
 
     /// Clears the in-memory payload. The OS clipboard is left as-is.

--- a/src/editor/graph/graph_clipboard.h
+++ b/src/editor/graph/graph_clipboard.h
@@ -58,6 +58,7 @@ class OrchestratorEditorGraphClipboard {
 
     static void _write_payload(const Dictionary& p_payload);
     static bool _read_payload(Dictionary& r_payload);
+    static Variant _get_declared(const Dictionary& p_properties, const StringName& p_class, const StringName& p_name);
     static void _apply_properties(const Ref<Resource>& p_resource, const Dictionary& p_properties, const Vector<StringName>& p_excluded);
     static void _remap_comment_attachments(const Ref<OrchestrationGraph>& p_graph, const HashSet<uint64_t>& p_node_ids, const HashMap<uint64_t, uint64_t>& p_remap);
 

--- a/src/editor/graph/graph_panel.cpp
+++ b/src/editor/graph/graph_panel.cpp
@@ -759,11 +759,6 @@ void OrchestratorEditorGraphPanel::_graph_changed() {
     }
 }
 
-
-void OrchestratorEditorGraphPanel::_clear_copy_buffer() {
-    _clipboard.clear();
-}
-
 void OrchestratorEditorGraphPanel::_toggle_resizer_for_selected_nodes() {
     for (OrchestratorEditorGraphNode* node : get_selected<OrchestratorEditorGraphNode>()) {
         node->set_resizable(!node->is_resizable());

--- a/src/editor/graph/graph_panel.cpp
+++ b/src/editor/graph/graph_panel.cpp
@@ -247,7 +247,7 @@ void OrchestratorEditorGraphPanel::_copy_nodes_request() {
 
 void OrchestratorEditorGraphPanel::_cut_nodes_request() {
     const Vector<Ref<OrchestrationGraphNode>> selected = _get_selected_model_nodes();
-    if (selected.is_empty() || !_can_copy_nodes(selected)) {
+    if (selected.is_empty() || !_can_copy_nodes(selected, true)) {
         return;
     }
 
@@ -2108,11 +2108,13 @@ bool OrchestratorEditorGraphPanel::_can_duplicate_nodes(const Vector<Ref<Orchest
     return true;
 }
 
-bool OrchestratorEditorGraphPanel::_can_copy_nodes(const Vector<Ref<OrchestrationGraphNode>>& p_nodes, bool p_error_dialog) {
+bool OrchestratorEditorGraphPanel::_can_copy_nodes(const Vector<Ref<OrchestrationGraphNode>>& p_nodes, bool p_cut, bool p_error_dialog) {
     for (const Ref<OrchestrationGraphNode>& node : p_nodes) {
         if (node.is_valid() && !node->can_copy()) {
             if (p_error_dialog) {
-                const String message = vformat("Cannot copy node '%s' with ID %d", node->get_node_title(), node->get_id());
+                // The whole operation is refused, the message says so rather than reading as a per-node warning
+                const String message = vformat("Nothing was %s. Node '%s' with ID %d cannot be placed on the clipboard.",
+                    p_cut ? "cut" : "copied", node->get_node_title(), node->get_id());
                 OrchestratorEditorDialogs::error(message);
             }
             return false;

--- a/src/editor/graph/graph_panel.cpp
+++ b/src/editor/graph/graph_panel.cpp
@@ -40,6 +40,7 @@
 #include "editor/graph/graph_pin.h"
 #include "editor/graph/nodes/comment_graph_frame.h"
 #include "editor/graph/nodes/reroute_graph_node.h"
+#include "editor/gui/clipboard_conflict_dialog.h"
 #include "editor/gui/context_menu.h"
 #include "editor/gui/dialogs_helper.h"
 #include "editor/settings/editor_settings.h"
@@ -288,10 +289,30 @@ void OrchestratorEditorGraphPanel::_duplicate_nodes_request() {
 void OrchestratorEditorGraphPanel::_paste_nodes_request() {
     const Vector2 offset = (get_scroll_offset() + get_local_mouse_position()) / get_zoom();
 
-    OrchestratorEditorGraphClipboard::ClipboardResult result = _clipboard.paste(
-        _graph, offset, is_snapping_enabled(), get_snapping_distance());
+    // Declarations that exist here with a different definition need the user's decision first
+    const Vector<OrchestratorEditorGraphClipboard::Conflict> conflicts = _clipboard.plan(_graph->get_orchestration());
+    if (conflicts.is_empty()) {
+        _paste_nodes(offset, Vector<OrchestratorEditorGraphClipboard::Resolution>());
+        return;
+    }
 
-    if (result.added_nodes.is_empty()) {
+    OrchestratorEditorClipboardConflictDialog* dialog = memnew(OrchestratorEditorClipboardConflictDialog);
+    dialog->popup_conflicts(conflicts, callable_mp_this(_paste_conflicts_confirmed).bind(dialog, offset));
+}
+
+void OrchestratorEditorGraphPanel::_paste_conflicts_confirmed(Object* p_dialog, const Vector2& p_offset) {
+    OrchestratorEditorClipboardConflictDialog* dialog = cast_to<OrchestratorEditorClipboardConflictDialog>(p_dialog);
+    ERR_FAIL_NULL(dialog);
+
+    _paste_nodes(p_offset, dialog->get_resolutions());
+}
+
+void OrchestratorEditorGraphPanel::_paste_nodes(const Vector2& p_offset, const Vector<OrchestratorEditorGraphClipboard::Resolution>& p_resolutions) {
+    OrchestratorEditorGraphClipboard::ClipboardResult result = _clipboard.paste(
+        _graph, p_offset, is_snapping_enabled(), get_snapping_distance(), p_resolutions);
+
+    // A payload of declarations alone adds no nodes here, that is still a paste
+    if (result.is_empty()) {
         ORCHESTRATOR_ERROR("No nodes were pasted");
     }
 
@@ -304,21 +325,9 @@ void OrchestratorEditorGraphPanel::_paste_nodes_request() {
 
     _set_edited(true);
 
-    if (result.had_skipped_nodes()) {
-        String message = "Several nodes were not pasted due to the following reasons:\n\n";
-        for (const KeyValue<StringName, String>& E : result.skipped_functions) {
-            message += "* Function " + E.key + ": " + E.value + "\n";
-        }
-        for (const KeyValue<StringName, String>& E : result.skipped_events) {
-            message += "* Event " + E.key + ": " + E.value + "\n";
-        }
-        for (const KeyValue<StringName, String>& E : result.skipped_variables) {
-            message += "* Variable " + E.key + ": " + E.value + "\n";
-        }
-        for (const KeyValue<StringName, String>& E : result.skipped_signals) {
-            message += "* Signal " + E.key + ": " + E.value + "\n";
-        }
-        ORCHESTRATOR_ERROR(message);
+    const String summary = result.get_summary();
+    if (!summary.is_empty()) {
+        OrchestratorEditorDialogs::accept(summary);
     }
 }
 

--- a/src/editor/graph/graph_panel.h
+++ b/src/editor/graph/graph_panel.h
@@ -223,7 +223,6 @@ private:
     void _graph_changed();
     //~ End OrchestrationGraph Signals
 
-    void _clear_copy_buffer();
     void _toggle_resizer_for_selected_nodes();
     void _resize_selected_nodes_to_content();
     void _refresh_selected_nodes();

--- a/src/editor/graph/graph_panel.h
+++ b/src/editor/graph/graph_panel.h
@@ -180,6 +180,8 @@ protected:
     void _cut_nodes_request();
     void _duplicate_nodes_request();
     void _paste_nodes_request();
+    void _paste_conflicts_confirmed(Object* p_dialog, const Vector2& p_offset);
+    void _paste_nodes(const Vector2& p_offset, const Vector<OrchestratorEditorGraphClipboard::Resolution>& p_resolutions);
     void _begin_node_move();
     void _end_node_move();
     void _scroll_offset_changed(const Vector2& p_scroll_offset);

--- a/src/editor/graph/graph_panel.h
+++ b/src/editor/graph/graph_panel.h
@@ -266,7 +266,7 @@ private:
     void _show_drag_hint(const String& p_hint_text) const;
     bool _is_delete_confirmation_enabled();
     bool _can_duplicate_nodes(const Vector<Ref<OrchestrationGraphNode>>& p_nodes, bool p_error_dialog = true);
-    bool _can_copy_nodes(const Vector<Ref<OrchestrationGraphNode>>& p_nodes, bool p_error_dialog = true);
+    bool _can_copy_nodes(const Vector<Ref<OrchestrationGraphNode>>& p_nodes, bool p_cut = false, bool p_error_dialog = true);
     void _set_scroll_offset_and_zoom(const Vector2& p_scroll_offset, float p_zoom = 1.f, const Callable& p_callback = Callable());
     void _schedule_restore();
     void _restore_edit_state();

--- a/src/editor/gui/clipboard_conflict_dialog.cpp
+++ b/src/editor/gui/clipboard_conflict_dialog.cpp
@@ -1,0 +1,129 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editor/gui/clipboard_conflict_dialog.h"
+
+#include "common/macros.h"
+#include "common/scene_utils.h"
+#include "core/godot/scene_string_names.h"
+
+#include <godot_cpp/classes/editor_interface.hpp>
+#include <godot_cpp/classes/label.hpp>
+#include <godot_cpp/classes/tree_item.hpp>
+#include <godot_cpp/classes/v_box_container.hpp>
+
+String OrchestratorEditorClipboardConflictDialog::_get_kind_name(Conflict::Kind p_kind) {
+    switch (p_kind) {
+        case Conflict::FUNCTION:
+            return "Function";
+        case Conflict::VARIABLE:
+            return "Variable";
+        case Conflict::SIGNAL:
+            return "Signal";
+    }
+    return String();
+}
+
+void OrchestratorEditorClipboardConflictDialog::_bind_methods() {
+}
+
+Vector<OrchestratorEditorClipboardConflictDialog::Resolution> OrchestratorEditorClipboardConflictDialog::get_resolutions() const {
+    Vector<Resolution> resolutions;
+
+    TreeItem* root = _tree->get_root();
+    if (!root) {
+        return resolutions;
+    }
+
+    for (TreeItem* item = root->get_first_child(); item; item = item->get_next()) {
+        Resolution resolution;
+        resolution.kind = static_cast<Conflict::Kind>(static_cast<int>(item->get_meta("__kind")));
+        resolution.name = item->get_meta("__name");
+        resolution.rename = item->is_checked(COLUMN_RENAME);
+        resolutions.push_back(resolution);
+    }
+
+    return resolutions;
+}
+
+void OrchestratorEditorClipboardConflictDialog::popup_conflicts(const Vector<Conflict>& p_conflicts, const Callable& p_confirmed) {
+    _tree->clear();
+
+    TreeItem* root = _tree->create_item();
+    for (const Conflict& conflict : p_conflicts) {
+        TreeItem* item = _tree->create_item(root);
+        item->set_text(COLUMN_KIND, _get_kind_name(conflict.kind));
+        item->set_text(COLUMN_NAME, conflict.name);
+        item->set_text(COLUMN_SOURCE, conflict.source);
+        item->set_text(COLUMN_TARGET, conflict.target);
+
+        // A check reads at a glance: on pastes under a unique name, off skips the item
+        item->set_cell_mode(COLUMN_RENAME, TreeItem::CELL_MODE_CHECK);
+        item->set_checked(COLUMN_RENAME, true);
+        item->set_editable(COLUMN_RENAME, true);
+
+        item->set_meta("__kind", conflict.kind);
+        item->set_meta("__name", conflict.name);
+    }
+
+    if (p_confirmed.is_valid()) {
+        connect(SceneStringName(confirmed), p_confirmed);
+    }
+
+    // Connected after the caller so the caller reads the choices before the dialog goes away
+    connect(SceneStringName(confirmed), callable_mp_cast(this, Node, queue_free));
+    connect(SceneStringName(canceled), callable_mp_cast(this, Node, queue_free));
+
+    EI->popup_dialog_centered(this, Size2(820, 360) * EDSCALE);
+}
+
+OrchestratorEditorClipboardConflictDialog::OrchestratorEditorClipboardConflictDialog() {
+    set_title("Paste Conflicts");
+    set_ok_button_text("Paste");
+
+    VBoxContainer* container = memnew(VBoxContainer);
+    add_child(container);
+
+    Label* label = memnew(Label);
+    label->set_text("These items already exist in the script with a different definition.\n"
+                    "Checked items are pasted under a new name, unchecked items are skipped.");
+    container->add_child(label);
+
+    _tree = memnew(Tree);
+    SceneUtils::set_theme_type_variation(_tree, "Tree");
+    _tree->set_columns(COLUMN_MAX);
+    _tree->set_column_titles_visible(true);
+    _tree->set_column_title(COLUMN_KIND, "Type");
+    _tree->set_column_title(COLUMN_NAME, "Name");
+    _tree->set_column_title(COLUMN_SOURCE, "In Clipboard");
+    _tree->set_column_title(COLUMN_TARGET, "In Script");
+    _tree->set_column_title(COLUMN_RENAME, "Paste as New Name");
+
+    // Every column expands, weighted by how long its content runs; minimums keep short columns readable
+    _tree->set_column_expand_ratio(COLUMN_KIND, 1);
+    _tree->set_column_expand_ratio(COLUMN_NAME, 2);
+    _tree->set_column_expand_ratio(COLUMN_SOURCE, 3);
+    _tree->set_column_expand_ratio(COLUMN_TARGET, 3);
+    _tree->set_column_expand_ratio(COLUMN_RENAME, 1);
+    _tree->set_column_custom_minimum_width(COLUMN_KIND, 90 * EDSCALE);
+    _tree->set_column_custom_minimum_width(COLUMN_NAME, 120 * EDSCALE);
+    _tree->set_column_custom_minimum_width(COLUMN_RENAME, 150 * EDSCALE);
+
+    _tree->set_hide_root(true);
+    _tree->set_select_mode(Tree::SELECT_ROW);
+    _tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+    container->add_child(_tree);
+}

--- a/src/editor/gui/clipboard_conflict_dialog.h
+++ b/src/editor/gui/clipboard_conflict_dialog.h
@@ -1,0 +1,55 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include "editor/graph/graph_clipboard.h"
+
+#include <godot_cpp/classes/confirmation_dialog.hpp>
+#include <godot_cpp/classes/tree.hpp>
+
+using namespace godot;
+
+/// Asks the user how to paste declarations that already exist in the target script with a different
+/// definition. Each conflict can be pasted under a unique name or skipped; cancel aborts the paste.
+class OrchestratorEditorClipboardConflictDialog : public ConfirmationDialog {
+    GDCLASS(OrchestratorEditorClipboardConflictDialog, ConfirmationDialog);
+
+    using Conflict = OrchestratorEditorGraphClipboard::Conflict;
+    using Resolution = OrchestratorEditorGraphClipboard::Resolution;
+
+    enum Column {
+        COLUMN_KIND,
+        COLUMN_NAME,
+        COLUMN_SOURCE,
+        COLUMN_TARGET,
+        COLUMN_RENAME,   //! Checked pastes under a unique name, unchecked skips
+        COLUMN_MAX
+    };
+
+    Tree* _tree = nullptr;
+
+    static String _get_kind_name(Conflict::Kind p_kind);
+
+protected:
+    static void _bind_methods();
+
+public:
+    Vector<Resolution> get_resolutions() const;
+    void popup_conflicts(const Vector<Conflict>& p_conflicts, const Callable& p_confirmed);
+
+    OrchestratorEditorClipboardConflictDialog();
+};

--- a/src/editor/register_editor_types.cpp
+++ b/src/editor/register_editor_types.cpp
@@ -34,6 +34,7 @@
 #include "editor/graph/nodes/reroute_graph_node.h"
 #include "editor/graph/pins/pins.h"
 #include "editor/gui/about_dialog.h"
+#include "editor/gui/clipboard_conflict_dialog.h"
 #include "editor/gui/context_menu.h"
 #include "editor/gui/editor_log_event_router.h"
 #include "editor/gui/file_dialog.h"
@@ -139,6 +140,7 @@ void register_editor_types() {
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorComponentView)
     GDREGISTER_INTERNAL_CLASS(OrchestratorScriptComponentsContainer)
     GDREGISTER_INTERNAL_CLASS(OrchestratorGotoNodeDialog)
+    GDREGISTER_INTERNAL_CLASS(OrchestratorEditorClipboardConflictDialog)
     GDREGISTER_INTERNAL_CLASS(OrchestratorUpdaterButton)
     GDREGISTER_INTERNAL_CLASS(OrchestratorUpdaterVersionPicker)
     GDREGISTER_INTERNAL_CLASS(OrchestratorUpdaterReleaseNotesDialog)

--- a/src/editor/script_components_container.cpp
+++ b/src/editor/script_components_container.cpp
@@ -28,6 +28,7 @@
 #include "editor/editor.h"
 #include "editor/editor_component_view.h"
 #include "editor/graph/graph_panel.h"
+#include "editor/gui/clipboard_conflict_dialog.h"
 #include "editor/gui/context_menu.h"
 #include "editor/gui/dialogs_helper.h"
 #include "editor/inspector/properties/type_selector.h"
@@ -181,6 +182,8 @@ void OrchestratorScriptComponentsContainer::_component_show_context_menu(Node* p
             menu->add_shortcut(ED_GET_SHORTCUT("graph_components_panel/open"), callable_mp_this(_open_graph).bind(func->get_function_name()));
             menu->add_icon_shortcut("Duplicate", ED_GET_SHORTCUT("graph_components_panel/duplicate"), callable_mp_this(_component_duplicate_item).bind(p_item, DictionaryUtils::of({{ "include_code", "true" }})));
             menu->add_icon_shortcut("Duplicate", ED_GET_SHORTCUT("graph_components_panel/duplicate_without_code"), callable_mp_this(_component_duplicate_item).bind(p_item, Dictionary()));
+            menu->add_icon_shortcut("ActionCopy", ED_ACTION_SHORTCUT("ui_copy", "Copy"), callable_mp_this(_component_copy_item).bind(p_item));
+            menu->add_icon_shortcut("ActionPaste", ED_ACTION_SHORTCUT("ui_paste", "Paste"), callable_mp_this(_component_paste));
             menu->add_icon_shortcut("Rename", ED_GET_SHORTCUT("graph_components_panel/rename"), RENAME_ITEM(_functions, p_item));
             menu->add_icon_shortcut("Remove", ED_GET_SHORTCUT("graph_components_panel/remove"), callable_mp_this(_component_remove_item).bind(p_item, true));
             menu->add_icon_shortcut(
@@ -195,11 +198,15 @@ void OrchestratorScriptComponentsContainer::_component_show_context_menu(Node* p
         }
         case SCRIPT_VARIABLE: {
             menu->add_icon_shortcut("Duplicate", ED_GET_SHORTCUT("graph_components_panel/duplicate"), callable_mp_this(_component_duplicate_item).bind(p_item, Dictionary()));
+            menu->add_icon_shortcut("ActionCopy", ED_ACTION_SHORTCUT("ui_copy", "Copy"), callable_mp_this(_component_copy_item).bind(p_item));
+            menu->add_icon_shortcut("ActionPaste", ED_ACTION_SHORTCUT("ui_paste", "Paste"), callable_mp_this(_component_paste));
             menu->add_icon_shortcut("Rename", ED_GET_SHORTCUT("graph_components_panel/rename"), RENAME_ITEM(_variables, p_item));
             menu->add_icon_shortcut("Remove", ED_GET_SHORTCUT("graph_components_panel/remove"), callable_mp_this(_component_remove_item).bind(p_item, true));
             break;
         }
         case SCRIPT_SIGNAL: {
+            menu->add_icon_shortcut("ActionCopy", ED_ACTION_SHORTCUT("ui_copy", "Copy"), callable_mp_this(_component_copy_item).bind(p_item));
+            menu->add_icon_shortcut("ActionPaste", ED_ACTION_SHORTCUT("ui_paste", "Paste"), callable_mp_this(_component_paste));
             menu->add_icon_shortcut("Rename", ED_GET_SHORTCUT("graph_components_panel/rename"), RENAME_ITEM(_signals, p_item));
             menu->add_icon_shortcut("Remove", ED_GET_SHORTCUT("graph_components_panel/remove"), callable_mp_this(_component_remove_item).bind(p_item, true));
             break;
@@ -247,6 +254,18 @@ void OrchestratorScriptComponentsContainer::_component_item_gui_input(TreeItem* 
         }
 
         _component_remove_item(p_item);
+        accept_event();
+        return;
+    }
+
+    if (ED_IS_ACTION_SHORTCUT("ui_copy", p_event)) {
+        _component_copy_item(p_item);
+        accept_event();
+        return;
+    }
+
+    if (ED_IS_ACTION_SHORTCUT("ui_paste", p_event)) {
+        _component_paste();
         accept_event();
         return;
     }
@@ -672,6 +691,69 @@ void OrchestratorScriptComponentsContainer::_component_duplicate_item(TreeItem* 
         }
         default:
             break;
+    }
+}
+
+void OrchestratorScriptComponentsContainer::_component_copy_item(TreeItem* p_item) {
+    ERR_FAIL_NULL_MSG(p_item, "Cannot copy component item with no tree item");
+    ERR_FAIL_COND_MSG(!_orchestration.is_valid(), "Cannot copy component item, orchestration is invalid");
+
+    const StringName name = p_item->get_meta("__name", "");
+    const uint32_t type = p_item->get_meta("__component_type", NONE);
+
+    switch (type) {
+        case SCRIPT_FUNCTION: {
+            _clipboard.copy_function(_get_orchestration().ptr(), name);
+            break;
+        }
+        case SCRIPT_VARIABLE: {
+            _clipboard.copy_variable(_get_orchestration().ptr(), name);
+            break;
+        }
+        case SCRIPT_SIGNAL: {
+            _clipboard.copy_signal(_get_orchestration().ptr(), name);
+            break;
+        }
+        default:
+            break;
+    }
+}
+
+void OrchestratorScriptComponentsContainer::_component_paste() {
+    ERR_FAIL_COND_MSG(!_orchestration.is_valid(), "Cannot paste, orchestration is invalid");
+
+    // Declarations that exist here with a different definition need the user's decision first
+    const Vector<OrchestratorEditorGraphClipboard::Conflict> conflicts = _clipboard.plan(_get_orchestration().ptr());
+    if (conflicts.is_empty()) {
+        _component_paste_declarations(Vector<OrchestratorEditorGraphClipboard::Resolution>());
+        return;
+    }
+
+    OrchestratorEditorClipboardConflictDialog* dialog = memnew(OrchestratorEditorClipboardConflictDialog);
+    dialog->popup_conflicts(conflicts, callable_mp_this(_component_paste_conflicts_confirmed).bind(dialog));
+}
+
+void OrchestratorScriptComponentsContainer::_component_paste_conflicts_confirmed(Object* p_dialog) {
+    OrchestratorEditorClipboardConflictDialog* dialog = cast_to<OrchestratorEditorClipboardConflictDialog>(p_dialog);
+    ERR_FAIL_NULL(dialog);
+
+    _component_paste_declarations(dialog->get_resolutions());
+}
+
+void OrchestratorScriptComponentsContainer::_component_paste_declarations(const Vector<OrchestratorEditorGraphClipboard::Resolution>& p_resolutions) {
+    // Only declarations are pasted here; functions bring their bodies, graph nodes in the payload are ignored
+    const OrchestratorEditorGraphClipboard::ClipboardResult result = _clipboard.paste_declarations(_get_orchestration().ptr(), p_resolutions);
+    if (result.is_empty()) {
+        OrchestratorEditorDialogs::error("Nothing was pasted");
+        return;
+    }
+
+    _update_components();
+    _set_edited(true);
+
+    const String summary = result.get_summary();
+    if (!summary.is_empty()) {
+        OrchestratorEditorDialogs::accept(summary);
     }
 }
 

--- a/src/editor/script_components_container.h
+++ b/src/editor/script_components_container.h
@@ -16,6 +16,7 @@
 //
 #pragma once
 
+#include "editor/graph/graph_clipboard.h"
 #include "orchestration/orchestration.h"
 #include "script/script.h"
 
@@ -66,6 +67,7 @@ class OrchestratorScriptComponentsContainer : public ScrollContainer {
     };
 
     Ref<Orchestration> _orchestration;
+    OrchestratorEditorGraphClipboard _clipboard;
 
     OrchestratorEditorComponentView* _graphs = nullptr;
     OrchestratorEditorComponentView* _functions = nullptr;
@@ -104,6 +106,10 @@ class OrchestratorScriptComponentsContainer : public ScrollContainer {
     void _component_add_item_commit(TreeItem* p_item);
     void _component_add_item_canceled(TreeItem* p_item);
     void _component_duplicate_item(TreeItem* p_item, const Dictionary& p_data);
+    void _component_copy_item(TreeItem* p_item);
+    void _component_paste();
+    void _component_paste_conflicts_confirmed(Object* p_dialog);
+    void _component_paste_declarations(const Vector<OrchestratorEditorGraphClipboard::Resolution>& p_resolutions);
     void _component_rename_item(TreeItem* p_item);
     void _component_remove_item(TreeItem* p_item, bool p_confirm = true);
     void _component_focus_item(TreeItem* p_item);

--- a/src/orchestration/graph.cpp
+++ b/src/orchestration/graph.cpp
@@ -523,8 +523,12 @@ void OScriptGraph::import_nodes(const Dictionary& p_data, const Vector2& p_offse
     // Nodes created here, keyed by their new id, for the fix-ups that must run after linking
     HashMap<uint64_t, Dictionary> created;
 
-    // Seeded entries that fail verification join the skipped set so nothing links to them
-    HashSet<int> skipped = p_skipped;
+    // Seeded entries that fail verification join the skipped set so nothing links to them.
+    // Copied by hand, HashSet has no copy constructor from a const reference.
+    HashSet<int> skipped;
+    for (const int id : p_skipped) {
+        skipped.insert(id);
+    }
 
     const Array entries = p_data.get("nodes", Array());
     for (int i = 0; i < entries.size(); i++) {

--- a/src/orchestration/graph.cpp
+++ b/src/orchestration/graph.cpp
@@ -523,15 +523,32 @@ void OScriptGraph::import_nodes(const Dictionary& p_data, const Vector2& p_offse
     // Nodes created here, keyed by their new id, for the fix-ups that must run after linking
     HashMap<uint64_t, Dictionary> created;
 
+    // Seeded entries that fail verification join the skipped set so nothing links to them
+    HashSet<int> skipped = p_skipped;
+
     const Array entries = p_data.get("nodes", Array());
     for (int i = 0; i < entries.size(); i++) {
         const Dictionary entry = entries[i];
         const int exported_id = entry.get("id", -1);
-        if (exported_id < 0 || p_skipped.has(exported_id) || r_remap.has(exported_id)) {
+        if (exported_id < 0 || skipped.has(exported_id)) {
             continue;
         }
 
         const String class_name = entry.get("class", String());
+
+        // A seeded entry is the caller's promise that the mapped node already stands in for the export.
+        // The node is not created, but the promise is checked so connections never land on the wrong node.
+        if (r_remap.has(exported_id)) {
+            const uint64_t seeded_id = r_remap[exported_id];
+            const Ref<OScriptNode> seeded = _orchestration->get_node(static_cast<int>(seeded_id));
+            if (!seeded.is_valid() || String(seeded->get_class()) != class_name) {
+                ERR_PRINT(vformat("Cannot import node %d, the node seeded for it (%d) is missing or is not a '%s'.", exported_id, seeded_id, class_name));
+                r_remap.erase(exported_id);
+                skipped.insert(exported_id);
+            }
+            continue;
+        }
+
         const Ref<OScriptNode> node = OScriptNodeFactory::create_node_from_name(class_name, _orchestration);
         ERR_CONTINUE_MSG(!node.is_valid(), vformat("Cannot import node %d, unknown node type '%s'.", exported_id, class_name));
 

--- a/src/orchestration/graph.cpp
+++ b/src/orchestration/graph.cpp
@@ -16,8 +16,10 @@
 //
 #include "orchestration/graph.h"
 
+#include "common/resource_utils.h"
 #include "orchestration/nodes.h"
 #include "orchestration/orchestration.h"
+#include "orchestration/serialization/format.h"
 
 #include <godot_cpp/variant/utility_functions.hpp>
 #include <godot_cpp/templates/hash_set.hpp>
@@ -458,6 +460,154 @@ Ref<OScriptNode> OScriptGraph::paste_node(const Ref<OScriptNode>& p_node, const 
     node->post_placed_new_node();
 
     return node;
+}
+
+Dictionary OScriptGraph::export_nodes(const Vector<int>& p_node_ids) const {
+    Dictionary data;
+    data["format"] = OrchestrationFormat::FORMAT_VERSION;
+
+    HashSet<int> exported;
+    Array nodes;
+    for (const int node_id : p_node_ids) {
+        if (!_nodes.has(node_id)) {
+            continue;
+        }
+
+        const Ref<OScriptNode> node = get_node(node_id);
+        if (!node.is_valid()) {
+            continue;
+        }
+
+        // The id is carried on the entry, the importer assigns a new one
+        Dictionary properties = ResourceUtils::get_storage_properties(node);
+        properties.erase("id");
+
+        Dictionary entry;
+        entry["class"] = node->get_class();
+        entry["id"] = node_id;
+        entry["properties"] = properties;
+
+        nodes.push_back(entry);
+        exported.insert(node_id);
+    }
+    data["nodes"] = nodes;
+
+    // Connections are stored flat, four values per connection, matching the script file layout
+    Array connections;
+    Dictionary knots;
+    for (const OScriptConnection& C : get_connections()) {
+        if (!exported.has(C.from_node) || !exported.has(C.to_node)) {
+            continue;
+        }
+
+        connections.push_back(static_cast<int>(C.from_node));
+        connections.push_back(static_cast<int>(C.from_port));
+        connections.push_back(static_cast<int>(C.to_node));
+        connections.push_back(static_cast<int>(C.to_port));
+
+        if (_knots.has(C.id)) {
+            knots[static_cast<int64_t>(C.id)] = _knots[C.id];
+        }
+    }
+    data["connections"] = connections;
+    data["knots"] = knots;
+
+    return data;
+}
+
+void OScriptGraph::import_nodes(const Dictionary& p_data, const Vector2& p_offset, HashMap<uint64_t, uint64_t>& r_remap, const HashSet<int>& p_skipped) {
+    ERR_FAIL_NULL(_orchestration);
+
+    const uint32_t version = p_data.get("format", OrchestrationFormat::FORMAT_VERSION);
+
+    // Nodes created here, keyed by their new id, for the fix-ups that must run after linking
+    HashMap<uint64_t, Dictionary> created;
+
+    const Array entries = p_data.get("nodes", Array());
+    for (int i = 0; i < entries.size(); i++) {
+        const Dictionary entry = entries[i];
+        const int exported_id = entry.get("id", -1);
+        if (exported_id < 0 || p_skipped.has(exported_id) || r_remap.has(exported_id)) {
+            continue;
+        }
+
+        const String class_name = entry.get("class", String());
+        const Ref<OScriptNode> node = OScriptNodeFactory::create_node_from_name(class_name, _orchestration);
+        ERR_CONTINUE_MSG(!node.is_valid(), vformat("Cannot import node %d, unknown node type '%s'.", exported_id, class_name));
+
+        const Dictionary properties = entry.get("properties", Dictionary());
+        const Array keys = properties.keys();
+        for (int j = 0; j < keys.size(); j++) {
+            node->set(keys[j], properties[keys[j]]);
+        }
+
+        node->set_id(_orchestration->get_available_id());
+        node->set_position(Vector2(properties.get("position", Vector2())) + p_offset);
+
+        if (version < OrchestrationFormat::FORMAT_VERSION) {
+            node->_upgrade(version, OrchestrationFormat::FORMAT_VERSION);
+        }
+
+        node->post_initialize();
+        _orchestration->add_node(this, node);
+        node->post_placed_new_node();
+
+        r_remap[exported_id] = node->get_id();
+        created[node->get_id()] = properties;
+    }
+
+    const Array connections = p_data.get("connections", Array());
+    const Dictionary knots = p_data.get("knots", Dictionary());
+    bool knots_changed = false;
+    for (int i = 0; i + 3 < connections.size(); i += 4) {
+        OScriptConnection exported;
+        exported.from_node = static_cast<int>(connections[i]);
+        exported.from_port = static_cast<int>(connections[i + 1]);
+        exported.to_node = static_cast<int>(connections[i + 2]);
+        exported.to_port = static_cast<int>(connections[i + 3]);
+
+        if (!r_remap.has(exported.from_node) || !r_remap.has(exported.to_node)) {
+            continue;
+        }
+
+        OScriptConnection imported;
+        imported.from_node = r_remap[exported.from_node];
+        imported.from_port = exported.from_port;
+        imported.to_node = r_remap[exported.to_node];
+        imported.to_port = exported.to_port;
+
+        link(imported.from_node, imported.from_port, imported.to_node, imported.to_port);
+
+        const int64_t exported_key = static_cast<int64_t>(exported.id);
+        if (knots.has(exported_key)) {
+            PackedVector2Array points = knots[exported_key];
+            for (int j = 0; j < points.size(); j++) {
+                points.set(j, points[j] + p_offset);
+            }
+            _knots[imported.id] = points;
+            knots_changed = true;
+        }
+    }
+
+    if (knots_changed) {
+        emit_signal("knots_updated");
+    }
+
+    for (const KeyValue<uint64_t, Dictionary>& E : created) {
+        const Ref<OScriptNode> node = _orchestration->get_node(E.key);
+        if (!node.is_valid()) {
+            continue;
+        }
+
+        // Linking may have promoted operator pins away from the exported types
+        OScriptNodePromotableOperator::copy_pin_types(E.value, node);
+
+        // Attachments still reference the exported ids
+        const Ref<OScriptNodeComment> comment = node;
+        if (comment.is_valid()) {
+            comment->remap_attached_nodes(r_remap);
+        }
+    }
 }
 
 Vector<Ref<OScriptFunction>> OScriptGraph::get_functions() const {

--- a/src/orchestration/graph.h
+++ b/src/orchestration/graph.h
@@ -20,6 +20,7 @@
 
 #include <godot_cpp/classes/resource.hpp>
 #include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/templates/rb_set.hpp>
 
 using namespace godot;
@@ -198,6 +199,27 @@ public:
     /// @param p_position the position to be placed
     /// @return the pasted node
     Ref<OScriptNode> paste_node(const Ref<OScriptNode>& p_node, const Vector2& p_position);
+
+    /// Exports a set of nodes as data that any graph can import, including one in another orchestration.
+    /// The data holds each node's persisted properties, the connections between the exported nodes, and
+    /// the knots on those connections. Connections to nodes outside the set are dropped.
+    /// @param p_node_ids the nodes to export, ids not in this graph are ignored
+    /// @return the exported data
+    Dictionary export_nodes(const Vector<int>& p_node_ids) const;
+
+    /// Imports nodes from data produced by <code>export_nodes</code> into this graph, assigning new ids
+    /// and preserving everything internal to the set: connections, knots, comment attachments, and
+    /// promotable operator pin types.
+    /// @param p_data the exported data
+    /// @param p_offset the offset added to each exported node position
+    /// @param r_remap map of exported node id to the id of its imported counterpart in this graph. Import
+    ///   adds an entry for every node it creates. A caller may seed entries for exported nodes it has
+    ///   already recreated by other means, for example an event node created through <code>create_node</code>
+    ///   so its function exists. For a seeded entry, import does not create a node and does not verify that
+    ///   the mapped node matches the exported one in type or pins; it simply wires connections and comment
+    ///   attachments to it. The caller is responsible for the mapped node being an equivalent of the export.
+    /// @param p_skipped exported node ids that are not imported
+    void import_nodes(const Dictionary& p_data, const Vector2& p_offset, HashMap<uint64_t, uint64_t>& r_remap, const HashSet<int>& p_skipped = HashSet<int>());
 
     /// Sanitize the nodes array
     void sanitize_nodes();

--- a/src/orchestration/graph.h
+++ b/src/orchestration/graph.h
@@ -215,9 +215,9 @@ public:
     /// @param r_remap map of exported node id to the id of its imported counterpart in this graph. Import
     ///   adds an entry for every node it creates. A caller may seed entries for exported nodes it has
     ///   already recreated by other means, for example an event node created through <code>create_node</code>
-    ///   so its function exists. For a seeded entry, import does not create a node and does not verify that
-    ///   the mapped node matches the exported one in type or pins; it simply wires connections and comment
-    ///   attachments to it. The caller is responsible for the mapped node being an equivalent of the export.
+    ///   so its function exists. For a seeded entry, import does not create a node. It verifies that the
+    ///   mapped node exists and is of the exported class, then wires connections and comment attachments to
+    ///   it; pins are not compared. A seeded entry that fails verification is dropped from the map and skipped.
     /// @param p_skipped exported node ids that are not imported
     void import_nodes(const Dictionary& p_data, const Vector2& p_offset, HashMap<uint64_t, uint64_t>& r_remap, const HashSet<int>& p_skipped = HashSet<int>());
 

--- a/src/orchestration/nodes/operator_node.cpp
+++ b/src/orchestration/nodes/operator_node.cpp
@@ -913,6 +913,25 @@ void OScriptNodePromotableOperator::copy_pin_types(const Ref<OrchestrationGraphN
     target->_set_operand_types(source->_operands);
 }
 
+void OScriptNodePromotableOperator::copy_pin_types(const Dictionary& p_properties, const Ref<OrchestrationGraphNode>& p_target) {
+    if (p_target.is_null() || !p_target->has_any_connections() || !p_properties.has("operand_types")) {
+        return;
+    }
+
+    const Ref<OScriptNodePromotableOperator> target = p_target;
+    if (target.is_null()) {
+        return;
+    }
+
+    const PackedInt32Array array = p_properties["operand_types"];
+    Vector<Variant::Type> types;
+    for (int i = 0; i < array.size(); i++) {
+        types.push_back(CAST_INT_TO_ENUM(Variant::Type, array[i]));
+    }
+
+    target->_set_operand_types(types);
+}
+
 void OScriptNodePromotableOperator::_bind_methods() {
 
 }

--- a/src/orchestration/nodes/operator_node.h
+++ b/src/orchestration/nodes/operator_node.h
@@ -143,4 +143,5 @@ public:
     static String get_operator_tooltip_text(VariantOperators::Code p_operator);
 
     static void copy_pin_types(const Ref<OrchestrationGraphNode>& p_source, const Ref<OrchestrationGraphNode>& p_target);
+    static void copy_pin_types(const Dictionary& p_properties, const Ref<OrchestrationGraphNode>& p_target);
 };

--- a/src/orchestration/orchestration.cpp
+++ b/src/orchestration/orchestration.cpp
@@ -19,6 +19,7 @@
 #include "common/dictionary_utils.h"
 #include "common/method_utils.h"
 #include "common/name_utils.h"
+#include "common/resource_utils.h"
 #include "common/scene_utils.h"
 #include "common/string_utils.h"
 #include "common/variant_utils.h"
@@ -992,158 +993,131 @@ Ref<OScriptFunction> Orchestration::duplicate_function(const StringName& p_name,
     ERR_FAIL_COND_V_MSG(_has_instances(), nullptr, "Cannot duplicate functions, instances exist.");
     ERR_FAIL_COND_V_MSG(!has_function(p_name), nullptr, "No function exists with the name: " + p_name);
 
-    Ref<OScriptGraph> old_graph = find_graph(p_name);
-    Ref<OScriptFunction> old_function = find_function(p_name);
+    // A duplicate is an export re-imported under a unique name, so the copy shares the clipboard's
+    // invariants: id remap, connections, comment attachments, and promotable operator pin types.
+    const Dictionary data = export_function(p_name);
+    const String new_name = NameUtils::create_unique_name(p_name, get_function_names());
 
-    // make a unique name for the new function
-    String new_name = NameUtils::create_unique_name(p_name, get_function_names());
-
-    // make a graph
-    Ref<OScriptGraph> new_graph = create_graph(new_name, OScriptGraph::GF_FUNCTION | OScriptGraph::GF_DEFAULT);
-
-    // duplicate each node, make a lookup table that maps old node IDs to new node IDs
-    HashMap<int,int> node_id_map;
-
-    // new entry and result nodes (only needed later if we don't include code)
-    Ref<OScriptNodeFunctionEntry> new_entry;
-    Ref<OScriptNodeFunctionResult> new_result;
-
-    // Block signals for performance reasons
-    old_graph->set_block_signals(true);
-    new_graph->set_block_signals(true);
-
-    bool failed = false;
-    for (const Ref<OScriptNode>& old_node : old_graph->get_nodes()) {
-        // Short-cut exit
-        if (new_entry.is_valid() && new_result.is_valid() && !p_include_code) {
-            break;
-        }
-
-        if (!new_entry.is_valid()) {
-            Ref<OScriptNodeFunctionEntry> old_entry = old_node;
-            if (old_entry.is_valid()) {
-                const Ref<OScriptNodeFunctionEntry> entry = old_graph->duplicate_node(old_node->get_id(), {}, true);
-                if (!entry.is_valid()) {
-                    ERR_PRINT("Failed to duplicate entry node " + itos(old_node->get_id()));
-                    failed = true;
-                    break;
-                }
-                node_id_map[old_node->get_id()] = entry->get_id();
-                old_graph->remove_node(entry);
-                new_graph->add_node(entry);
-                new_entry = entry;
-                continue;
-            }
-        }
-
-        if (!new_result.is_valid()) {
-            Ref<OScriptNodeFunctionResult> old_result = old_node;
-            if (old_result.is_valid()) {
-                const Ref<OScriptNodeFunctionResult> result = old_graph->duplicate_node(old_node->get_id(), {}, true);
-                if (!result.is_valid()) {
-                    ERR_PRINT("Failed to duplicate result node " + itos(old_node->get_id()));
-                    failed = true;
-                    break;
-                }
-                node_id_map[old_node->get_id()] = result->get_id();
-                old_graph->remove_node(result);
-                new_graph->add_node(result);
-                new_result = result;
-                continue;
-            }
-        }
-
-        if (p_include_code) {
-            const Ref<OScriptNode> new_node = old_graph->duplicate_node(old_node->get_id(), {}, true);
-            if (!new_node.is_valid()) {
-                ERR_PRINT("Failed to duplicate node " + itos(old_node->get_id()));
-                failed = true;
-                break;
-            }
-            node_id_map[old_node->get_id()] = new_node->get_id();
-            old_graph->move_node_to(new_node, new_graph);
-        }
-    }
-
-    // Re-enable signals
-    old_graph->set_block_signals(false);
-    new_graph->set_block_signals(false);
-
-    if (failed) {
-        remove_graph(new_graph->get_graph_name());
+    const Ref<OScriptFunction> function = import_function(data, new_name);
+    if (!function.is_valid()) {
         return nullptr;
     }
 
-    MethodInfo method = old_function->get_method_info();
-    method.name = new_name;
+    if (p_include_code && data.has("graph")) {
+        if (!import_function_body(new_name, data["graph"])) {
+            remove_function(new_name);
+            return nullptr;
+        }
+    }
 
-    Ref<OScriptFunction> new_function = create_function(method, new_entry->get_id(), old_function->is_user_defined());
-    if (!new_function.is_valid()) {
-        remove_graph(new_graph->get_graph_name());
+    return function;
+}
+
+Dictionary Orchestration::export_function(const StringName& p_name) const {
+    const Ref<OScriptFunction> function = find_function(p_name);
+    ERR_FAIL_COND_V_MSG(!function.is_valid(), Dictionary(), "No function exists with the name: " + p_name);
+
+    Dictionary data = ResourceUtils::get_storage_properties(function);
+
+    const Ref<OScriptGraph> graph = find_graph(p_name);
+    if (graph.is_valid()) {
+        Vector<int> node_ids;
+        for (const Ref<OScriptNode>& node : graph->get_nodes()) {
+            node_ids.push_back(node->get_id());
+        }
+        data["graph"] = graph->export_nodes(node_ids);
+    }
+
+    return data;
+}
+
+Ref<OScriptFunction> Orchestration::import_function(const Dictionary& p_data, const StringName& p_name) {
+    ERR_FAIL_COND_V_MSG(_has_instances(), nullptr, "Cannot import functions, instances exist.");
+
+    MethodInfo method = DictionaryUtils::to_method(ResourceUtils::get_storage_property(p_data, OScriptFunction::get_class_static(), "method"));
+    method.name = p_name;
+
+    const bool user_defined = ResourceUtils::get_storage_property(p_data, OScriptFunction::get_class_static(), "user_defined");
+
+    const Ref<OScriptFunction> function = create_function(method, user_defined);
+    if (!function.is_valid()) {
         return nullptr;
     }
 
-    // The duplicated terminators carry the source function's guid, as that is stored state that is
-    // copied verbatim. They must be rebound onto the new function, otherwise the duplicate resolves
-    // back to the source function when the orchestration is reloaded.
-    new_entry->set_function(new_function);
-    if (new_result.is_valid()) {
-        new_result->set_function(new_function);
-    }
+    // The identity properties belong to the exporting orchestration or were consumed above
+    ResourceUtils::apply_storage_properties(function, p_data, { "guid", "id", "method", "user_defined", "graph" });
 
-    old_graph->emit_changed();
-    new_graph->emit_changed();
+    return function;
+}
 
-    // now restore connections
-    if (p_include_code) {
-        // if we include code, we need to restore all connections
-        for (const OScriptConnection& old_connection : old_graph->get_connections()) {
-            int source_id = node_id_map[static_cast<int>(old_connection.from_node)];
-            int target_id = node_id_map[static_cast<int>(old_connection.to_node)];
-            int source_port = old_connection.from_port;
-            int target_port = old_connection.to_port;
-            new_graph->link(source_id, source_port, target_id, target_port);
-        }
-    }
-    else
-    {
-        // otherwise we just connect the entry node to the result node (if we had a result node)
-        if (new_entry.is_valid() && new_result.is_valid()) {
-            // get first the output pin of the entry node that is an execution pin
-            Ref<OScriptNodePin> entry_execution_pin;
-            for (const Ref<OScriptNodePin>& pin : new_entry->find_pins(PD_Output)) {
-                if (pin->is_execution()) {
-                    entry_execution_pin = pin;
-                    break;
-                }
-            }
-            Ref<OScriptNodePin> result_execution_pin;
-            // get the fist input pin of the result node that is an execution pin
-            for (const Ref<OScriptNodePin>& pin : new_result->find_pins(PD_Input)) {
-                if (pin->is_execution()) {
-                    result_execution_pin = pin;
-                    break;
-                }
-            }
+bool Orchestration::import_function_body(const StringName& p_name, const Dictionary& p_graph_data) {
+    ERR_FAIL_COND_V_MSG(_has_instances(), false, "Cannot import function bodies, instances exist.");
 
+    const Ref<OScriptFunction> function = find_function(p_name);
+    ERR_FAIL_COND_V_MSG(!function.is_valid(), false, "No function exists with the name: " + p_name);
 
-            // connect the entry node to the result node
-            if (entry_execution_pin.is_valid() && result_execution_pin.is_valid()) {
-                // link the entry execution pin to the result execution pin
-                new_graph->link(
-                    new_entry->get_id(),
-                    entry_execution_pin->get_pin_index(),
-                    new_result->get_id(),
-                    result_execution_pin->get_pin_index());
-            }
+    const Ref<OScriptGraph> graph = find_graph(p_name);
+    ERR_FAIL_COND_V_MSG(!graph.is_valid(), false, "No function graph exists with the name: " + p_name);
 
-            // and move the result node close to the entry node
-            // this doesn't work too well on HDPI displays, but it is better than nothing
-            new_result->set_position(new_entry->get_position() + Vector2(250, 0));
+    const Ref<OScriptNode> entry = function->get_owning_node();
+    ERR_FAIL_COND_V_MSG(!entry.is_valid(), false, "The function has no entry node: " + p_name);
+
+    // Creating the function produced the entry node and, for a function with a return value, one result
+    // node linked to it. The body carries its own result nodes, any number of them, which are imported as
+    // ordinary nodes below.
+    //
+    // Only the generated node is surplus, and it is removed after the body is in place: removing the last
+    // result node of a function clears its return value, see OScriptNodeFunctionResult::pre_remove. The
+    // entry node is kept and seeded so the body's connections land on it.
+    Vector<int> generated_results;
+    for (const Ref<OScriptNode>& node : graph->get_nodes()) {
+        const Ref<OScriptNodeFunctionResult> result = node;
+        if (result.is_valid()) {
+            generated_results.push_back(result->get_id());
         }
     }
 
-    return new_function;
+    // The body is worked on as a deep copy; terminators must carry this function's guid, not the source's
+    const Dictionary data = p_graph_data.duplicate(true);
+    const String guid = function->get_guid().to_string();
+
+    HashMap<uint64_t, uint64_t> remap;
+    const Array entries = data.get("nodes", Array());
+    for (int i = 0; i < entries.size(); i++) {
+        const Dictionary node_entry = entries[i];
+        const String class_name = node_entry.get("class", String());
+        Dictionary properties = node_entry.get("properties", Dictionary());
+
+        if (ClassDB::is_parent_class(class_name, OScriptNodeFunctionEntry::get_class_static())) {
+            const int exported_id = node_entry.get("id", -1);
+            remap[exported_id] = entry->get_id();
+
+            // Keep the exported layout for the seeded node
+            entry->set_position(properties.get("position", entry->get_position()));
+            entry->set_size(properties.get("size", entry->get_size()));
+        } else if (ClassDB::is_parent_class(class_name, OScriptNodeFunctionTerminator::get_class_static())) {
+            properties["function_id"] = guid;
+        }
+    }
+
+    graph->import_nodes(data, Vector2(), remap);
+
+    // A body may legitimately carry no result node, in which case the removal below would clear the
+    // return the declaration asked for, so it is captured here and restored if that happens.
+    const bool returns_value = function->has_return_type();
+    const PropertyInfo return_value = function->get_method_info().return_val;
+
+    for (const int node_id : generated_results) {
+        remove_node(node_id);
+    }
+
+    if (returns_value && !function->has_return_type()) {
+        function->set_return(return_value);
+    }
+
+    graph->emit_changed();
+
+    return true;
 }
 
 void Orchestration::remove_function(const StringName& p_name) {

--- a/src/orchestration/orchestration.h
+++ b/src/orchestration/orchestration.h
@@ -298,6 +298,9 @@ public:
     Ref<OScriptFunction> create_function(const MethodInfo& p_method, bool p_user_defined = false);
     Ref<OScriptFunction> create_function(const MethodInfo& p_method, int p_node_id, bool p_user_defined = false);
     Ref<OScriptFunction> duplicate_function(const StringName& p_name, bool p_include_code);
+    Dictionary export_function(const StringName& p_name) const;
+    Ref<OScriptFunction> import_function(const Dictionary& p_data, const StringName& p_name);
+    bool import_function_body(const StringName& p_name, const Dictionary& p_graph_data);
     void remove_function(const StringName& p_name);
     Ref<OScriptFunction> find_function(const StringName& p_name) const;
     Ref<OScriptFunction> find_function(const Guid& p_guid) const;


### PR DESCRIPTION
Fixes GH-1355

## Description

This PR introduces the ability to copy/paste functions, variables, and signals across scripts, not only within the same Godot editor but also across different Godot editor instances by using the OS clipboard.

When pasting content across scripts, the paste operation evaluates whether the target function, variable, or signal exists, compares its signature/type, and if there are conflicts, provides you with a conflict resolution dialog to decide how to proceed:

<img width="849" height="413" alt="image" src="https://github.com/user-attachments/assets/2134d9b2-4c26-4bf4-b14c-0bdcc444786a" />

In addition, copying a script function call node now traverses the user-defined function's content and buffers the entire function (and any used variables or signals) for pasting, allowing users to quickly move code across different scripts and editor instances. Additionally, components can be selected using the new context-menu copy/paste options:

<img width="409" height="272" alt="image" src="https://github.com/user-attachments/assets/e684f152-8430-4268-a71f-280e12e57685" />

