### PR TITLE
GH-1827 Fix unusual white border with Godot 4.8

### DIFF
--- a/src/editor/editor.cpp
+++ b/src/editor/editor.cpp
@@ -2457,7 +2457,6 @@ void OrchestratorEditor::_notification(int p_what) {
         case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
         case NOTIFICATION_THEME_CHANGED: {
             _theme_manager->theme_changed();
-            _tab_container->add_theme_stylebox_override(SceneStringName(panel), get_theme_stylebox("ScriptEditor", "EditorStyles"));
 
             _calculate_script_name_button_size();
 
@@ -2473,8 +2472,6 @@ void OrchestratorEditor::_notification(int p_what) {
             break;
         }
         case NOTIFICATION_READY: {
-            add_theme_stylebox_override(SceneStringName(panel), get_theme_stylebox("ScriptEditorPanel", "EditorStyles"));
-
             EditorNode->connect("script_add_function_request", callable_mp_this(_add_callback));
             EditorNode->connect("resource_saved", callable_mp_this(_resource_saved_callback));
 
@@ -2526,6 +2523,11 @@ OrchestratorEditor::OrchestratorEditor(OrchestratorWindowWrapper* p_window_wrapp
     _theme_manager->connect("theme_rebuilt", callable_mp_lambda(this, [this] {
         set_theme(_theme_manager->get_theme());
     }));
+
+    // The builder produces the initial theme synchronously, so the panel style resolves from it
+    // on the first frame rather than falling back to the Godot editor theme.
+    set_theme(_theme_manager->get_theme());
+    set_theme_type_variation("OrchestratorEditorPanel");
 
     add_child(memnew(OrchestratorEditorActionRegistry));
     add_child(memnew(OrchestratorEditorConnectionsDock));
@@ -2580,6 +2582,7 @@ OrchestratorEditor::OrchestratorEditor(OrchestratorWindowWrapper* p_window_wrapp
     _script_split->add_child(editor_container);
 
     _tab_container = memnew(TabContainer);
+    _tab_container->set_theme_type_variation("OrchestratorEditorTabs");
     _tab_container->set_tabs_visible(false);
     _tab_container->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
     _tab_container->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/src/editor/theme/theme_builder.cpp
+++ b/src/editor/theme/theme_builder.cpp
@@ -37,6 +37,26 @@ OrchestratorEditorThemeBuilder::ThemeParams OrchestratorEditorThemeBuilder::_rea
     };
 }
 
+void OrchestratorEditorThemeBuilder::_build_editor_styles(const Ref<Theme>& p_theme) {
+    // The editor panel and its tab container used to borrow the ScriptEditorPanel and ScriptEditor styles
+    // from the Godot editor theme. These styles were subset in Godot 4.8, so the equivalents are defined
+    // here as type variations that the editor selects, keeping the lookup independent of the editor.
+    const float base_margin = 4 * EDSCALE;
+
+    const Ref<StyleBoxEmpty> panel_sb = memnew(StyleBoxEmpty);
+    panel_sb->set_content_margin_all(base_margin);
+    panel_sb->set_content_margin(SIDE_TOP, 0);
+
+    p_theme->set_type_variation("OrchestratorEditorPanel", "PanelContainer");
+    p_theme->set_stylebox(SceneStringName(panel), "OrchestratorEditorPanel", panel_sb);
+
+    const Ref<StyleBoxEmpty> tabs_sb = memnew(StyleBoxEmpty);
+    tabs_sb->set_content_margin_all(0);
+
+    p_theme->set_type_variation("OrchestratorEditorTabs", "TabContainer");
+    p_theme->set_stylebox(SceneStringName(panel), "OrchestratorEditorTabs", tabs_sb);
+}
+
 void OrchestratorEditorThemeBuilder::_build_graph_styles(const Ref<Theme>& p_theme, const ThemeParams& p_params) {
 
     // Base GraphNode: panel font color adapts to background brightness
@@ -122,12 +142,13 @@ void OrchestratorEditorThemeBuilder::_build_graph_styles(const Ref<Theme>& p_the
 
 }
 
-void OrchestratorEditorThemeBuilder::_rebuild_theme() {
+void OrchestratorEditorThemeBuilder::rebuild() {
     _rebuilding = false;
 
     const ThemeParams params = _read_theme_params();
     Ref<Theme> theme = memnew(Theme);
 
+    _build_editor_styles(theme);
     _build_graph_styles(theme, params);
 
     _theme = theme;
@@ -140,14 +161,16 @@ void OrchestratorEditorThemeBuilder::queue_rebuild() {
     }
 
     _rebuilding = true;
-    callable_mp_this(_rebuild_theme).call_deferred();
+    callable_mp_this(rebuild).call_deferred();
 }
 
 void OrchestratorEditorThemeBuilder::_notification(int p_what) {
     switch (p_what) {
         case NOTIFICATION_POSTINITIALIZE: {
             ProjectSettings::get_singleton()->connect("settings_changed", callable_mp_this(queue_rebuild));
-            callable_mp_this(queue_rebuild).call_deferred();
+
+            // Built synchronously so the theme can be applied before the editor enters the tree
+            rebuild();
             break;
         }
     }

--- a/src/editor/theme/theme_builder.h
+++ b/src/editor/theme/theme_builder.h
@@ -39,9 +39,8 @@ class OrchestratorEditorThemeBuilder : public Object {
 
     ThemeParams _read_theme_params() const;
 
+    void _build_editor_styles(const Ref<Theme>& p_theme);
     void _build_graph_styles(const Ref<Theme>& p_theme, const ThemeParams& p_params);
-
-    void _rebuild_theme();
 
 protected:
     static void _bind_methods();
@@ -53,5 +52,6 @@ protected:
 public:
     Ref<Theme> get_theme() const { return _theme; }
 
+    void rebuild();
     void queue_rebuild();
 };


### PR DESCRIPTION
Fixes GH-1827 

## Description

With the rework in Godot 4.8, several editor styles were sunset, including `ScriptEditor` and `ScriptEditorPanel`. As a result, this triggered an editor fallback to a Flat-based stylebox for `OrchestratorEditor` control, leaving an unusual white border. 

The PR reintroduces those same retired styles, but defines them within Orchestrator to avoid the problem. This also means that we can reuse the same logic on 2.5 and 2.4 without any Godot-version guards.
