### PR TITLE
GH-1513 Annotation support

### DIFF
--- a/src/editor/inspector/annotation_presentation.cpp
+++ b/src/editor/inspector/annotation_presentation.cpp
@@ -1,0 +1,187 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editor/inspector/annotation_presentation.h"
+
+#include "script/script_warning.h"
+
+#include <godot_cpp/classes/global_constants.hpp>
+#include <godot_cpp/variant/variant.hpp>
+
+namespace {
+    struct Entry {
+        const char* name;
+        const char* label;
+        const char* description;
+    };
+
+    // Descriptions follow the GDScript reference so the tooltips read the same as Godot's own docs.
+    const Entry ENTRIES[] = {
+        { "@export", "Export", "Expose the variable in the inspector using its declared type." },
+        { "@export_enum", "Export Enum", "Expose an int or String as a dropdown of the given names. Use \"Name:value\" to set explicit values." },
+        { "@export_file", "Export File", "Expose a String as a file path, optionally limited to the given filters such as \"*.png\"." },
+        { "@export_dir", "Export Directory", "Expose a String as a directory path inside the project." },
+        { "@export_global_file", "Export Global File", "Expose a String as a file path anywhere on disk, optionally limited to the given filters." },
+        { "@export_global_dir", "Export Global Directory", "Expose a String as a directory path anywhere on disk." },
+        { "@export_multiline", "Export Multiline", "Expose a String or Dictionary with a multiline text editor." },
+        { "@export_placeholder", "Export Placeholder", "Expose a String with placeholder text shown while the field is empty." },
+        { "@export_range", "Export Range", "Expose an int or float with a minimum, maximum and optional step. Extra hints: or_greater, or_less, hide_slider, exp, radians_as_degrees, degrees, suffix:unit." },
+        { "@export_exp_easing", "Export Exp Easing", "Expose a float as an easing curve. Hints: attenuation, positive_only." },
+        { "@export_color_no_alpha", "Export Color No Alpha", "Expose a Color without the alpha channel." },
+        { "@export_node_path", "Export Node Path", "Expose a NodePath, optionally limited to the given node types." },
+        { "@export_flags", "Export Flags", "Expose an int as a set of named bit flags. Use \"Name:value\" to set explicit values." },
+        { "@export_flags_2d_render", "Export 2D Render Layers", "Expose an int as 2D render layers." },
+        { "@export_flags_2d_physics", "Export 2D Physics Layers", "Expose an int as 2D physics layers." },
+        { "@export_flags_2d_navigation", "Export 2D Navigation Layers", "Expose an int as 2D navigation layers." },
+        { "@export_flags_3d_render", "Export 3D Render Layers", "Expose an int as 3D render layers." },
+        { "@export_flags_3d_physics", "Export 3D Physics Layers", "Expose an int as 3D physics layers." },
+        { "@export_flags_3d_navigation", "Export 3D Navigation Layers", "Expose an int as 3D navigation layers." },
+        { "@export_flags_avoidance", "Export Avoidance Layers", "Expose an int as navigation avoidance layers." },
+        { "@export_storage", "Export Storage", "Store the variable in the scene without showing it in the inspector." },
+        { "@export_custom", "Export Custom", "Expose the variable with an explicit property hint, hint string and usage flags." },
+        { "@export_tool_button", "Export Tool Button", "Expose a Callable as a button in the inspector with the given text and optional icon." },
+        { "@rpc", "RPC", "Mark the function as a remote procedure call. Choose who may call it, whether it also runs locally, the transfer mode and the channel." },
+        { "@onready", "On Ready", "Assign the default value when the owner enters the scene tree, just before _ready. Required when the initializer is a node path." },
+        { "@warning_ignore", "Ignore Warnings", "Suppress the named compiler warnings for this member." },
+    };
+
+    struct Choice {
+        const char* label;
+        const char* value;
+    };
+
+    const Choice RPC_MODES[] = {
+        { "Authority", "authority" },
+        { "Any Peer", "any_peer" },
+    };
+
+    const Choice RPC_SYNCS[] = {
+        { "Call Remote", "call_remote" },
+        { "Call Local", "call_local" },
+    };
+
+    const Choice RPC_TRANSFER_MODES[] = {
+        { "Unreliable", "unreliable" },
+        { "Unreliable Ordered", "unreliable_ordered" },
+        { "Reliable", "reliable" },
+    };
+
+    template <size_t N>
+    void add_choices(const Choice (&p_choices)[N], PackedStringArray& r_labels, Array& r_values) {
+        for (const Choice& choice : p_choices) {
+            r_labels.push_back(choice.label);
+            r_values.push_back(choice.value);
+        }
+    }
+
+    struct HintEntry {
+        PropertyHint hint;
+        const char* label;
+    };
+
+    // PropertyHint values that make sense as an @export_custom hint, in enum order.
+    const HintEntry HINTS[] = {
+        { PROPERTY_HINT_NONE, "None" },
+        { PROPERTY_HINT_RANGE, "Range" },
+        { PROPERTY_HINT_ENUM, "Enum" },
+        { PROPERTY_HINT_ENUM_SUGGESTION, "Enum Suggestion" },
+        { PROPERTY_HINT_EXP_EASING, "Exp Easing" },
+        { PROPERTY_HINT_LINK, "Link" },
+        { PROPERTY_HINT_FLAGS, "Flags" },
+        { PROPERTY_HINT_LAYERS_2D_RENDER, "Layers 2D Render" },
+        { PROPERTY_HINT_LAYERS_2D_PHYSICS, "Layers 2D Physics" },
+        { PROPERTY_HINT_LAYERS_2D_NAVIGATION, "Layers 2D Navigation" },
+        { PROPERTY_HINT_LAYERS_3D_RENDER, "Layers 3D Render" },
+        { PROPERTY_HINT_LAYERS_3D_PHYSICS, "Layers 3D Physics" },
+        { PROPERTY_HINT_LAYERS_3D_NAVIGATION, "Layers 3D Navigation" },
+        { PROPERTY_HINT_FILE, "File" },
+        { PROPERTY_HINT_DIR, "Directory" },
+        { PROPERTY_HINT_GLOBAL_FILE, "Global File" },
+        { PROPERTY_HINT_GLOBAL_DIR, "Global Directory" },
+        { PROPERTY_HINT_RESOURCE_TYPE, "Resource Type" },
+        { PROPERTY_HINT_MULTILINE_TEXT, "Multiline Text" },
+        { PROPERTY_HINT_EXPRESSION, "Expression" },
+        { PROPERTY_HINT_PLACEHOLDER_TEXT, "Placeholder Text" },
+        { PROPERTY_HINT_COLOR_NO_ALPHA, "Color No Alpha" },
+        { PROPERTY_HINT_TYPE_STRING, "Type String" },
+        { PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Node Path Valid Types" },
+        { PROPERTY_HINT_SAVE_FILE, "Save File" },
+        { PROPERTY_HINT_GLOBAL_SAVE_FILE, "Global Save File" },
+        { PROPERTY_HINT_ARRAY_TYPE, "Array Type" },
+        { PROPERTY_HINT_LOCALE_ID, "Locale ID" },
+        { PROPERTY_HINT_LOCALIZABLE_STRING, "Localizable String" },
+        { PROPERTY_HINT_NODE_TYPE, "Node Type" },
+        { PROPERTY_HINT_HIDE_QUATERNION_EDIT, "Hide Quaternion Edit" },
+        { PROPERTY_HINT_PASSWORD, "Password" },
+        { PROPERTY_HINT_LAYERS_AVOIDANCE, "Layers Avoidance" },
+        { PROPERTY_HINT_DICTIONARY_TYPE, "Dictionary Type" },
+        { PROPERTY_HINT_TOOL_BUTTON, "Tool Button" },
+        { PROPERTY_HINT_ONESHOT, "Oneshot" },
+        { PROPERTY_HINT_GROUP_ENABLE, "Group Enable" },
+        { PROPERTY_HINT_INPUT_NAME, "Input Name" },
+        { PROPERTY_HINT_FILE_PATH, "File Path" },
+    };
+}
+
+OrchestratorEditorAnnotationPresentation OrchestratorEditorAnnotationPresentation::get(const StringName& p_name) {
+    for (const Entry& entry : ENTRIES) {
+        if (p_name == StringName(entry.name)) {
+            return { entry.label, entry.description };
+        }
+    }
+    return { String(p_name), String() };
+}
+
+bool OrchestratorEditorAnnotationPresentation::get_argument_choices(const StringName& p_name, int p_argument_index, PackedStringArray& r_labels, Array& r_values) {
+    if (p_name == StringName("@export_custom") && p_argument_index == 0) {
+        for (const HintEntry& entry : HINTS) {
+            r_labels.push_back(entry.label);
+            r_values.push_back(Variant(static_cast<int64_t>(entry.hint)));
+        }
+        return true;
+    }
+
+    if (p_name == StringName("@rpc")) {
+        switch (p_argument_index) {
+            case 0:
+                add_choices(RPC_MODES, r_labels, r_values);
+                return true;
+            case 1:
+                add_choices(RPC_SYNCS, r_labels, r_values);
+                return true;
+            case 2:
+                add_choices(RPC_TRANSFER_MODES, r_labels, r_values);
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    #ifdef DEBUG_ENABLED
+    // Warnings only exist in debug builds; elsewhere the name stays a free-text argument.
+    if (p_name == StringName("@warning_ignore")) {
+        // GDScript spells warning names in lower case inside the annotation.
+        for (int i = 0; i < OScriptWarning::WARNING_MAX; i++) {
+            const String name = OScriptWarning::get_name_from_code(static_cast<OScriptWarning::Code>(i));
+            r_labels.push_back(name.capitalize());
+            r_values.push_back(name.to_lower());
+        }
+        return true;
+    }
+    #endif
+
+    return false;
+}

--- a/src/editor/inspector/annotation_presentation.h
+++ b/src/editor/inspector/annotation_presentation.h
@@ -1,0 +1,43 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/string.hpp>
+
+using namespace godot;
+
+/// Presentation metadata for an annotation shown in the editor.
+///
+/// Rules live in OScriptAnnotationRegistry. This table only supplies what the inspector displays:
+/// a label, a description, and dropdown choices for arguments that are enumerations.
+///
+struct OrchestratorEditorAnnotationPresentation {
+    String label;
+    String description;
+
+    /// Looks up the presentation for an annotation, falling back to its name when unlisted.
+    static OrchestratorEditorAnnotationPresentation get(const StringName& p_name);
+
+    /// Dropdown choices for a signature argument.
+    /// @param p_name the annotation name
+    /// @param p_argument_index the signature argument index
+    /// @param r_labels the labels to display
+    /// @param r_values the stored values, parallel to the labels
+    /// @return true when the argument is rendered as a dropdown
+    static bool get_argument_choices(const StringName& p_name, int p_argument_index, PackedStringArray& r_labels, Array& r_values);
+};

--- a/src/editor/inspector/function_inspector_plugin.cpp
+++ b/src/editor/inspector/function_inspector_plugin.cpp
@@ -18,6 +18,7 @@
 
 #include "common/dictionary_utils.h"
 #include "common/macros.h"
+#include "editor/inspector/properties/editor_property_annotations.h"
 #include "editor/inspector/properties/editor_property_pin_properties.h"
 #include "orchestration/nodes/function_entry.h"
 #include "orchestration/orchestration.h"
@@ -112,6 +113,12 @@ bool OrchestratorEditorInspectorPluginFunction::_parse_property(Object* p_object
         outputs->setup(false, 1);
         outputs->connect("remove", callable_mp_this(_remove_return_value).bind(function));
         add_property_editor(p_name, outputs, true);
+        return true;
+    }
+
+    if (p_name.match("annotations")) {
+        OrchestratorEditorPropertyAnnotations* annotations = memnew(OrchestratorEditorPropertyAnnotations);
+        add_property_editor(p_name, annotations, false, "Annotations");
         return true;
     }
 

--- a/src/editor/inspector/properties/editor_property_annotations.cpp
+++ b/src/editor/inspector/properties/editor_property_annotations.cpp
@@ -1,0 +1,561 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editor/inspector/properties/editor_property_annotations.h"
+
+#include "common/macros.h"
+#include "common/scene_utils.h"
+#include "core/godot/scene_string_names.h"
+#include "editor/inspector/annotation_presentation.h"
+#include "orchestration/annotation_registry.h"
+#include "orchestration/function.h"
+#include "orchestration/variable.h"
+
+#include <godot_cpp/classes/button.hpp>
+#include <godot_cpp/classes/check_box.hpp>
+#include <godot_cpp/classes/editor_spin_slider.hpp>
+#include <godot_cpp/classes/h_box_container.hpp>
+#include <godot_cpp/classes/label.hpp>
+#include <godot_cpp/classes/line_edit.hpp>
+#include <godot_cpp/classes/option_button.hpp>
+#include <godot_cpp/classes/popup_menu.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+void OrchestratorEditorPropertyAnnotations::_get_owner(PropertyInfo& r_owner, uint32_t& r_target, bool& r_constant) {
+    r_owner = PropertyInfo();
+    r_target = OScriptAnnotationRegistry::TARGET_VARIABLE;
+    r_constant = false;
+
+    if (const OScriptVariable* variable = cast_to<OScriptVariable>(get_edited_object())) {
+        r_owner = variable->get_info();
+        r_constant = variable->is_constant();
+        return;
+    }
+
+    if (const OScriptFunction* function = cast_to<OScriptFunction>(get_edited_object())) {
+        r_owner = function->get_method_info().return_val;
+        r_target = function->is_user_defined()
+            ? OScriptAnnotationRegistry::TARGET_FUNCTION
+            : OScriptAnnotationRegistry::TARGET_EVENT;
+    }
+}
+
+String OrchestratorEditorPropertyAnnotations::_get_summary(const OScriptAnnotation& p_annotation) const {
+    if (p_annotation.arguments.is_empty()) {
+        return p_annotation.name;
+    }
+
+    PackedStringArray parts;
+    for (int i = 0; i < p_annotation.arguments.size(); i++) {
+        parts.push_back(UtilityFunctions::var_to_str(p_annotation.arguments[i]));
+    }
+    return vformat("%s(%s)", p_annotation.name, String(", ").join(parts));
+}
+
+Variant OrchestratorEditorPropertyAnnotations::_get_argument_default(const OScriptAnnotationDescriptor& p_descriptor, int p_index) const {
+    const MethodInfo& info = p_descriptor.info;
+    const int signature_index = _get_signature_index(p_descriptor, p_index);
+    const int required = info.arguments.size() - info.default_arguments.size();
+    if (signature_index >= required && signature_index - required < info.default_arguments.size()) {
+        return info.default_arguments[signature_index - required];
+    }
+
+    switch (info.arguments[signature_index].type) {
+        case Variant::INT:
+            return 0;
+        case Variant::FLOAT:
+            return 0.0;
+        case Variant::BOOL:
+            return false;
+        case Variant::STRING:
+        default:
+            return String();
+    }
+}
+
+int OrchestratorEditorPropertyAnnotations::_get_signature_index(const OScriptAnnotationDescriptor& p_descriptor, int p_argument) const {
+    const int last = p_descriptor.info.arguments.size() - 1;
+    return p_argument > last ? last : p_argument;
+}
+
+void OrchestratorEditorPropertyAnnotations::_emit() {
+    Array array;
+    for (const OScriptAnnotation& annotation : _annotations) {
+        array.push_back(annotation.to_dict());
+    }
+
+    _self_change = true;
+    emit_changed(get_edited_property(), array);
+}
+
+void OrchestratorEditorPropertyAnnotations::_rebuild_chips() {
+    if (!_chips) {
+        return;
+    }
+
+    while (_chips->get_child_count() > 0) {
+        Node* child = _chips->get_child(_chips->get_child_count() - 1);
+        _chips->remove_child(child);
+        child->queue_free();
+    }
+
+    for (int i = 0; i < _annotations.size(); i++) {
+        const OScriptAnnotation& annotation = _annotations[i];
+        const OrchestratorEditorAnnotationPresentation presentation = OrchestratorEditorAnnotationPresentation::get(annotation.name);
+
+        HBoxContainer* chip = memnew(HBoxContainer);
+        chip->add_theme_constant_override("separation", 0);
+
+        Button* toggle = memnew(Button);
+        toggle->set_text(_get_summary(annotation));
+        toggle->set_tooltip_text(presentation.description.is_empty() ? presentation.label : presentation.description);
+        toggle->set_toggle_mode(true);
+        toggle->set_pressed_no_signal(i == _expanded);
+        toggle->set_focus_mode(FOCUS_NONE);
+        toggle->connect(SceneStringName(toggled), callable_mp_this(_chip_toggled).bind(i));
+        chip->add_child(toggle);
+
+        Button* remove = memnew(Button);
+        remove->set_button_icon(SceneUtils::get_editor_icon("Remove"));
+        remove->set_tooltip_text(vformat("Remove %s", annotation.name));
+        remove->set_flat(true);
+        remove->set_focus_mode(FOCUS_NONE);
+        remove->set_disabled(_read_only);
+        remove->connect(SceneStringName(pressed), callable_mp_this(_chip_remove_pressed).bind(i));
+        chip->add_child(remove);
+
+        _chips->add_child(chip);
+    }
+}
+
+void OrchestratorEditorPropertyAnnotations::_rebuild_form() {
+    if (!_form_box) {
+        return;
+    }
+
+    while (_form_box->get_child_count() > 0) {
+        Node* child = _form_box->get_child(_form_box->get_child_count() - 1);
+        _form_box->remove_child(child);
+        child->queue_free();
+    }
+    _form = nullptr;
+
+    _form_stale = false;
+
+    if (_expanded < 0 || _expanded >= _annotations.size()) {
+        _form_box->hide();
+        return;
+    }
+
+    const OScriptAnnotation& annotation = _annotations[_expanded];
+    const OScriptAnnotationDescriptor* descriptor = OScriptAnnotationRegistry::find(annotation.name);
+    if (descriptor == nullptr) {
+        Label* unknown = memnew(Label);
+        unknown->set_text(vformat("%s is not a known annotation and will fail to compile.", annotation.name));
+        _form_box->add_child(unknown);
+        _form_box->show();
+        return;
+    }
+
+    const MethodInfo& info = descriptor->info;
+    if (info.arguments.is_empty()) {
+        _form_box->hide();
+        return;
+    }
+
+    _form = memnew(GridContainer);
+    _form->set_columns(3);
+    _form->add_theme_constant_override("h_separation", 8);
+    _form->add_theme_constant_override("v_separation", 4);
+    _form_box->add_child(_form);
+
+    // Fixed arguments come first; a vararg signature repeats its last argument for every extra value.
+    const int fixed = descriptor->is_vararg() ? info.arguments.size() - 1 : info.arguments.size();
+    const int provided = annotation.arguments.size();
+    const int rows = descriptor->is_vararg() ? (provided > fixed ? provided : fixed) : fixed;
+
+    for (int argument = 0; argument < rows; argument++) {
+        const int signature_index = _get_signature_index(*descriptor, argument);
+        const PropertyInfo& parameter = info.arguments[signature_index];
+
+        Label* label = memnew(Label);
+        label->set_text(String(parameter.name).capitalize());
+        _form->add_child(label);
+
+        const Variant value = argument < provided ? annotation.arguments[argument] : _get_argument_default(*descriptor, argument);
+        Control* editor = _make_argument_editor(*descriptor, signature_index, value, argument);
+        editor->set_h_size_flags(SIZE_EXPAND_FILL);
+        _form->add_child(editor);
+
+        if (descriptor->is_vararg() && argument >= fixed) {
+            Button* remove = memnew(Button);
+            remove->set_button_icon(SceneUtils::get_editor_icon("Remove"));
+            remove->set_tooltip_text("Remove this value");
+            remove->set_flat(true);
+            remove->set_focus_mode(FOCUS_NONE);
+            remove->set_disabled(_read_only);
+            remove->connect(SceneStringName(pressed), callable_mp_this(_argument_remove_pressed).bind(argument));
+            _form->add_child(remove);
+        } else {
+            _form->add_child(memnew(Control));
+        }
+    }
+
+    if (descriptor->is_vararg()) {
+        const PropertyInfo& parameter = info.arguments[info.arguments.size() - 1];
+
+        Button* add = memnew(Button);
+        add->set_button_icon(SceneUtils::get_editor_icon("Add"));
+        add->set_text(vformat("Add %s", String(parameter.name).capitalize()));
+        add->set_theme_type_variation("InspectorActionButton");
+        add->set_h_size_flags(SIZE_SHRINK_CENTER);
+        add->set_focus_mode(FOCUS_NONE);
+        add->set_disabled(_read_only);
+        add->connect(SceneStringName(pressed), callable_mp_this(_argument_add_pressed));
+        _form_box->add_child(add);
+    }
+
+    _form_box->show();
+}
+
+void OrchestratorEditorPropertyAnnotations::_refresh_chip_text() {
+    if (!_chips) {
+        return;
+    }
+
+    for (int i = 0; i < _annotations.size() && i < _chips->get_child_count(); i++) {
+        const HBoxContainer* chip = cast_to<HBoxContainer>(_chips->get_child(i));
+        if (chip && chip->get_child_count() > 0) {
+            Button* toggle = cast_to<Button>(chip->get_child(0));
+            if (toggle) {
+                toggle->set_text(_get_summary(_annotations[i]));
+            }
+        }
+    }
+}
+
+Control* OrchestratorEditorPropertyAnnotations::_make_argument_editor(const OScriptAnnotationDescriptor& p_descriptor, int p_signature_index, const Variant& p_value, int p_argument) {
+    const PropertyInfo& parameter = p_descriptor.info.arguments[p_signature_index];
+
+    PackedStringArray labels;
+    Array values;
+    if (OrchestratorEditorAnnotationPresentation::get_argument_choices(p_descriptor.info.name, p_signature_index, labels, values)) {
+        OptionButton* option = memnew(OptionButton);
+        for (int i = 0; i < labels.size(); i++) {
+            option->add_item(labels[i]);
+            option->set_item_metadata(i, values[i]);
+            if (values[i] == p_value) {
+                option->select(i);
+            }
+        }
+        option->set_disabled(_read_only);
+        option->connect(SceneStringName(item_selected), callable_mp_this(_argument_item_selected).bind(p_argument));
+        add_focusable(option);
+        return option;
+    }
+
+    switch (parameter.type) {
+        case Variant::INT:
+        case Variant::FLOAT: {
+            const bool integer = parameter.type == Variant::INT;
+
+            EditorSpinSlider* spin = memnew(EditorSpinSlider);
+            spin->set_min(-1000000);
+            spin->set_max(1000000);
+            spin->set_allow_greater(true);
+            spin->set_allow_lesser(true);
+            spin->set_step(integer ? 1.0 : 0.001);
+            spin->set_hide_slider(true);
+            spin->set_value(p_value);
+            spin->set_read_only(_read_only);
+            spin->connect(SceneStringName(value_changed), callable_mp_this(_argument_value_changed).bind(p_argument, integer));
+            add_focusable(spin);
+            return spin;
+        }
+        case Variant::BOOL: {
+            CheckBox* check = memnew(CheckBox);
+            check->set_pressed_no_signal(p_value);
+            check->set_disabled(_read_only);
+            check->connect(SceneStringName(toggled), callable_mp_this(_argument_toggled).bind(p_argument));
+            add_focusable(check);
+            return check;
+        }
+        default: {
+            LineEdit* edit = memnew(LineEdit);
+            edit->set_text(p_value);
+            edit->set_editable(!_read_only);
+            edit->connect(SceneStringName(text_submitted), callable_mp_this(_argument_text_submitted).bind(p_argument));
+            edit->connect(SceneStringName(focus_exited), callable_mp_this(_argument_focus_exited).bind(p_argument));
+            add_focusable(edit);
+            return edit;
+        }
+    }
+}
+
+void OrchestratorEditorPropertyAnnotations::_set_argument(int p_argument, const Variant& p_value) {
+    if (_expanded < 0 || _expanded >= _annotations.size()) {
+        return;
+    }
+
+    const OScriptAnnotationDescriptor* descriptor = OScriptAnnotationRegistry::find(_annotations[_expanded].name);
+    if (descriptor == nullptr) {
+        return;
+    }
+
+    Array arguments = _annotations[_expanded].arguments.duplicate();
+    while (arguments.size() <= p_argument) {
+        arguments.push_back(_get_argument_default(*descriptor, arguments.size()));
+    }
+
+    if (arguments[p_argument] == p_value) {
+        return;
+    }
+
+    arguments[p_argument] = p_value;
+    _annotations.write[_expanded].arguments = arguments;
+    _emit();
+}
+
+void OrchestratorEditorPropertyAnnotations::_add_menu_about_to_popup() {
+    PopupMenu* popup = _add_button->get_popup();
+    popup->clear();
+
+    PropertyInfo owner;
+    uint32_t target = 0;
+    bool constant = false;
+    _get_owner(owner, target, constant);
+
+    const Vector<OScriptAnnotationDescriptor>& descriptors = OScriptAnnotationRegistry::get_descriptors();
+    for (int i = 0; i < descriptors.size(); i++) {
+        const OScriptAnnotationDescriptor& descriptor = descriptors[i];
+        if (constant && descriptor.family == StringName(OScriptAnnotationRegistry::FAMILY_EXPORT)) {
+            continue;
+        }
+        if (OScriptAnnotationRegistry::can_add(target, owner, _annotations, descriptor.info.name) != OK) {
+            continue;
+        }
+
+        const OrchestratorEditorAnnotationPresentation presentation = OrchestratorEditorAnnotationPresentation::get(descriptor.info.name);
+        popup->add_item(presentation.label, i);
+        popup->set_item_tooltip(popup->get_item_count() - 1, vformat("%s\n%s", descriptor.info.name, presentation.description));
+    }
+
+    if (popup->get_item_count() == 0) {
+        popup->add_item("No annotations apply to this type");
+        popup->set_item_disabled(0, true);
+    }
+}
+
+void OrchestratorEditorPropertyAnnotations::_add_menu_id_pressed(int p_id) {
+    const Vector<OScriptAnnotationDescriptor>& descriptors = OScriptAnnotationRegistry::get_descriptors();
+    if (p_id < 0 || p_id >= descriptors.size()) {
+        return;
+    }
+
+    const OScriptAnnotationDescriptor& descriptor = descriptors[p_id];
+
+    OScriptAnnotation annotation(descriptor.info.name);
+    const int required = descriptor.info.arguments.size() - descriptor.info.default_arguments.size();
+    for (int i = 0; i < required; i++) {
+        annotation.arguments.push_back(_get_argument_default(descriptor, i));
+    }
+
+    _annotations.push_back(annotation);
+    _expanded = _annotations.size() - 1;
+    _form_stale = true;
+    _emit();
+}
+
+void OrchestratorEditorPropertyAnnotations::_chip_toggled(bool p_pressed, int p_index) {
+    _expanded = p_pressed ? p_index : -1;
+
+    for (int i = 0; i < _chips->get_child_count(); i++) {
+        const HBoxContainer* chip = cast_to<HBoxContainer>(_chips->get_child(i));
+        if (chip && chip->get_child_count() > 0) {
+            Button* toggle = cast_to<Button>(chip->get_child(0));
+            if (toggle) {
+                toggle->set_pressed_no_signal(i == _expanded);
+            }
+        }
+    }
+
+    _rebuild_form();
+}
+
+void OrchestratorEditorPropertyAnnotations::_chip_remove_pressed(int p_index) {
+    if (p_index < 0 || p_index >= _annotations.size()) {
+        return;
+    }
+
+    _annotations.remove_at(p_index);
+    _expanded = -1;
+    _form_stale = true;
+    _emit();
+}
+
+void OrchestratorEditorPropertyAnnotations::_argument_value_changed(double p_value, int p_argument, bool p_integer) {
+    if (p_integer) {
+        _set_argument(p_argument, static_cast<int64_t>(p_value));
+    } else {
+        _set_argument(p_argument, p_value);
+    }
+}
+
+void OrchestratorEditorPropertyAnnotations::_argument_text_submitted(const String& p_text, int p_argument) {
+    _set_argument(p_argument, p_text);
+}
+
+void OrchestratorEditorPropertyAnnotations::_argument_focus_exited(int p_argument) {
+    if (!_form || _form->get_child_count() <= p_argument * 3 + 1) {
+        return;
+    }
+
+    const LineEdit* edit = cast_to<LineEdit>(_form->get_child(p_argument * 3 + 1));
+    if (edit) {
+        _set_argument(p_argument, edit->get_text());
+    }
+}
+
+void OrchestratorEditorPropertyAnnotations::_argument_toggled(bool p_pressed, int p_argument) {
+    _set_argument(p_argument, p_pressed);
+}
+
+void OrchestratorEditorPropertyAnnotations::_argument_item_selected(int p_item, int p_argument) {
+    if (!_form || _form->get_child_count() <= p_argument * 3 + 1) {
+        return;
+    }
+
+    const OptionButton* option = cast_to<OptionButton>(_form->get_child(p_argument * 3 + 1));
+    if (option) {
+        _set_argument(p_argument, option->get_item_metadata(p_item));
+    }
+}
+
+void OrchestratorEditorPropertyAnnotations::_argument_remove_pressed(int p_argument) {
+    if (_expanded < 0 || _expanded >= _annotations.size()) {
+        return;
+    }
+
+    Array arguments = _annotations[_expanded].arguments.duplicate();
+    if (p_argument < 0 || p_argument >= arguments.size()) {
+        return;
+    }
+
+    arguments.remove_at(p_argument);
+    _annotations.write[_expanded].arguments = arguments;
+    _form_stale = true;
+    _emit();
+}
+
+void OrchestratorEditorPropertyAnnotations::_argument_add_pressed() {
+    if (_expanded < 0 || _expanded >= _annotations.size()) {
+        return;
+    }
+
+    const OScriptAnnotationDescriptor* descriptor = OScriptAnnotationRegistry::find(_annotations[_expanded].name);
+    if (descriptor == nullptr || !descriptor->is_vararg()) {
+        return;
+    }
+
+    // Fill the fixed arguments first so the new value lands in the repeating slot.
+    Array arguments = _annotations[_expanded].arguments.duplicate();
+    const int fixed = descriptor->info.arguments.size() - 1;
+    while (arguments.size() < fixed) {
+        arguments.push_back(_get_argument_default(*descriptor, arguments.size()));
+    }
+    arguments.push_back(_get_argument_default(*descriptor, arguments.size()));
+
+    _annotations.write[_expanded].arguments = arguments;
+    _form_stale = true;
+    _emit();
+}
+
+void OrchestratorEditorPropertyAnnotations::_notification(int p_what) {
+    switch (p_what) {
+        case NOTIFICATION_READY: {
+            _add_button = memnew(MenuButton);
+            _add_button->set_text("Add");
+            _add_button->set_button_icon(SceneUtils::get_editor_icon("Add"));
+            _add_button->set_tooltip_text("Add an annotation that applies to this type");
+            _add_button->set_focus_mode(FOCUS_NONE);
+            _add_button->set_disabled(_read_only);
+            _add_button->set_h_size_flags(SIZE_EXPAND_FILL);
+            _add_button->get_popup()->connect("about_to_popup", callable_mp_this(_add_menu_about_to_popup));
+            _add_button->get_popup()->connect(SceneStringName(id_pressed), callable_mp_this(_add_menu_id_pressed));
+            add_child(_add_button);
+
+            _margin = memnew(MarginContainer);
+            _margin->set_theme_type_variation("MarginContainer4px");
+            set_bottom_editor(_margin);
+            add_child(_margin);
+
+            VBoxContainer* outer = memnew(VBoxContainer);
+            outer->add_theme_constant_override("separation", 5);
+            _margin->add_child(outer);
+
+            _chips = memnew(HFlowContainer);
+            _chips->add_theme_constant_override("h_separation", 4);
+            _chips->add_theme_constant_override("v_separation", 4);
+            outer->add_child(_chips);
+
+            _form_box = memnew(VBoxContainer);
+            _form_box->add_theme_constant_override("separation", 5);
+            _form_box->hide();
+            outer->add_child(_form_box);
+
+            _rebuild_chips();
+            _rebuild_form();
+            break;
+        }
+    }
+}
+
+void OrchestratorEditorPropertyAnnotations::_update_property() {
+    ERR_FAIL_NULL(get_edited_object());
+
+    OScriptAnnotationList list;
+    list.from_array(get_edited_object()->get(get_edited_property()));
+    _annotations = list.get_items();
+
+    if (_expanded >= _annotations.size()) {
+        _expanded = -1;
+    }
+
+    // An edit made here rebuilds only what changed, so the control being dragged or typed
+    // into survives. Anything else, such as undo or a type change, rebuilds everything.
+    if (_self_change) {
+        _self_change = false;
+        if (_form_stale) {
+            _rebuild_chips();
+            _rebuild_form();
+        } else {
+            _refresh_chip_text();
+        }
+        return;
+    }
+
+    _rebuild_chips();
+    _rebuild_form();
+}
+
+void OrchestratorEditorPropertyAnnotations::_set_read_only(bool p_read_only) {
+    _read_only = p_read_only;
+    if (_add_button) {
+        _add_button->set_disabled(p_read_only);
+    }
+    _rebuild_chips();
+    _rebuild_form();
+}

--- a/src/editor/inspector/properties/editor_property_annotations.h
+++ b/src/editor/inspector/properties/editor_property_annotations.h
@@ -1,0 +1,106 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include "orchestration/annotation.h"
+
+#include <godot_cpp/classes/editor_property.hpp>
+#include <godot_cpp/classes/grid_container.hpp>
+#include <godot_cpp/classes/h_flow_container.hpp>
+#include <godot_cpp/classes/margin_container.hpp>
+#include <godot_cpp/classes/menu_button.hpp>
+#include <godot_cpp/classes/v_box_container.hpp>
+#include <godot_cpp/core/object.hpp>
+
+using namespace godot;
+
+/// Forward declarations
+struct OScriptAnnotationDescriptor;
+
+/// An EditorProperty for the "annotations" list on a script member.
+///
+/// Renders one chip per applied annotation, an add menu filtered through the annotation registry,
+/// and an argument form generated from the selected annotation's signature. Every edit emits the
+/// whole list, so the inspector's undo history captures it as a single property change.
+///
+class OrchestratorEditorPropertyAnnotations : public EditorProperty {
+    GDCLASS(OrchestratorEditorPropertyAnnotations, EditorProperty);
+
+    MenuButton* _add_button = nullptr;               //! Add menu, populated from the registry when opened
+    MarginContainer* _margin = nullptr;              //! Bottom editor margin
+    HFlowContainer* _chips = nullptr;                //! One chip per applied annotation
+    VBoxContainer* _form_box = nullptr;              //! Holds the argument form for the expanded chip
+    GridContainer* _form = nullptr;                  //! Argument form, label and editor per row
+    Vector<OScriptAnnotation> _annotations;          //! Working copy of the edited list
+    int _expanded = -1;                              //! Index of the chip whose form is shown
+    bool _self_change = false;                       //! Whether the next update was caused by this editor
+    bool _form_stale = true;                         //! Whether the form must be rebuilt on the next update
+    bool _read_only = false;                         //! Whether editing is disabled
+
+    /// Reads the owner's type information and kind for registry checks
+    /// @param r_owner receives the owner's property information
+    /// @param r_target receives the registry target kind
+    /// @param r_constant receives whether the owner is a constant
+    void _get_owner(PropertyInfo& r_owner, uint32_t& r_target, bool& r_constant);
+
+    /// Formats an annotation as it would appear in source, for chip text
+    String _get_summary(const OScriptAnnotation& p_annotation) const;
+
+    /// Default value for a signature argument, from the signature or the argument type
+    Variant _get_argument_default(const OScriptAnnotationDescriptor& p_descriptor, int p_index) const;
+
+    /// Signature argument index for a stored argument, clamped for vararg signatures
+    int _get_signature_index(const OScriptAnnotationDescriptor& p_descriptor, int p_argument) const;
+
+    void _emit();
+    void _rebuild_chips();
+    void _rebuild_form();
+    void _refresh_chip_text();
+
+    /// Builds the editor control for one argument
+    Control* _make_argument_editor(const OScriptAnnotationDescriptor& p_descriptor, int p_signature_index, const Variant& p_value, int p_argument);
+
+    /// Writes an argument value, filling any missing preceding optional arguments with defaults
+    void _set_argument(int p_argument, const Variant& p_value);
+
+    //~ Begin Signal Handlers
+    void _add_menu_about_to_popup();
+    void _add_menu_id_pressed(int p_id);
+    void _chip_toggled(bool p_pressed, int p_index);
+    void _chip_remove_pressed(int p_index);
+    void _argument_value_changed(double p_value, int p_argument, bool p_integer);
+    void _argument_text_submitted(const String& p_text, int p_argument);
+    void _argument_focus_exited(int p_argument);
+    void _argument_toggled(bool p_pressed, int p_argument);
+    void _argument_item_selected(int p_item, int p_argument);
+    void _argument_remove_pressed(int p_argument);
+    void _argument_add_pressed();
+    //~ End Signal Handlers
+
+protected:
+    static void _bind_methods() { }
+
+    //~ Begin Wrapped Interface
+    void _notification(int p_what);
+    //~ End Wrapped Interface
+
+public:
+    //~ Begin EditorProperty Interface
+    void _update_property() override;
+    void _set_read_only(bool p_read_only) override;
+    //~ End EditorProperty Interface
+};

--- a/src/editor/inspector/variable_inspector_plugin.cpp
+++ b/src/editor/inspector/variable_inspector_plugin.cpp
@@ -16,8 +16,10 @@
 //
 #include "editor/inspector/variable_inspector_plugin.h"
 
-#include "common/macros.h"
+#include "common/scene_utils.h"
+#include "editor/inspector/properties/editor_property_annotations.h"
 #include "editor/inspector/properties/editor_property_type.h"
+#include "orchestration/orchestration.h"
 #include "orchestration/variable.h"
 
 #include <godot_cpp/classes/editor_interface.hpp>
@@ -62,6 +64,19 @@ bool OrchestratorEditorInspectorPluginVariable::_can_handle(Object* p_object) co
     return p_object && p_object->get_class() == OScriptVariable::get_class_static();
 }
 
+void OrchestratorEditorInspectorPluginVariable::_parse_begin(Object* p_object) {
+    const Ref<OScriptVariable> variable = cast_to<OScriptVariable>(p_object);
+    if (variable.is_null() || !variable->get_orchestration()) {
+        return;
+    }
+
+    if (Node* base_node = SceneUtils::get_scene_base_node(variable->get_orchestration()->get_self())) {
+        variable->set_meta("__base_node_relative", base_node);
+    } else if (variable->has_meta("__base_node_relative")) {
+        variable->remove_meta("__base_node_relative");
+    }
+}
+
 bool OrchestratorEditorInspectorPluginVariable::_parse_property(Object* p_object, Variant::Type p_type, const String& p_name,
     PropertyHint p_hint, const String& p_hint_string, BitField<PropertyUsageFlags> p_usage, bool p_wide) {
 
@@ -75,6 +90,12 @@ bool OrchestratorEditorInspectorPluginVariable::_parse_property(Object* p_object
         editor->setup("variable_type", true);
         editor->set_constraint_provider(std::make_unique<OScriptVariableConstraintProvider>(variable));
         add_property_editor(p_name, editor, true, "Variable Type");
+        return true;
+    }
+
+    if (p_name.match("annotations")) {
+        OrchestratorEditorPropertyAnnotations* editor = memnew(OrchestratorEditorPropertyAnnotations);
+        add_property_editor(p_name, editor, false, "Annotations");
         return true;
     }
 

--- a/src/editor/inspector/variable_inspector_plugin.h
+++ b/src/editor/inspector/variable_inspector_plugin.h
@@ -30,6 +30,7 @@ protected:
 public:
     //~ Begin EditorInspectorPlugin Interface
     bool _can_handle(Object* p_object) const override;
+    void _parse_begin(Object* p_object) override;
     bool _parse_property(Object* p_object, Variant::Type p_type, const String& p_name, PropertyHint p_hint, const String& p_hint_string, BitField<PropertyUsageFlags> p_usage, bool p_wide) override;
     //~ End EditorInspectorPlugin Interface
 };

--- a/src/editor/register_editor_types.cpp
+++ b/src/editor/register_editor_types.cpp
@@ -47,6 +47,7 @@
 #include "editor/inspector/function_inspector_plugin.h"
 #include "editor/inspector/new_object_inspector_plugin.h"
 #include "editor/inspector/orchestration_inspector_plugin.h"
+#include "editor/inspector/properties/editor_property_annotations.h"
 #include "editor/inspector/properties/editor_property_class_name.h"
 #include "editor/inspector/properties/editor_property_extends.h"
 #include "editor/inspector/properties/editor_property_pin_properties.h"
@@ -104,6 +105,7 @@ void register_editor_types() {
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorTypeSelector)
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorLogEventRouter)
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorPropertyType)
+    GDREGISTER_INTERNAL_CLASS(OrchestratorEditorPropertyAnnotations)
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorPropertyClassName)
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorPropertyPinProperties)
     GDREGISTER_INTERNAL_CLASS(OrchestratorEditorPropertyExtends)

--- a/src/editor/script_components_container.cpp
+++ b/src/editor/script_components_container.cpp
@@ -36,6 +36,7 @@
 #include "editor/scene/connections_dock.h"
 #include "editor/scene/script_connections.h"
 #include "editor/settings/editor_settings.h"
+#include "orchestration/annotation_registry.h"
 #include "orchestration/nodes/function_entry.h"
 #include "orchestration/nodes/function_result.h"
 #include "script/script.h"
@@ -1237,7 +1238,12 @@ void OrchestratorScriptComponentsContainer::_update_variables() {
         } else {
             String tooltip_text = "Variable is not exported and only visible to scripts.";
             if (!variable->is_exportable()) {
-                tooltip_text += "\nType cannot be exported.";
+                const StringName conflict = OScriptAnnotationRegistry::find_conflict("@export", variable->get_annotations());
+                if (conflict.is_empty()) {
+                    tooltip_text += "\nType cannot be exported.";
+                } else {
+                    tooltip_text += vformat("\nCannot be exported while %s is applied.", conflict);
+                }
             }
             int32_t index = item->get_button_count(0);
             item->add_button(0, SceneUtils::get_editor_icon("GuiVisibilityHidden"), 3);

--- a/src/orchestration/annotation.cpp
+++ b/src/orchestration/annotation.cpp
@@ -1,0 +1,170 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "orchestration/annotation.h"
+
+#include "orchestration/annotation_registry.h"
+
+bool OScriptAnnotation::operator==(const OScriptAnnotation& p_other) const {
+    return name == p_other.name && arguments == p_other.arguments;
+}
+
+bool OScriptAnnotation::operator!=(const OScriptAnnotation& p_other) const {
+    return !(*this == p_other);
+}
+
+Dictionary OScriptAnnotation::to_dict() const {
+    Dictionary dict;
+    dict["name"] = name;
+    if (!arguments.is_empty()) {
+        dict["args"] = arguments;
+    }
+    return dict;
+}
+
+OScriptAnnotation OScriptAnnotation::from_dict(const Dictionary& p_dict) {
+    OScriptAnnotation annotation;
+    annotation.name = p_dict.get("name", StringName());
+    annotation.arguments = p_dict.get("args", Array());
+    return annotation;
+}
+
+OScriptAnnotation::OScriptAnnotation(const StringName& p_name, const Array& p_arguments)
+    : name(p_name)
+    , arguments(p_arguments) {
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// OScriptAnnotationList
+
+int OScriptAnnotationList::find(const StringName& p_name) const {
+    for (int i = 0; i < _items.size(); i++) {
+        if (_items[i].name == p_name) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+bool OScriptAnnotationList::has(const StringName& p_name) const {
+    return find(p_name) >= 0;
+}
+
+bool OScriptAnnotationList::has_family(const StringName& p_family) const {
+    for (const OScriptAnnotation& item : _items) {
+        if (OScriptAnnotationRegistry::is_family(item.name, p_family)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+Error OScriptAnnotationList::add(uint32_t p_target, const PropertyInfo& p_owner, const OScriptAnnotation& p_annotation, String* r_reason) {
+    const Error result = OScriptAnnotationRegistry::can_add(p_target, p_owner, _items, p_annotation.name, r_reason);
+    if (result != OK) {
+        return result;
+    }
+
+    _items.push_back(p_annotation);
+    return OK;
+}
+
+bool OScriptAnnotationList::remove_at(int p_index) {
+    if (p_index < 0 || p_index >= _items.size()) {
+        return false;
+    }
+
+    _items.remove_at(p_index);
+    return true;
+}
+
+int OScriptAnnotationList::remove_family(const StringName& p_family) {
+    int removed = 0;
+    for (int i = _items.size() - 1; i >= 0; i--) {
+        if (OScriptAnnotationRegistry::is_family(_items[i].name, p_family)) {
+            _items.remove_at(i);
+            removed++;
+        }
+    }
+    return removed;
+}
+
+int OScriptAnnotationList::prune(uint32_t p_target, const PropertyInfo& p_owner) {
+    int removed = 0;
+    for (int i = _items.size() - 1; i >= 0; i--) {
+        const OScriptAnnotationDescriptor* descriptor = OScriptAnnotationRegistry::find(_items[i].name);
+        if (descriptor && !OScriptAnnotationRegistry::applies_to(*descriptor, p_target, p_owner)) {
+            _items.remove_at(i);
+            removed++;
+        }
+    }
+    return removed;
+}
+
+bool OScriptAnnotationList::set_arguments(int p_index, const Array& p_arguments) {
+    if (p_index < 0 || p_index >= _items.size()) {
+        return false;
+    }
+
+    if (_items[p_index].arguments == p_arguments) {
+        return false;
+    }
+
+    _items.write[p_index].arguments = p_arguments;
+    return true;
+}
+
+Array OScriptAnnotationList::to_array() const {
+    Array result;
+    for (const OScriptAnnotation& item : _items) {
+        result.push_back(item.to_dict());
+    }
+    return result;
+}
+
+void OScriptAnnotationList::from_array(const Array& p_array) {
+    _items.clear();
+    for (int i = 0; i < p_array.size(); i++) {
+        const Variant& entry = p_array[i];
+        if (entry.get_type() != Variant::DICTIONARY) {
+            continue;
+        }
+
+        const OScriptAnnotation annotation = OScriptAnnotation::from_dict(entry);
+        if (annotation.name.is_empty()) {
+            continue;
+        }
+
+        _items.push_back(annotation);
+    }
+}
+
+bool OScriptAnnotationList::operator==(const OScriptAnnotationList& p_other) const {
+    if (_items.size() != p_other._items.size()) {
+        return false;
+    }
+
+    for (int i = 0; i < _items.size(); i++) {
+        if (_items[i] != p_other._items[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool OScriptAnnotationList::operator!=(const OScriptAnnotationList& p_other) const {
+    return !(*this == p_other);
+}

--- a/src/orchestration/annotation.h
+++ b/src/orchestration/annotation.h
@@ -1,0 +1,89 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <godot_cpp/core/property_info.hpp>
+#include <godot_cpp/templates/vector.hpp>
+#include <godot_cpp/variant/array.hpp>
+#include <godot_cpp/variant/dictionary.hpp>
+#include <godot_cpp/variant/string_name.hpp>
+
+using namespace godot;
+
+/// A single annotation applied to a script member, such as a variable or a function.
+///
+/// The model records only what the user asked for: the annotation name and its literal argument values.
+/// Whether the annotation is legal for the member is decided by the OScriptAnnotationRegistry when it
+/// is added, and again by the parser at compile time.
+///
+struct OScriptAnnotation {
+    StringName name;    //! Annotation name, including the leading '@'
+    Array arguments;    //! Literal argument values, in signature order
+
+    bool operator==(const OScriptAnnotation& p_other) const;
+    bool operator!=(const OScriptAnnotation& p_other) const;
+
+    Dictionary to_dict() const;
+    static OScriptAnnotation from_dict(const Dictionary& p_dict);
+
+    OScriptAnnotation() = default;
+    explicit OScriptAnnotation(const StringName& p_name, const Array& p_arguments = Array());
+};
+
+/// The ordered set of annotations applied to a single script member.
+///
+/// Owners embed this and forward the mutating calls, emitting their own change signals. All rule
+/// checks are delegated to the OScriptAnnotationRegistry so that the model, the editor and the
+/// parser enforce the same constraints.
+///
+class OScriptAnnotationList {
+    Vector<OScriptAnnotation> _items;
+
+public:
+    const Vector<OScriptAnnotation>& get_items() const { return _items; }
+    void set_items(const Vector<OScriptAnnotation>& p_items) { _items = p_items; }
+    int size() const { return _items.size(); }
+    bool is_empty() const { return _items.is_empty(); }
+    const OScriptAnnotation& get(int p_index) const { return _items[p_index]; }
+
+    int find(const StringName& p_name) const;
+    bool has(const StringName& p_name) const;
+    bool has_family(const StringName& p_family) const;
+
+    /// Adds an annotation when the registry allows it for the given target and owner.
+    /// @return OK on success, otherwise the registry's error with an optional reason
+    Error add(uint32_t p_target, const PropertyInfo& p_owner, const OScriptAnnotation& p_annotation, String* r_reason = nullptr);
+
+    bool remove_at(int p_index);
+
+    /// Removes every annotation in the given family.
+    /// @return the number of annotations removed
+    int remove_family(const StringName& p_family);
+
+    /// Removes annotations whose type constraint no longer holds for the owner.
+    /// Unknown annotation names are kept so the compiler can report them.
+    /// @return the number of annotations removed
+    int prune(uint32_t p_target, const PropertyInfo& p_owner);
+
+    bool set_arguments(int p_index, const Array& p_arguments);
+
+    Array to_array() const;
+    void from_array(const Array& p_array);
+
+    bool operator==(const OScriptAnnotationList& p_other) const;
+    bool operator!=(const OScriptAnnotationList& p_other) const;
+};

--- a/src/orchestration/annotation_registry.cpp
+++ b/src/orchestration/annotation_registry.cpp
@@ -1,0 +1,358 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "orchestration/annotation_registry.h"
+
+#include "common/property_utils.h"
+#include "script/script_server.h"
+
+#include <godot_cpp/core/class_db.hpp>
+
+OScriptAnnotationRegistry* OScriptAnnotationRegistry::_instance = nullptr;
+
+const char* OScriptAnnotationRegistry::FAMILY_EXPORT = "export";
+const char* OScriptAnnotationRegistry::FAMILY_RPC = "rpc";
+const char* OScriptAnnotationRegistry::FAMILY_ONREADY = "onready";
+const char* OScriptAnnotationRegistry::FAMILY_WARNING = "warning";
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Type predicates
+///
+/// Each predicate sees the owner's declared PropertyInfo. Typed arrays and packed arrays are reduced to their
+/// element type, mirroring how the parser validates export annotations. A Variant-typed owner is accepted
+/// everywhere, as the parser infers from the initializer.
+
+static Variant::Type _effective_type(const PropertyInfo& p_owner) {
+    switch (p_owner.type) {
+        case Variant::ARRAY: {
+            if (p_owner.hint == PROPERTY_HINT_ARRAY_TYPE && !p_owner.hint_string.is_empty()) {
+                Variant::Type builtin = Variant::NIL;
+                StringName class_name;
+                Variant script;
+                PropertyUtils::get_element_type(p_owner.hint_string, builtin, class_name, script);
+                return builtin;
+            }
+            return Variant::ARRAY;
+        }
+        case Variant::PACKED_BYTE_ARRAY:
+        case Variant::PACKED_INT32_ARRAY:
+        case Variant::PACKED_INT64_ARRAY:
+            return Variant::INT;
+        case Variant::PACKED_FLOAT32_ARRAY:
+        case Variant::PACKED_FLOAT64_ARRAY:
+            return Variant::FLOAT;
+        case Variant::PACKED_STRING_ARRAY:
+            return Variant::STRING;
+        case Variant::PACKED_VECTOR2_ARRAY:
+            return Variant::VECTOR2;
+        case Variant::PACKED_VECTOR3_ARRAY:
+            return Variant::VECTOR3;
+        case Variant::PACKED_VECTOR4_ARRAY:
+            return Variant::VECTOR4;
+        case Variant::PACKED_COLOR_ARRAY:
+            return Variant::COLOR;
+        default:
+            return p_owner.type;
+    }
+}
+
+static bool _is_variant(const PropertyInfo& p_owner) {
+    return PropertyUtils::is_variant(p_owner);
+}
+
+static bool _is_one_of(const PropertyInfo& p_owner, std::initializer_list<Variant::Type> p_types) {
+    if (_is_variant(p_owner)) {
+        return true;
+    }
+
+    const Variant::Type type = _effective_type(p_owner);
+    for (const Variant::Type candidate : p_types) {
+        if (type == candidate) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool _is_node_or_resource(const StringName& p_class) {
+    StringName native_class = p_class;
+    if (ScriptServer::is_global_class(p_class)) {
+        native_class = ScriptServer::get_global_class_native_base(p_class);
+    }
+    return ClassDB::is_parent_class(native_class, "Node") || ClassDB::is_parent_class(native_class, "Resource");
+}
+
+static bool _accepts_export(const PropertyInfo& p_owner) {
+    if (_is_variant(p_owner)) {
+        return true;
+    }
+
+    switch (p_owner.type) {
+        case Variant::CALLABLE:
+        case Variant::SIGNAL:
+        case Variant::RID:
+            return false;
+
+        case Variant::OBJECT: {
+            if (!p_owner.class_name.is_empty()) {
+                return _is_node_or_resource(p_owner.class_name);
+            }
+            if (p_owner.hint_string.is_empty()) {
+                return false;
+            }
+            return _is_node_or_resource(p_owner.hint_string);
+        }
+
+        default:
+            return true;
+    }
+}
+
+static bool _accepts_int(const PropertyInfo& p_owner) {
+    return _is_one_of(p_owner, { Variant::INT });
+}
+
+static bool _accepts_int_or_float(const PropertyInfo& p_owner) {
+    return _is_one_of(p_owner, { Variant::INT, Variant::FLOAT });
+}
+
+static bool _accepts_int_or_string(const PropertyInfo& p_owner) {
+    return _is_one_of(p_owner, { Variant::INT, Variant::STRING });
+}
+
+static bool _accepts_float(const PropertyInfo& p_owner) {
+    return _is_one_of(p_owner, { Variant::FLOAT });
+}
+
+static bool _accepts_string(const PropertyInfo& p_owner) {
+    return _is_one_of(p_owner, { Variant::STRING });
+}
+
+static bool _accepts_string_or_dictionary(const PropertyInfo& p_owner) {
+    return _is_one_of(p_owner, { Variant::STRING, Variant::DICTIONARY });
+}
+
+static bool _accepts_color(const PropertyInfo& p_owner) {
+    return _is_one_of(p_owner, { Variant::COLOR });
+}
+
+static bool _accepts_node_path(const PropertyInfo& p_owner) {
+    return _is_one_of(p_owner, { Variant::NODE_PATH });
+}
+
+static bool _accepts_callable(const PropertyInfo& p_owner) {
+    return _is_one_of(p_owner, { Variant::CALLABLE });
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// OScriptAnnotationRegistry
+
+OScriptAnnotationRegistry* OScriptAnnotationRegistry::_get() {
+    if (_instance == nullptr) {
+        _instance = memnew(OScriptAnnotationRegistry);
+    }
+    return _instance;
+}
+
+void OScriptAnnotationRegistry::_add(const OScriptAnnotationDescriptor& p_descriptor) {
+    ERR_FAIL_COND_MSG(_index.has(p_descriptor.info.name), vformat(R"(Annotation "%s" already registered.)", p_descriptor.info.name));
+
+    _index[p_descriptor.info.name] = _descriptors.size();
+    _descriptors.push_back(p_descriptor);
+}
+
+void OScriptAnnotationRegistry::_add_export(const MethodInfo& p_info, OScriptAnnotationDescriptor::TypePredicate p_applies_to, const Vector<Variant>& p_defaults, bool p_vararg) {
+    OScriptAnnotationDescriptor descriptor;
+    descriptor.info = p_info;
+    for (const Variant& item : p_defaults) {
+        descriptor.info.default_arguments.push_back(item);
+    }
+    if (p_vararg) {
+        descriptor.info.flags |= METHOD_FLAG_VARARG;
+    }
+    descriptor.targets = TARGET_VARIABLE;
+    descriptor.family = FAMILY_EXPORT;
+    descriptor.repeatable = false;
+    descriptor.applies_to = p_applies_to;
+    _add(descriptor);
+}
+
+void OScriptAnnotationRegistry::_register_export_annotations() {
+    // Mirrors the GDScript parser's export annotation table, in the same order.
+    _add_export(MethodInfo("@export"), _accepts_export);
+    _add_export(MethodInfo("@export_enum", PropertyInfo(Variant::STRING, "names")), _accepts_int_or_string, {}, true);
+    _add_export(MethodInfo("@export_file", PropertyInfo(Variant::STRING, "filter")), _accepts_string, { "" }, true);
+    _add_export(MethodInfo("@export_dir"), _accepts_string);
+    _add_export(MethodInfo("@export_global_file", PropertyInfo(Variant::STRING, "filter")), _accepts_string, { "" }, true);
+    _add_export(MethodInfo("@export_global_dir"), _accepts_string);
+    _add_export(MethodInfo("@export_multiline"), _accepts_string_or_dictionary);
+    _add_export(MethodInfo("@export_placeholder", PropertyInfo(Variant::STRING, "placeholder")), _accepts_string);
+    _add_export(MethodInfo("@export_range", PropertyInfo(Variant::FLOAT, "min"), PropertyInfo(Variant::FLOAT, "max"), PropertyInfo(Variant::FLOAT, "step"), PropertyInfo(Variant::STRING, "extra_hints")), _accepts_int_or_float, { 1.0, "" }, true);
+    _add_export(MethodInfo("@export_exp_easing", PropertyInfo(Variant::STRING, "hints")), _accepts_float, { "" }, true);
+    _add_export(MethodInfo("@export_color_no_alpha"), _accepts_color);
+    _add_export(MethodInfo("@export_node_path", PropertyInfo(Variant::STRING, "type")), _accepts_node_path, { "" }, true);
+    _add_export(MethodInfo("@export_flags", PropertyInfo(Variant::STRING, "names")), _accepts_int, {}, true);
+    _add_export(MethodInfo("@export_flags_2d_render"), _accepts_int);
+    _add_export(MethodInfo("@export_flags_2d_physics"), _accepts_int);
+    _add_export(MethodInfo("@export_flags_2d_navigation"), _accepts_int);
+    _add_export(MethodInfo("@export_flags_3d_render"), _accepts_int);
+    _add_export(MethodInfo("@export_flags_3d_physics"), _accepts_int);
+    _add_export(MethodInfo("@export_flags_3d_navigation"), _accepts_int);
+    _add_export(MethodInfo("@export_flags_avoidance"), _accepts_int);
+    _add_export(MethodInfo("@export_storage"), nullptr);
+    _add_export(MethodInfo("@export_custom", PropertyInfo(Variant::INT, "hint", PROPERTY_HINT_ENUM, ""), PropertyInfo(Variant::STRING, "hint_string"), PropertyInfo(Variant::INT, "usage", PROPERTY_HINT_FLAGS, "")), nullptr, { PROPERTY_USAGE_DEFAULT });
+    _add_export(MethodInfo("@export_tool_button", PropertyInfo(Variant::STRING, "text"), PropertyInfo(Variant::STRING, "icon")), _accepts_callable, { "" });
+}
+
+void OScriptAnnotationRegistry::_register_function_annotations() {
+    // GDScript accepts the @rpc tokens in any order; the model stores them positionally so the
+    // editor can render a fixed form. The parser counts by category, so order does not matter to it.
+    OScriptAnnotationDescriptor rpc;
+    rpc.info = MethodInfo("@rpc", PropertyInfo(Variant::STRING, "mode"), PropertyInfo(Variant::STRING, "sync"), PropertyInfo(Variant::STRING, "transfer_mode"), PropertyInfo(Variant::INT, "transfer_channel"));
+    rpc.info.default_arguments.push_back("authority");
+    rpc.info.default_arguments.push_back("call_remote");
+    rpc.info.default_arguments.push_back("unreliable");
+    rpc.info.default_arguments.push_back(0);
+    rpc.targets = TARGET_FUNCTION;
+    rpc.family = FAMILY_RPC;
+    _add(rpc);
+
+    // Any variable may carry @onready; whether the initializer needs it is the compiler's call.
+    // It never combines with an export: the ready-time assignment would overwrite the exported value,
+    // which the compiler also reports for hand-written files.
+    OScriptAnnotationDescriptor onready;
+    onready.info = MethodInfo("@onready");
+    onready.targets = TARGET_VARIABLE;
+    onready.family = FAMILY_ONREADY;
+    onready.conflicts.push_back(FAMILY_EXPORT);
+    _add(onready);
+
+    OScriptAnnotationDescriptor warning_ignore;
+    warning_ignore.info = MethodInfo("@warning_ignore", PropertyInfo(Variant::STRING, "warning"));
+    warning_ignore.info.flags |= METHOD_FLAG_VARARG;
+    warning_ignore.targets = TARGET_VARIABLE | TARGET_FUNCTION | TARGET_EVENT;
+    warning_ignore.family = FAMILY_WARNING;
+    warning_ignore.repeatable = true;
+    _add(warning_ignore);
+}
+
+OScriptAnnotationRegistry::OScriptAnnotationRegistry() {
+    _register_export_annotations();
+    _register_function_annotations();
+}
+
+const OScriptAnnotationDescriptor* OScriptAnnotationRegistry::find(const StringName& p_name) {
+    const OScriptAnnotationRegistry* registry = _get();
+    const int* index = registry->_index.getptr(p_name);
+    if (index == nullptr) {
+        return nullptr;
+    }
+    return &registry->_descriptors[*index];
+}
+
+const Vector<OScriptAnnotationDescriptor>& OScriptAnnotationRegistry::get_descriptors() {
+    return _get()->_descriptors;
+}
+
+bool OScriptAnnotationRegistry::is_family(const StringName& p_name, const StringName& p_family) {
+    const OScriptAnnotationDescriptor* descriptor = find(p_name);
+    return descriptor != nullptr && descriptor->family == p_family;
+}
+
+bool OScriptAnnotationRegistry::applies_to(const OScriptAnnotationDescriptor& p_descriptor, uint32_t p_target, const PropertyInfo& p_owner) {
+    if ((p_descriptor.targets & p_target) == 0) {
+        return false;
+    }
+    if (p_descriptor.applies_to != nullptr && !p_descriptor.applies_to(p_owner)) {
+        return false;
+    }
+    return true;
+}
+
+bool OScriptAnnotationRegistry::applies_to(const StringName& p_name, uint32_t p_target, const PropertyInfo& p_owner) {
+    const OScriptAnnotationDescriptor* descriptor = find(p_name);
+    return descriptor != nullptr && applies_to(*descriptor, p_target, p_owner);
+}
+
+StringName OScriptAnnotationRegistry::find_conflict(const StringName& p_name, const Vector<OScriptAnnotation>& p_existing) {
+    const OScriptAnnotationDescriptor* descriptor = find(p_name);
+    if (descriptor == nullptr) {
+        return StringName();
+    }
+
+    for (const OScriptAnnotation& existing : p_existing) {
+        const OScriptAnnotationDescriptor* other = find(existing.name);
+        if (other == nullptr) {
+            continue;
+        }
+        if (descriptor->conflicts.has(other->family) || other->conflicts.has(descriptor->family)) {
+            return existing.name;
+        }
+    }
+    return StringName();
+}
+
+Error OScriptAnnotationRegistry::can_add(uint32_t p_target, const PropertyInfo& p_owner, const Vector<OScriptAnnotation>& p_existing, const StringName& p_name, String* r_reason) {
+    const OScriptAnnotationDescriptor* descriptor = find(p_name);
+    if (descriptor == nullptr) {
+        if (r_reason) {
+            *r_reason = vformat(R"(Unknown annotation "%s".)", p_name);
+        }
+        return ERR_DOES_NOT_EXIST;
+    }
+
+    if ((descriptor->targets & p_target) == 0) {
+        if (r_reason) {
+            *r_reason = vformat(R"(Annotation "%s" cannot be applied here.)", p_name);
+        }
+        return ERR_INVALID_PARAMETER;
+    }
+
+    if (descriptor->applies_to != nullptr && !descriptor->applies_to(p_owner)) {
+        if (r_reason) {
+            *r_reason = vformat(R"(Annotation "%s" cannot be applied to type "%s".)", p_name, PropertyUtils::get_property_type_name(p_owner));
+        }
+        return ERR_INVALID_DATA;
+    }
+
+    if (!descriptor->repeatable) {
+        for (const OScriptAnnotation& existing : p_existing) {
+            if (is_family(existing.name, descriptor->family)) {
+                if (r_reason) {
+                    *r_reason = vformat(R"(Annotation "%s" cannot be used with "%s".)", p_name, existing.name);
+                }
+                return ERR_ALREADY_EXISTS;
+            }
+        }
+    }
+
+    const StringName conflict = find_conflict(p_name, p_existing);
+    if (!conflict.is_empty()) {
+        if (r_reason) {
+            *r_reason = vformat(R"(Annotation "%s" cannot be combined with "%s".)", p_name, conflict);
+        }
+        return ERR_INVALID_DATA;
+    }
+
+    return OK;
+}
+
+void OScriptAnnotationRegistry::cleanup() {
+    if (_instance != nullptr) {
+        memdelete(_instance);
+        _instance = nullptr;
+    }
+}

--- a/src/orchestration/annotation_registry.h
+++ b/src/orchestration/annotation_registry.h
@@ -1,0 +1,109 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include "orchestration/annotation.h"
+
+#include <godot_cpp/core/object.hpp>
+#include <godot_cpp/templates/hash_map.hpp>
+
+using namespace godot;
+
+/// Describes one annotation the model accepts: its signature, where it may be applied, the family it
+/// beglons to for cardinality, and the type constraint on its owner.
+///
+/// The parser pairs each descriptor with its compile-time apply callback by name; the editor pairs
+/// it with presentation metadata. Neither is stored here.
+///
+struct OScriptAnnotationDescriptor {
+    /// Type predicate evaluated against the owner's property information.
+    /// The owner is a variable's declared type, or for functions the return value.
+    typedef bool (*TypePredicate)(const PropertyInfo& p_owner);
+
+    MethodInfo info;                    //! Signature, including default arguments and the vararg flag
+    uint32_t targets = 0;               //! Bitmask of OScriptAnnotationRegistry::Target
+    StringName family;                  //! Cardinality group, see OScriptAnnotationRegistry
+    bool repeatable = false;            //! Whether more than one of this family may be applied
+    Vector<StringName> conflicts;       //! Families this one cannot be combined with, checked symmetrically
+    TypePredicate applies_to = nullptr; //! Owner type constraint, null accepts any type
+
+    bool is_vararg() const { return (info.flags & METHOD_FLAG_VARARG) != 0; }
+};
+
+/// The single source of annotation rules.
+///
+/// The model consults it when an annotation is added or an owner's type changes, the editor consults
+/// it to filter what can be offered, and the parser registers its apply callbacks  from it. The table
+/// holds Variant-typed data, so it is created lazily on first use and  released from
+/// unregister_orchestration_types().
+///
+class OScriptAnnotationRegistry {
+    Vector<OScriptAnnotationDescriptor> _descriptors;
+    HashMap<StringName, int> _index;
+
+    static OScriptAnnotationRegistry* _instance;
+
+    static OScriptAnnotationRegistry* _get();
+
+    void _add(const OScriptAnnotationDescriptor& p_descriptor);
+    void _add_export(const MethodInfo& p_info, OScriptAnnotationDescriptor::TypePredicate p_applies_to, const Vector<Variant>& p_defaults = Vector<Variant>(), bool p_vararg = false);
+
+    void _register_export_annotations();
+    void _register_function_annotations();
+
+    OScriptAnnotationRegistry();
+
+public:
+    /// Targets an annotation may be applied to. Mapped explicitly by the parser onto its own kinds.
+    /// Event is a built-in function override, such as _ready; the parser treats it as a function.
+    enum Target {
+        TARGET_VARIABLE = 1 << 0,
+        TARGET_FUNCTION = 1 << 1,
+        TARGET_CLASS = 1 << 2,
+        TARGET_EVENT = 1 << 3,
+    };
+
+    /// Family names used for cardinality checks.
+    static const char* FAMILY_EXPORT;
+    static const char* FAMILY_RPC;
+    static const char* FAMILY_ONREADY;
+    static const char* FAMILY_WARNING;
+
+    static const OScriptAnnotationDescriptor* find(const StringName& p_name);
+    static const Vector<OScriptAnnotationDescriptor>& get_descriptors();
+
+    static bool is_family(const StringName& p_name, const StringName& p_family);
+
+    /// Whether the descriptor's target and type constraint accept the owner.
+    static bool applies_to(const OScriptAnnotationDescriptor& p_descriptor, uint32_t p_target, const PropertyInfo& p_owner);
+
+    /// Whether the named annotation's target and type constraint accept the owner.
+    /// Unknown names return false.
+    static bool applies_to(const StringName& p_name, uint32_t p_target, const PropertyInfo& p_owner);
+
+    /// The applied annotation the named one cannot be combined with, if any.
+    /// @return the conflicting annotation's name, or an empty name when there is no conflict
+    static StringName find_conflict(const StringName& p_name, const Vector<OScriptAnnotation>& p_existing);
+
+    /// The one rule entry point. Checks that the annotation exists, targets the owner kind,
+    /// accepts the owner's type, and does not violate its family's cardinality.
+    /// @return OK when the annotation may be added, otherwise an error with an optional reason
+    static Error can_add(uint32_t p_target, const PropertyInfo& p_owner, const Vector<OScriptAnnotation>& p_existing, const StringName& p_name, String* r_reason = nullptr);
+
+    /// Releases the lazily created table.
+    static void cleanup();
+};

--- a/src/orchestration/function.cpp
+++ b/src/orchestration/function.cpp
@@ -19,6 +19,7 @@
 #include "common/dictionary_utils.h"
 #include "common/method_utils.h"
 #include "common/property_utils.h"
+#include "orchestration/annotation_registry.h"
 #include "orchestration/nodes/call_function.h"
 #include "orchestration/nodes/function_entry.h"
 #include "orchestration/nodes/function_result.h"
@@ -34,6 +35,10 @@ void OScriptFunction::_get_property_list(List<PropertyInfo> *r_list) const {
     r_list->push_back(PropertyInfo(Variant::STRING, "built-in", PROPERTY_HINT_ENUM, "Yes,No", PROPERTY_USAGE_READ_ONLY | PROPERTY_USAGE_EDITOR));
 
     r_list->push_back(PropertyInfo(Variant::STRING, "description", PROPERTY_HINT_MULTILINE_TEXT, "", _user_defined ? PROPERTY_USAGE_DEFAULT : PROPERTY_USAGE_STORAGE));
+
+    // Shown for every function: events accept warning suppression even though they cannot be RPCs.
+    // Written only when non-empty so untouched functions serialize as before.
+    r_list->push_back(PropertyInfo(Variant::ARRAY, "annotations", PROPERTY_HINT_NONE, "", _annotations.is_empty() ? PROPERTY_USAGE_EDITOR : PROPERTY_USAGE_DEFAULT));
 
     uint32_t usage = (_user_defined ? PROPERTY_USAGE_EDITOR : PROPERTY_USAGE_READ_ONLY | PROPERTY_USAGE_EDITOR);
     r_list->push_back(PropertyInfo(Variant::STRING, "Inputs/Outputs", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CATEGORY));
@@ -56,6 +61,9 @@ bool OScriptFunction::_get(const StringName &p_name, Variant &r_value) {
         return true;
     } else if (p_name.match("description")) {
         r_value = _description;
+        return true;
+    } else if (p_name.match("annotations")) {
+        r_value = _annotations.to_array();
         return true;
     } else if (p_name.match("built-in")) {
         r_value = _user_defined ? "No" : "Yes";
@@ -116,6 +124,11 @@ bool OScriptFunction::_set(const StringName &p_name, const Variant &p_value)
     } else if (p_name.match("description")) {
         _description = p_value;
         result = true;
+    } else if (p_name.match("annotations")) {
+        OScriptAnnotationList annotations;
+        annotations.from_array(p_value);
+        set_annotations(annotations.get_items());
+        return true;
     } else if (p_name.match("inputs")) {
         // The inspector's argument editor adds and removes its own rows, and graph nodes that
         // reference this function reconstruct from "changed", so a property list refresh here
@@ -392,6 +405,39 @@ void OScriptFunction::remove_argument(int p_index) {
 
         _method.arguments.remove_at(p_index);
 
+        emit_changed();
+    }
+}
+
+Error OScriptFunction::add_annotation(const OScriptAnnotation& p_annotation, String* r_reason) {
+    const uint32_t target = _user_defined ? OScriptAnnotationRegistry::TARGET_FUNCTION : OScriptAnnotationRegistry::TARGET_EVENT;
+    const Error result = _annotations.add(target, _method.return_val, p_annotation, r_reason);
+    if (result == OK) {
+        emit_changed();
+    }
+    return result;
+}
+
+void OScriptFunction::remove_annotation(int p_index) {
+    if (_annotations.remove_at(p_index)) {
+        emit_changed();
+    }
+}
+
+void OScriptFunction::set_annotation_arguments(int p_index, const Array& p_arguments) {
+    if (_annotations.set_arguments(p_index, p_arguments)) {
+        emit_changed();
+    }
+}
+
+void OScriptFunction::set_annotations(const Vector<OScriptAnnotation>& p_annotations) {
+    // Whole-list replacement bypasses the cardinality check so a snapshot restores verbatim;
+    // the parser reports any conflict at compile time.
+    OScriptAnnotationList replacement;
+    replacement.set_items(p_annotations);
+
+    if (_annotations != replacement) {
+        _annotations = replacement;
         emit_changed();
     }
 }

--- a/src/orchestration/function.h
+++ b/src/orchestration/function.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "common/guid.h"
+#include "orchestration/annotation.h"
 
 #include <godot_cpp/classes/resource.hpp>
 #include <godot_cpp/variant/dictionary.hpp>
@@ -51,6 +52,7 @@ class OScriptFunction : public Resource {
     int _owning_node_id = -1;                  //! Owning node id
     bool _returns_value = false;               //! Whether the function returns a value
     String _description;                       //! Optional description for a function
+    OScriptAnnotationList _annotations;        //! Annotations applied to the function
 
 protected:
     static void _bind_methods() { }
@@ -202,4 +204,20 @@ public:
     /// Removes the specified argument from the function signature
     /// @param p_index argument index
     void remove_argument(int p_index);
+
+    const Vector<OScriptAnnotation>& get_annotations() const { return _annotations.get_items(); }
+    bool has_annotation(const StringName& p_name) const { return _annotations.has(p_name); }
+    bool has_annotation_family(const StringName& p_family) const { return _annotations.has_family(p_family); }
+    int find_annotation(const StringName& p_name) const { return _annotations.find(p_name); }
+
+    /// Adds an annotation when the registry permits it for this function
+    /// @param p_annotation the annotation to add
+    /// @param r_reason optional explanation when the annotation is rejected
+    /// @return OK if added, otherwise the registry's error
+    Error add_annotation(const OScriptAnnotation& p_annotation, String* r_reason = nullptr);
+    void remove_annotation(int p_index);
+    void set_annotation_arguments(int p_index, const Array& p_arguments);
+
+    /// Replaces the whole annotation list, used by serialization and undo snapshots
+    void set_annotations(const Vector<OScriptAnnotation>& p_annotations);
 };

--- a/src/orchestration/register_orchestration_types.cpp
+++ b/src/orchestration/register_orchestration_types.cpp
@@ -17,6 +17,7 @@
 #include "orchestration/register_orchestration_types.h"
 
 #include "common/version.h"
+#include "orchestration/annotation_registry.h"
 #include "orchestration/nodes.h"
 #include "orchestration/orchestration.h"
 
@@ -43,7 +44,7 @@ void register_orchestration_types() {
 }
 
 void unregister_orchestration_types() {
-
+    OScriptAnnotationRegistry::cleanup();
 }
 
 void register_orchestration_node_types() {

--- a/src/orchestration/serialization/format.h
+++ b/src/orchestration/serialization/format.h
@@ -21,5 +21,7 @@
 struct OrchestrationFormat {
     // Format 4: Introduction of OScriptNodeReroute nodes
     // Format 5: Split pins store their sub-pins nested under the parent pin's data
+    //           Annotations on variables and functions; the "exported" flag is derived and no longer stored;
+    //           variable initializer kind for node paths resolved at ready
     static inline uint32_t FORMAT_VERSION = 5;
 };

--- a/src/orchestration/variable.cpp
+++ b/src/orchestration/variable.cpp
@@ -21,6 +21,7 @@
 #include "common/property_utils.h"
 #include "common/string_utils.h"
 #include "common/variant_utils.h"
+#include "orchestration/annotation_registry.h"
 #include "script/script_server.h"
 
 class ClassificationParser {
@@ -181,7 +182,7 @@ bool OScriptVariable::_set(const StringName& p_name, const Variant& p_value) {
         PropertyInfo property;
         bool converted;
         if (parse_classification(p_value, property, converted)) {
-            if (converted) {
+            if (converted && _initializer == INITIALIZER_LITERAL) {
                 _convert_default_value(property.type);
             }
         }
@@ -192,6 +193,9 @@ bool OScriptVariable::_set(const StringName& p_name, const Variant& p_value) {
         _info.class_name = property.class_name;
         _info.usage = property.usage | PROPERTY_USAGE_SCRIPT_VARIABLE;
 
+        _prune_annotations();
+        _reset_initializer_if_needed();
+
         notify_property_list_changed();
         emit_changed();
         return true;
@@ -201,7 +205,8 @@ bool OScriptVariable::_set(const StringName& p_name, const Variant& p_value) {
         if (_info.type != value) {
             _info.type = value;
 
-            if (_default_value.get_type() != _info.type) {
+            _reset_initializer_if_needed();
+            if (_initializer == INITIALIZER_LITERAL && _default_value.get_type() != _info.type) {
                 set_default_value(VariantUtils::make_default(_info.type));
             }
 
@@ -214,7 +219,24 @@ bool OScriptVariable::_set(const StringName& p_name, const Variant& p_value) {
 }
 
 void OScriptVariable::_validate_property(PropertyInfo& p_property) const {
+    if (p_property.name.match("initializer")) {
+        if (!is_node_path_initializer_allowed()) {
+            p_property.usage &= ~PROPERTY_USAGE_EDITOR;
+        }
+        return;
+    }
+
     if (p_property.name.match("default_value")) {
+        if (_initializer == INITIALIZER_NODE_PATH) {
+            // Picked relative to the edited scene root, matching the scene node graph node.
+            p_property.type = Variant::NODE_PATH;
+            p_property.hint = PROPERTY_HINT_NODE_PATH_VALID_TYPES;
+            p_property.hint_string = ClassDB::class_exists(_info.class_name) ? String(_info.class_name) : String();
+            p_property.class_name = StringName();
+            p_property.usage = PROPERTY_USAGE_DEFAULT;
+            return;
+        }
+
         if (PropertyUtils::is_variant(_info)) {
             p_property.usage |= PROPERTY_USAGE_READ_ONLY;
             return;
@@ -289,7 +311,7 @@ void OScriptVariable::_validate_property(PropertyInfo& p_property) const {
 }
 
 bool OScriptVariable::_property_can_revert(const StringName& p_name) const {
-    static Array properties = Array::make("name", "category", "exported", "default_value", "description", "constant", "info");
+    static Array properties = Array::make("name", "category", "exported", "default_value", "description", "constant", "info", "annotations", "initializer");
     return properties.has(p_name);
 }
 
@@ -315,6 +337,12 @@ bool OScriptVariable::_property_get_revert(const StringName& p_name, Variant& r_
     } else if (p_name.match("info")) {
         r_property = DictionaryUtils::from_property(PropertyUtils::make_variant(_info.name), true);
         return true;
+    } else if (p_name.match("annotations")) {
+        r_property = Array();
+        return true;
+    } else if (p_name.match("initializer")) {
+        r_property = INITIALIZER_LITERAL;
+        return true;
     }
     return false;
 }
@@ -325,6 +353,31 @@ void OScriptVariable::_set_property_info(const Dictionary& p_property) {
 
 Dictionary OScriptVariable::_get_property_info() const {
     return DictionaryUtils::from_property(_info, true);
+}
+
+void OScriptVariable::_set_annotations_array(const Array& p_annotations) {
+    OScriptAnnotationList annotations;
+    annotations.from_array(p_annotations);
+    set_annotations(annotations.get_items());
+}
+
+Array OScriptVariable::_get_annotations_array() const {
+    return _annotations.to_array();
+}
+
+void OScriptVariable::_set_initializer(int p_initializer) {
+    set_initializer_kind(p_initializer == INITIALIZER_NODE_PATH ? INITIALIZER_NODE_PATH : INITIALIZER_LITERAL);
+}
+
+int OScriptVariable::_get_initializer() const {
+    return _initializer;
+}
+
+void OScriptVariable::_reset_initializer_if_needed() {
+    if (_initializer == INITIALIZER_NODE_PATH && !is_node_path_initializer_allowed()) {
+        _initializer = INITIALIZER_LITERAL;
+        _default_value = VariantUtils::make_default(_info.type);
+    }
 }
 
 bool OScriptVariable::_convert_default_value(Variant::Type p_new_type) {
@@ -361,6 +414,10 @@ bool OScriptVariable::_convert_default_value(Variant::Type p_new_type) {
     return true;
 }
 
+bool OScriptVariable::_prune_annotations() {
+    return _annotations.prune(OScriptAnnotationRegistry::TARGET_VARIABLE, _info) > 0;
+}
+
 Orchestration* OScriptVariable::get_orchestration() const {
     return _orchestration;
 }
@@ -376,7 +433,11 @@ void OScriptVariable::set_info(const PropertyInfo& p_property) {
     _info.hint_string = p_property.hint_string;
     _info.usage = p_property.usage;
 
-    _convert_default_value(_info.type);
+    _reset_initializer_if_needed();
+    if (_initializer == INITIALIZER_LITERAL) {
+        _convert_default_value(_info.type);
+    }
+    _prune_annotations();
 
     notify_property_list_changed();
     emit_changed();
@@ -415,9 +476,16 @@ void OScriptVariable::set_description(const String& p_description) {
     }
 }
 
+bool OScriptVariable::is_exported() const {
+    return _annotations.has_family(OScriptAnnotationRegistry::FAMILY_EXPORT);
+}
+
 void OScriptVariable::set_exported(bool p_exported) {
-    if (_exported != p_exported) {
-        _exported = p_exported;
+    if (p_exported) {
+        if (!is_exported()) {
+            add_annotation(OScriptAnnotation("@export"));
+        }
+    } else if (_annotations.remove_family(OScriptAnnotationRegistry::FAMILY_EXPORT) > 0) {
         emit_changed();
     }
 }
@@ -425,6 +493,11 @@ void OScriptVariable::set_exported(bool p_exported) {
 bool OScriptVariable::is_exportable() const {
     // Constants cannot be exported
     if (_constant) {
+        return false;
+    }
+
+    // Nor can a variable carrying an annotation the export family conflicts with, such as @onready
+    if (!OScriptAnnotationRegistry::find_conflict("@export", _annotations.get_items()).is_empty()) {
         return false;
     }
 
@@ -473,14 +546,91 @@ void OScriptVariable::set_default_value(const Variant& p_default_value) {
     }
 }
 
+void OScriptVariable::set_initializer_kind(InitializerKind p_initializer) {
+    if (_initializer == p_initializer) {
+        return;
+    }
+
+    if (p_initializer == INITIALIZER_NODE_PATH && !is_node_path_initializer_allowed()) {
+        return;
+    }
+
+    _initializer = p_initializer;
+    if (_initializer == INITIALIZER_NODE_PATH) {
+        if (_default_value.get_type() != Variant::NODE_PATH) {
+            _default_value = NodePath();
+        }
+    } else {
+        _default_value = VariantUtils::make_default(_info.type);
+    }
+
+    notify_property_list_changed();
+    emit_changed();
+}
+
+bool OScriptVariable::is_node_path_initializer_allowed() const {
+    if (_constant) {
+        return false;
+    }
+
+    if (PropertyUtils::is_variant(_info)) {
+        return true;
+    }
+
+    if (_info.type != Variant::OBJECT || _info.class_name.is_empty()) {
+        return false;
+    }
+
+    StringName native_class = _info.class_name;
+    if (ScriptServer::is_global_class(native_class)) {
+        native_class = ScriptServer::get_global_class_native_base(native_class);
+    }
+    return ClassDB::is_parent_class(native_class, "Node");
+}
+
 void OScriptVariable::set_constant(bool p_constant) {
     if (_constant != p_constant) {
         _constant = p_constant;
 
-        // Constants cannot be exported
-        _exported = _constant ? false : _exported;
+        // Constants cannot be exported or resolved from the scene tree
+        if (_constant) {
+            _annotations.remove_family(OScriptAnnotationRegistry::FAMILY_EXPORT);
+            _reset_initializer_if_needed();
+        }
 
         notify_property_list_changed();
+        emit_changed();
+    }
+}
+
+Error OScriptVariable::add_annotation(const OScriptAnnotation& p_annotation, String* r_reason) {
+    const Error result = _annotations.add(OScriptAnnotationRegistry::TARGET_VARIABLE, _info, p_annotation, r_reason);
+    if (result == OK) {
+        emit_changed();
+    }
+    return result;
+}
+
+void OScriptVariable::remove_annotation(int p_index) {
+    if (_annotations.remove_at(p_index)) {
+        emit_changed();
+    }
+}
+
+void OScriptVariable::set_annotation_arguments(int p_index, const Array& p_arguments) {
+    if (_annotations.set_arguments(p_index, p_arguments)) {
+        emit_changed();
+    }
+}
+
+void OScriptVariable::set_annotations(const Vector<OScriptAnnotation>& p_annotations) {
+    // Whole-list replacement bypasses the cardinality check so a snapshot restores verbatim;
+    // the parser reports any conflict at compile time.
+    OScriptAnnotationList replacement;
+    replacement.set_items(p_annotations);
+
+    if (_annotations != replacement) {
+        _annotations = replacement;
         emit_changed();
     }
 }
@@ -491,7 +641,8 @@ void OScriptVariable::copy_persistent_state(const Ref<OScriptVariable>& p_other)
         _constant = p_other->_constant;
         _default_value = p_other->_default_value;
         _description = p_other->_description;
-        _exported = p_other->_exported;
+        _annotations = p_other->_annotations;
+        _initializer = p_other->_initializer;
 
         set_info(p_other->_info);
     }
@@ -525,13 +676,20 @@ void OScriptVariable::_bind_methods() {
     ClassDB::bind_method(D_METHOD("is_constant"), &OScriptVariable::is_constant);
     ADD_PROPERTY(PropertyInfo(Variant::BOOL, "constant"), "set_constant", "is_constant");
 
+    // Derived from the annotation list and not stored since format 5; the setter still migrates the
+    // flag written by older formats into a plain "@export".
     ClassDB::bind_method(D_METHOD("set_exported", "exported"), &OScriptVariable::set_exported);
     ClassDB::bind_method(D_METHOD("is_exported"), &OScriptVariable::is_exported);
-    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "exported"), "set_exported", "is_exported");
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "exported", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_exported", "is_exported");
 
     ClassDB::bind_method(D_METHOD("set_property_info", "property"), &OScriptVariable::_set_property_info);
     ClassDB::bind_method(D_METHOD("get_property_info"), &OScriptVariable::_get_property_info);
     ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "info"), "set_property_info", "get_property_info");
+
+    // Bound before "default_value" so a stored NodePath loads under the right initializer kind.
+    ClassDB::bind_method(D_METHOD("set_initializer", "initializer"), &OScriptVariable::_set_initializer);
+    ClassDB::bind_method(D_METHOD("get_initializer"), &OScriptVariable::_get_initializer);
+    ADD_PROPERTY(PropertyInfo(Variant::INT, "initializer", PROPERTY_HINT_ENUM, "Literal,Node Path"), "set_initializer", "get_initializer");
 
     ClassDB::bind_method(D_METHOD("set_default_value", "value"), &OScriptVariable::set_default_value);
     ClassDB::bind_method(D_METHOD("get_default_value"), &OScriptVariable::get_default_value);
@@ -540,6 +698,11 @@ void OScriptVariable::_bind_methods() {
     ClassDB::bind_method(D_METHOD("set_description", "description"), &OScriptVariable::set_description);
     ClassDB::bind_method(D_METHOD("get_description"), &OScriptVariable::get_description);
     ADD_PROPERTY(PropertyInfo(Variant::STRING, "description", PROPERTY_HINT_MULTILINE_TEXT), "set_description", "get_description");
+
+    // Bound after "exported" so a stored list replaces the plain "@export" an older file's flag applies on load.
+    ClassDB::bind_method(D_METHOD("set_annotations", "annotations"), &OScriptVariable::_set_annotations_array);
+    ClassDB::bind_method(D_METHOD("get_annotations"), &OScriptVariable::_get_annotations_array);
+    ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "annotations"), "set_annotations", "get_annotations");
 }
 
 OScriptVariable::OScriptVariable() {

--- a/src/orchestration/variable.h
+++ b/src/orchestration/variable.h
@@ -16,6 +16,8 @@
 //
 #pragma once
 
+#include "orchestration/annotation.h"
+
 #include <godot_cpp/classes/resource.hpp>
 
 using namespace godot;
@@ -34,13 +36,25 @@ class OScriptVariable : public Resource {
 
     GDCLASS(OScriptVariable, Resource);
 
+public:
+    /// How the default value initializes the variable
+    enum InitializerKind {
+        INITIALIZER_LITERAL,    //! The default value is assigned as-is
+        INITIALIZER_NODE_PATH,  //! The default value is a NodePath resolved with get_node() on the owner
+    };
+
+private:
     Orchestration* _orchestration = nullptr;   //! The owning orchestration
     PropertyInfo _info;                        //! Basic property details
     Variant _default_value;                    //! Optional defined default value
     String _description;                       //! An optional description for the variable
     String _category;                          //! Category for variables
-    bool _exported = false;                    //! Whether the variable is exposed on the node
+    OScriptAnnotationList _annotations;        //! Annotations applied to the variable
+    InitializerKind _initializer = INITIALIZER_LITERAL;  //! How the default value is applied
     bool _constant = false;                    //! Whether variable is a constant
+
+    /// Falls back to a literal initializer when the type no longer accepts a node path
+    void _reset_initializer_if_needed();
 
 protected:
     static void _bind_methods();
@@ -56,11 +70,19 @@ protected:
     //~ Begin Serializers
     void _set_property_info(const Dictionary& p_property);
     Dictionary _get_property_info() const;
+    void _set_annotations_array(const Array& p_annotations);
+    Array _get_annotations_array() const;
+    void _set_initializer(int p_initializer);
+    int _get_initializer() const;
     //~ End Serializers
 
     /// Attempt to convert the default value to the new type
     /// @return true if the conversion was successful, false otherwise
     bool _convert_default_value(Variant::Type p_new_type);
+
+    /// Drops annotations that no longer apply to the variable's type
+    /// @return true if any annotation was removed
+    bool _prune_annotations();
 
 public:
     Orchestration* get_orchestration() const;
@@ -82,12 +104,39 @@ public:
     String get_description() const { return _description; }
     void set_description(const String& p_description);
 
-    bool is_exported() const { return _exported; }
+    /// Whether an annotation from the export family is applied
+    bool is_exported() const;
+    /// Applies a plain "@export" when true and none of the export family is present,
+    /// or removes whichever export-family annotation is applied when false.
     void set_exported(bool p_exported);
     bool is_exportable() const;
 
+    const Vector<OScriptAnnotation>& get_annotations() const { return _annotations.get_items(); }
+    bool has_annotation(const StringName& p_name) const { return _annotations.has(p_name); }
+    bool has_annotation_family(const StringName& p_family) const { return _annotations.has_family(p_family); }
+    int find_annotation(const StringName& p_name) const { return _annotations.find(p_name); }
+
+    /// Adds an annotation when the registry permits it for this variable
+    /// @param p_annotation the annotation to add
+    /// @param r_reason optional explanation when the annotation is rejected
+    /// @return OK if added, otherwise the registry's error
+    Error add_annotation(const OScriptAnnotation& p_annotation, String* r_reason = nullptr);
+    void remove_annotation(int p_index);
+    void set_annotation_arguments(int p_index, const Array& p_arguments);
+
+    /// Replaces the whole annotation list, used by serialization and undo snapshots
+    void set_annotations(const Vector<OScriptAnnotation>& p_annotations);
+
     Variant get_default_value() const { return _default_value; }
     void set_default_value(const Variant& p_default_value);
+
+    InitializerKind get_initializer_kind() const { return _initializer; }
+    /// Switching to a node path clears the default to an empty NodePath; switching back restores
+    /// the type's default. The "@onready" annotation is left to the user, as in GDScript.
+    void set_initializer_kind(InitializerKind p_initializer);
+    bool is_node_path_initializer() const { return _initializer == INITIALIZER_NODE_PATH; }
+    /// Whether the variable's type can be initialized from a node path: Variant or a Node class
+    bool is_node_path_initializer_allowed() const;
 
     bool is_constant() const { return _constant; }
     void set_constant(bool p_constant);

--- a/src/script/parser/parser.cpp
+++ b/src/script/parser/parser.cpp
@@ -23,6 +23,7 @@
 #include "common/settings.h"
 #include "common/string_utils.h"
 #include "core/godot/object/class_db.h"
+#include "orchestration/annotation_registry.h"
 #include "orchestration/node_pin.h"
 #include "orchestration/nodes/branch.h"
 #include "orchestration/nodes/call_function.h"
@@ -37,6 +38,8 @@
 #include <ranges>
 #include <string>
 
+#include <godot_cpp/classes/multiplayer_api.hpp>
+#include <godot_cpp/classes/multiplayer_peer.hpp>
 #include <godot_cpp/classes/resource_loader.hpp>
 
 #ifdef DEBUG_ENABLED
@@ -818,6 +821,7 @@ void OScriptParser::push_warning(const Node* p_source, OScriptWarning::Code p_co
 
     PendingWarning pw;
     pw.source = p_source;
+    pw.function = current_function;
     pw.code = p_code;
     pw.treated_as_error = warn_level == OScriptWarning::ERROR;
     pw.symbols = p_symbols;
@@ -831,6 +835,13 @@ void OScriptParser::apply_pending_warnings() {
             continue;
         }
         if (warning_ignore_start_nodes[pw.code] <= pw.source->script_node_id) {
+            continue;
+        }
+        // @warning_ignore on the member itself, or on the function whose body raised it.
+        if (pw.source->ignored_warning_codes.has(pw.code)) {
+            continue;
+        }
+        if (pw.function && pw.function->ignored_warning_codes.has(pw.code)) {
             continue;
         }
 
@@ -3261,17 +3272,25 @@ OScriptParser::VariableNode* OScriptParser::build_variable(const Ref<OScriptVari
     variable->export_info.usage &= ~PROPERTY_USAGE_SCRIPT_VARIABLE;
     variable->datatype_specifier = build_type(p_variable->get_info());
 
-    if (p_variable->is_exported()) {
-        AnnotationNode* annotation = memnew(AnnotationNode);
-        annotation->name = "@export";
-        annotation->info = &valid_annotations[annotation->name];
+    build_annotations(variable, p_variable->get_annotations(), AnnotationInfo::TargetKind::VARIABLE);
 
-        if (annotation->applies_to(AnnotationInfo::TargetKind::VARIABLE)) {
-            variable->annotations.push_back(annotation);
+    if (p_variable->is_node_path_initializer()) {
+        // get_node(path) as T, so the analyzer sees the same shape as a GDScript "$Path" initializer
+        // and raises GET_NODE_DEFAULT_WITHOUT_ONREADY when the annotation is missing.
+        CallNode* get_node = create_func_call("get_node");
+        get_node->arguments.push_back(create_literal(p_variable->get_default_value()));
+
+        ExpressionNode* initializer = get_node;
+        if (!PropertyUtils::is_variant(p_variable->get_info())) {
+            CastNode* cast = alloc_node<CastNode>();
+            cast->operand = get_node;
+            cast->cast_type = build_type(p_variable->get_info());
+            initializer = cast;
         }
-    }
 
-    if (p_variable->get_default_value().get_type() != Variant::NIL) {
+        variable->initializer = initializer;
+        variable->assignments++;
+    } else if (p_variable->get_default_value().get_type() != Variant::NIL) {
         ExpressionNode* default_value = create_expression(p_variable->get_default_value());
         variable->initializer = default_value;
         variable->assignments++;
@@ -3347,6 +3366,8 @@ OScriptParser::FunctionNode* OScriptParser::build_function(const Ref<OScriptFunc
     }
 
     function_node->return_type = build_type(p_function->get_method_info().return_val);
+
+    build_annotations(function_node, p_function->get_annotations(), AnnotationInfo::TargetKind::FUNCTION);
 
     #ifdef TOOLS_ENABLED
     function_node->doc_data.description = p_function->get_description();
@@ -3833,6 +3854,330 @@ bool OScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_tar
 	return true;
 }
 
+bool OScriptParser::export_storage_annotation(AnnotationNode* p_annotation, Node* p_target, ClassNode* p_class) {
+    ERR_FAIL_COND_V_MSG(p_target->type != Node::VARIABLE, false, vformat(R"("%s" annotation can only be applied to variables.)", p_annotation->name));
+
+    VariableNode* variable = static_cast<VariableNode*>(p_target);
+    if (variable->is_static) {
+        push_error(vformat(R"(Annotation "%s" cannot be applied to a static variable.)", p_annotation->name), p_annotation);
+        return false;
+    }
+    if (variable->exported) {
+        push_error(vformat(R"(Annotation "%s" cannot be used with another "@export" annotation.)", p_annotation->name), p_annotation);
+        return false;
+    }
+
+    variable->exported = true;
+
+    // Save the info because the compiler uses export info for overwriting member info.
+    variable->export_info = variable->get_datatype().to_property_info(variable->identifier->name);
+    variable->export_info.usage |= PROPERTY_USAGE_STORAGE;
+
+    return true;
+}
+
+bool OScriptParser::export_custom_annotation(AnnotationNode* p_annotation, Node* p_target, ClassNode* p_class) {
+    ERR_FAIL_COND_V_MSG(p_target->type != Node::VARIABLE, false, vformat(R"("%s" annotation can only be applied to variables.)", p_annotation->name));
+    ERR_FAIL_COND_V_MSG(p_annotation->resolved_arguments.size() < 2, false, R"(Annotation "@export_custom" requires 2 arguments.)");
+
+    VariableNode* variable = static_cast<VariableNode*>(p_target);
+    if (variable->is_static) {
+        push_error(vformat(R"(Annotation "%s" cannot be applied to a static variable.)", p_annotation->name), p_annotation);
+        return false;
+    }
+    if (variable->exported) {
+        push_error(vformat(R"(Annotation "%s" cannot be used with another "@export" annotation.)", p_annotation->name), p_annotation);
+        return false;
+    }
+
+    variable->exported = true;
+
+    const DataType export_type = variable->get_datatype();
+    variable->export_info.type = export_type.builtin_type;
+    variable->export_info.hint = static_cast<PropertyHint>(p_annotation->resolved_arguments[0].operator int64_t());
+    variable->export_info.hint_string = p_annotation->resolved_arguments[1];
+
+    if (p_annotation->resolved_arguments.size() >= 3) {
+        variable->export_info.usage = p_annotation->resolved_arguments[2].operator int64_t();
+    }
+
+    return true;
+}
+
+bool OScriptParser::export_tool_button_annotation(AnnotationNode* p_annotation, Node* p_target, ClassNode* p_class) {
+    #ifdef TOOLS_ENABLED
+    ERR_FAIL_COND_V_MSG(p_target->type != Node::VARIABLE, false, vformat(R"("%s" annotation can only be applied to variables.)", p_annotation->name));
+    ERR_FAIL_COND_V(p_annotation->resolved_arguments.is_empty(), false);
+
+    VariableNode* variable = static_cast<VariableNode*>(p_target);
+    if (variable->is_static) {
+        push_error(vformat(R"(Annotation "%s" cannot be applied to a static variable.)", p_annotation->name), p_annotation);
+        return false;
+    }
+    if (variable->exported) {
+        push_error(vformat(R"(Annotation "%s" cannot be used with another "@export" annotation.)", p_annotation->name), p_annotation);
+        return false;
+    }
+
+    const DataType variable_type = variable->get_datatype();
+    if (!variable_type.is_variant() && variable_type.is_hard_type()) {
+        if (variable_type.kind != DataType::BUILTIN || variable_type.builtin_type != Variant::CALLABLE) {
+            push_error(vformat(R"("@export_tool_button" annotation requires a variable of type "Callable", but type "%s" was given instead.)", variable_type.to_string()), p_annotation);
+            return false;
+        }
+    }
+
+    variable->exported = true;
+
+    // Build the hint string (format: `<text>[,<icon>]`).
+    String hint_string = p_annotation->resolved_arguments[0].operator String();
+    if (p_annotation->resolved_arguments.size() > 1) {
+        hint_string += "," + p_annotation->resolved_arguments[1].operator String();
+    }
+
+    variable->export_info.type = Variant::CALLABLE;
+    variable->export_info.hint = PROPERTY_HINT_TOOL_BUTTON;
+    variable->export_info.hint_string = hint_string;
+    variable->export_info.usage = PROPERTY_USAGE_EDITOR;
+    #endif
+
+    return true;
+}
+
+bool OScriptParser::rpc_annotation(AnnotationNode* p_annotation, Node* p_target, ClassNode* p_class) {
+    ERR_FAIL_COND_V_MSG(p_target->type != Node::FUNCTION, false, vformat(R"("%s" annotation can only be applied to functions.)", p_annotation->name));
+
+    FunctionNode* function = static_cast<FunctionNode*>(p_target);
+    if (function->rpc_config.get_type() != Variant::NIL) {
+        push_error(R"(RPC annotations can only be used once per function.)", p_annotation);
+        return false;
+    }
+
+    Dictionary rpc_config;
+    rpc_config["rpc_mode"] = MultiplayerAPI::RPC_MODE_AUTHORITY;
+
+    if (!p_annotation->resolved_arguments.is_empty()) {
+        unsigned char locality_args = 0;
+        unsigned char permission_args = 0;
+        unsigned char transfer_mode_args = 0;
+
+        for (int i = 0; i < p_annotation->resolved_arguments.size(); i++) {
+            if (i == 3) {
+                rpc_config["channel"] = p_annotation->resolved_arguments[i].operator int();
+                continue;
+            }
+
+            const String arg = p_annotation->resolved_arguments[i].operator String();
+            if (arg == "call_local") {
+                locality_args++;
+                rpc_config["call_local"] = true;
+            } else if (arg == "call_remote") {
+                locality_args++;
+                rpc_config["call_local"] = false;
+            } else if (arg == "any_peer") {
+                permission_args++;
+                rpc_config["rpc_mode"] = MultiplayerAPI::RPC_MODE_ANY_PEER;
+            } else if (arg == "authority") {
+                permission_args++;
+                rpc_config["rpc_mode"] = MultiplayerAPI::RPC_MODE_AUTHORITY;
+            } else if (arg == "reliable") {
+                transfer_mode_args++;
+                rpc_config["transfer_mode"] = MultiplayerPeer::TRANSFER_MODE_RELIABLE;
+            } else if (arg == "unreliable") {
+                transfer_mode_args++;
+                rpc_config["transfer_mode"] = MultiplayerPeer::TRANSFER_MODE_UNRELIABLE;
+            } else if (arg == "unreliable_ordered") {
+                transfer_mode_args++;
+                rpc_config["transfer_mode"] = MultiplayerPeer::TRANSFER_MODE_UNRELIABLE_ORDERED;
+            } else {
+                push_error(R"(Invalid RPC argument. Must be one of: "call_local"/"call_remote" (local calls), "any_peer"/"authority" (permission), "reliable"/"unreliable"/"unreliable_ordered" (transfer mode).)", p_annotation);
+            }
+        }
+
+        if (locality_args > 1) {
+            push_error(R"(Invalid RPC config. The locality ("call_local"/"call_remote") must be specified no more than once.)", p_annotation);
+        } else if (permission_args > 1) {
+            push_error(R"(Invalid RPC config. The permission ("any_peer"/"authority") must be specified no more than once.)", p_annotation);
+        } else if (transfer_mode_args > 1) {
+            push_error(R"(Invalid RPC config. The transfer mode ("reliable"/"unreliable"/"unreliable_ordered") must be specified no more than once.)", p_annotation);
+        }
+    }
+
+    function->rpc_config = rpc_config;
+    return true;
+}
+
+bool OScriptParser::onready_annotation(AnnotationNode* p_annotation, Node* p_target, ClassNode* p_class) {
+    ERR_FAIL_COND_V_MSG(p_target->type != Node::VARIABLE, false, R"("@onready" annotation can only be applied to class variables.)");
+    ERR_FAIL_NULL_V(p_class, false);
+
+    if (!ClassDB::is_parent_class(p_class->base_type.native_type, "Node")) {
+        push_error(R"("@onready" can only be used in classes that inherit "Node".)", p_annotation);
+        return false;
+    }
+
+    VariableNode* variable = static_cast<VariableNode*>(p_target);
+    if (variable->is_static) {
+        push_error(R"("@onready" annotation cannot be applied to a static variable.)", p_annotation);
+        return false;
+    }
+    if (variable->onready) {
+        push_error(R"("@onready" annotation can only be used once per variable.)", p_annotation);
+        return false;
+    }
+
+    variable->onready = true;
+    p_class->onready_used = true;
+    return true;
+}
+
+bool OScriptParser::warning_annotations(AnnotationNode* p_annotation, Node* p_target, ClassNode* p_class) {
+    #ifndef DEBUG_ENABLED
+    // Only available in debug builds.
+    return true;
+    #else
+    if (is_project_ignoring_warnings) {
+        // We already ignore all warnings, let's optimize it.
+        return true;
+    }
+
+    bool has_error = false;
+    for (const Variant& warning_name : p_annotation->resolved_arguments) {
+        const OScriptWarning::Code warning_code = OScriptWarning::get_code_from_name(String(warning_name).to_upper());
+        if (warning_code == OScriptWarning::WARNING_MAX) {
+            push_error(vformat(R"(Invalid warning name: "%s".)", warning_name), p_annotation);
+            has_error = true;
+        } else if (!p_target->ignored_warning_codes.has(warning_code)) {
+            // GDScript ignores by line range; here the target node and, for functions, every warning
+            // raised while its body is analyzed are suppressed instead.
+            p_target->ignored_warning_codes.push_back(warning_code);
+        }
+    }
+
+    return !has_error;
+    #endif
+}
+
+void OScriptParser::build_annotations(Node* p_target, const Vector<OScriptAnnotation>& p_annotations, uint32_t p_target_kind) {
+    for (const OScriptAnnotation& annotation : p_annotations) {
+        if (!valid_annotations.has(annotation.name)) {
+            push_error(vformat(R"(Unknown annotation "%s".)", annotation.name), p_target);
+            continue;
+        }
+
+        AnnotationNode* node = alloc_node<AnnotationNode>();
+        node->name = annotation.name;
+        node->info = &valid_annotations[annotation.name];
+        node->script_node_id = p_target->script_node_id;
+
+        if (!node->applies_to(p_target_kind)) {
+            push_error(vformat(R"(Annotation "%s" is not allowed in this context.)", annotation.name), p_target);
+            continue;
+        }
+
+        // Mirrors GDScriptParser::validate_annotation_arguments
+        const MethodInfo& info = node->info->info;
+        const int argument_count = annotation.arguments.size();
+        if (((info.flags & METHOD_FLAG_VARARG) == 0) && argument_count > info.arguments.size()) {
+            push_error(vformat(R"("%s" annotation requires at most %d arguments, but %d were given.)", annotation.name, info.arguments.size(), argument_count), p_target);
+            continue;
+        }
+        if (argument_count < info.arguments.size() - info.default_arguments.size()) {
+            push_error(vformat(R"("%s" annotation requires at least %d arguments, but %d were given.)", annotation.name, info.arguments.size() - info.default_arguments.size(), argument_count), p_target);
+            continue;
+        }
+
+        for (int i = 0; i < argument_count; i++) {
+            node->arguments.push_back(create_expression(annotation.arguments[i]));
+        }
+
+        p_target->annotations.push_back(node);
+    }
+}
+
+OScriptParser::AnnotationAction OScriptParser::get_annotation_action(const StringName& p_name) {
+    if (p_name == StringName("@export")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_NONE, Variant::NIL>;
+    } else if (p_name == StringName("@export_enum")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_ENUM, Variant::NIL>;
+    } else if (p_name == StringName("@export_file")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_FILE, Variant::STRING>;
+    } else if (p_name == StringName("@export_dir")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_DIR, Variant::STRING>;
+    } else if (p_name == StringName("@export_global_file")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_GLOBAL_FILE, Variant::STRING>;
+    } else if (p_name == StringName("@export_global_dir")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_GLOBAL_DIR, Variant::STRING>;
+    } else if (p_name == StringName("@export_multiline")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_MULTILINE_TEXT, Variant::STRING>;
+    } else if (p_name == StringName("@export_placeholder")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_PLACEHOLDER_TEXT, Variant::STRING>;
+    } else if (p_name == StringName("@export_range")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_RANGE, Variant::FLOAT>;
+    } else if (p_name == StringName("@export_exp_easing")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_EXP_EASING, Variant::FLOAT>;
+    } else if (p_name == StringName("@export_color_no_alpha")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_COLOR_NO_ALPHA, Variant::COLOR>;
+    } else if (p_name == StringName("@export_node_path")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_NODE_PATH_VALID_TYPES, Variant::NODE_PATH>;
+    } else if (p_name == StringName("@export_flags")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_FLAGS, Variant::INT>;
+    } else if (p_name == StringName("@export_flags_2d_render")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_LAYERS_2D_RENDER, Variant::INT>;
+    } else if (p_name == StringName("@export_flags_2d_physics")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_LAYERS_2D_PHYSICS, Variant::INT>;
+    } else if (p_name == StringName("@export_flags_2d_navigation")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_LAYERS_2D_NAVIGATION, Variant::INT>;
+    } else if (p_name == StringName("@export_flags_3d_render")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_LAYERS_3D_RENDER, Variant::INT>;
+    } else if (p_name == StringName("@export_flags_3d_physics")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_LAYERS_3D_PHYSICS, Variant::INT>;
+    } else if (p_name == StringName("@export_flags_3d_navigation")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_LAYERS_3D_NAVIGATION, Variant::INT>;
+    } else if (p_name == StringName("@export_flags_avoidance")) {
+        return &OScriptParser::export_annotations<PROPERTY_HINT_LAYERS_AVOIDANCE, Variant::INT>;
+    } else if (p_name == StringName("@export_storage")) {
+        return &OScriptParser::export_storage_annotation;
+    } else if (p_name == StringName("@export_custom")) {
+        return &OScriptParser::export_custom_annotation;
+    } else if (p_name == StringName("@export_tool_button")) {
+        return &OScriptParser::export_tool_button_annotation;
+    } else if (p_name == StringName("@rpc")) {
+        return &OScriptParser::rpc_annotation;
+    } else if (p_name == StringName("@onready")) {
+        return &OScriptParser::onready_annotation;
+    } else if (p_name == StringName("@warning_ignore")) {
+        return &OScriptParser::warning_annotations;
+    }
+    return nullptr;
+}
+
+uint32_t OScriptParser::get_annotation_target_kinds(uint32_t p_registry_targets) {
+    uint32_t kinds = AnnotationInfo::NONE;
+    if (p_registry_targets & OScriptAnnotationRegistry::TARGET_VARIABLE) {
+        kinds |= AnnotationInfo::VARIABLE;
+    }
+    if (p_registry_targets & (OScriptAnnotationRegistry::TARGET_FUNCTION | OScriptAnnotationRegistry::TARGET_EVENT)) {
+        kinds |= AnnotationInfo::FUNCTION;
+    }
+    if (p_registry_targets & OScriptAnnotationRegistry::TARGET_CLASS) {
+        kinds |= AnnotationInfo::CLASS;
+    }
+    return kinds;
+}
+
+void OScriptParser::register_annotations() {
+    // The registry owns the signatures and targets; the parser only contributes the apply callbacks.
+    // Every descriptor must have one, otherwise the model could accept an annotation the compiler
+    // cannot apply.
+    for (const OScriptAnnotationDescriptor& descriptor : OScriptAnnotationRegistry::get_descriptors()) {
+        const AnnotationAction action = get_annotation_action(descriptor.info.name);
+        ERR_CONTINUE_MSG(action == nullptr, vformat(R"(Annotation "%s" has no parser action.)", descriptor.info.name));
+
+        register_annotation(descriptor.info, get_annotation_target_kinds(descriptor.targets), action);
+    }
+}
+
 Error OScriptParser::parse(Orchestration* p_orchestration, const String& p_script_path) {
     ERR_FAIL_NULL_V_MSG(p_orchestration, ERR_PARSE_ERROR, "Orchestration was null and cannot be parsed.");
 
@@ -3966,7 +4311,7 @@ OScriptParser::OScriptParser() {
     bind_handlers();
 
     if (unlikely(valid_annotations.is_empty())) {
-        register_annotation(MethodInfo("@export"), AnnotationInfo::VARIABLE, &OScriptParser::export_annotations<PROPERTY_HINT_NONE, Variant::NIL>);
+        register_annotations();
     }
 }
 

--- a/src/script/parser/parser.h
+++ b/src/script/parser/parser.h
@@ -16,6 +16,7 @@
 //
 #pragma once
 
+#include "orchestration/annotation.h"
 #include "orchestration/nodes.h"
 #include "script/parser/parser_nodes.h"
 #include "script/parser/function_analyzer.h"
@@ -228,6 +229,7 @@ public:
 private:
     struct PendingWarning {
         const Node *source = nullptr;
+        const FunctionNode* function = nullptr;   // Function being analyzed when the warning was raised, if any
         OScriptWarning::Code code = OScriptWarning::WARNING_MAX;
         bool treated_as_error = false;
         Vector<String> symbols;
@@ -429,8 +431,21 @@ private:
     SuiteNode* build_suite(const String& p_name, const Ref<OScriptNodePin>& p_source_pin, SuiteNode* p_suite = nullptr);
 
     // Annotations
+    // Synthesizes annotation nodes from the model's list onto the target, validating argument counts.
+    void build_annotations(Node* p_target, const Vector<OScriptAnnotation>& p_annotations, uint32_t p_target_kind);
+    // Pairs a registry descriptor name with its compile-time apply callback; null when none exists.
+    static AnnotationAction get_annotation_action(const StringName& p_name);
+    static uint32_t get_annotation_target_kinds(uint32_t p_registry_targets);
+    static void register_annotations();
+
     template <PropertyHint t_hint, Variant::Type t_type>
     bool export_annotations(AnnotationNode* p_annotation, Node* p_target, ClassNode* p_class);
+    bool export_storage_annotation(AnnotationNode* p_annotation, Node* p_target, ClassNode* p_class);
+    bool export_custom_annotation(AnnotationNode* p_annotation, Node* p_target, ClassNode* p_class);
+    bool export_tool_button_annotation(AnnotationNode* p_annotation, Node* p_target, ClassNode* p_class);
+    bool rpc_annotation(AnnotationNode* p_annotation, Node* p_target, ClassNode* p_class);
+    bool onready_annotation(AnnotationNode* p_annotation, Node* p_target, ClassNode* p_class);
+    bool warning_annotations(AnnotationNode* p_annotation, Node* p_target, ClassNode* p_class);
 
 public:
     Error parse(Orchestration* p_orchestration, const String& p_script_path);

--- a/src/script/parser/parser_nodes.h
+++ b/src/script/parser/parser_nodes.h
@@ -249,6 +249,7 @@ namespace OScriptParserNodes
         Node* next = nullptr;
         DataType data_type;
         List<AnnotationNode*> annotations;
+        Vector<int> ignored_warning_codes;  // OScriptWarning::Code values suppressed by @warning_ignore on this node
 
         virtual DataType get_datatype() const { return data_type; }
         virtual void set_datatype(const DataType& p_datatype) { data_type = p_datatype; }

--- a/tests/scenes/errors/export_annotation_duplicate.out
+++ b/tests/scenes/errors/export_annotation_duplicate.out
@@ -1,0 +1,5 @@
+OSCRIPT_TEST_FAILURE
+ERROR: Parser Error: Annotation "@export_range" cannot be used with another "@export" annotation.
+   at: OScript::reload (res://scenes/errors/export_annotation_duplicate.torch:-1)
+ERROR: Failed to load script "res://scenes/errors/export_annotation_duplicate.torch" with error "Parse error".
+   at: _load (src/script/serialization/text/resource_loader_text.cpp)

--- a/tests/scenes/errors/export_annotation_duplicate.torch
+++ b/tests/scenes/errors/export_annotation_duplicate.torch
@@ -1,0 +1,23 @@
+[orchestration type="OScript" load_steps=3 format=5 uid="uid://cann0tdup1ic8"]
+
+[obj type="OScriptGraph" id="OScriptGraph_orolp"]
+graph_name = &"EventGraph"
+flags = 8
+
+[obj type="OScriptVariable" id="OScriptVariable_speed"]
+name = "speed"
+category = "Default"
+classification = "type:float"
+type = 3
+default_value = 1.0
+annotations = [{
+"name": &"@export"
+}, {
+"name": &"@export_range",
+"args": [0, 10]
+}]
+
+[resource]
+base_type = &"Node"
+variables = Array[OScriptVariable]([SubResource("OScriptVariable_speed")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_orolp")])

--- a/tests/scenes/errors/export_annotation_duplicate.tscn
+++ b/tests/scenes/errors/export_annotation_duplicate.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://bann0tdup1ic8"]
+
+[ext_resource type="Script" uid="uid://cann0tdup1ic8" path="res://scenes/errors/export_annotation_duplicate.torch" id="1_torch"]
+
+[node name="ExportAnnotationDuplicate" type="Node"]
+script = ExtResource("1_torch")

--- a/tests/scenes/errors/export_annotation_type_mismatch.out
+++ b/tests/scenes/errors/export_annotation_type_mismatch.out
@@ -1,0 +1,5 @@
+OSCRIPT_TEST_FAILURE
+ERROR: Parser Error: "@export_range" annotation requires a variable of type "float", "Array[float]", "PackedFloat32Array", or "PackedFloat64Array", but type "String" was given instead.
+   at: OScript::reload (res://scenes/errors/export_annotation_type_mismatch.torch:-1)
+ERROR: Failed to load script "res://scenes/errors/export_annotation_type_mismatch.torch" with error "Parse error".
+   at: _load (src/script/serialization/text/resource_loader_text.cpp)

--- a/tests/scenes/errors/export_annotation_type_mismatch.torch
+++ b/tests/scenes/errors/export_annotation_type_mismatch.torch
@@ -1,0 +1,21 @@
+[orchestration type="OScript" load_steps=3 format=5 uid="uid://cann0ttyp3m1s"]
+
+[obj type="OScriptGraph" id="OScriptGraph_orolp"]
+graph_name = &"EventGraph"
+flags = 8
+
+[obj type="OScriptVariable" id="OScriptVariable_label"]
+name = "label"
+category = "Default"
+classification = "type:String"
+type = 4
+default_value = "Hello"
+annotations = [{
+"name": &"@export_range",
+"args": [0, 10]
+}]
+
+[resource]
+base_type = &"Node"
+variables = Array[OScriptVariable]([SubResource("OScriptVariable_label")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_orolp")])

--- a/tests/scenes/errors/export_annotation_type_mismatch.tscn
+++ b/tests/scenes/errors/export_annotation_type_mismatch.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://bann0ttyp3m1s"]
+
+[ext_resource type="Script" uid="uid://cann0ttyp3m1s" path="res://scenes/errors/export_annotation_type_mismatch.torch" id="1_torch"]
+
+[node name="ExportAnnotationTypeMismatch" type="Node"]
+script = ExtResource("1_torch")

--- a/tests/scenes/errors/export_annotation_unknown.out
+++ b/tests/scenes/errors/export_annotation_unknown.out
@@ -1,0 +1,5 @@
+OSCRIPT_TEST_FAILURE
+ERROR: Parser Error: Unknown annotation "@bogus".
+   at: OScript::reload (res://scenes/errors/export_annotation_unknown.torch:-1)
+ERROR: Failed to load script "res://scenes/errors/export_annotation_unknown.torch" with error "Parse error".
+   at: _load (src/script/serialization/text/resource_loader_text.cpp)

--- a/tests/scenes/errors/export_annotation_unknown.torch
+++ b/tests/scenes/errors/export_annotation_unknown.torch
@@ -1,0 +1,20 @@
+[orchestration type="OScript" load_steps=3 format=5 uid="uid://cann0tunkn0wn"]
+
+[obj type="OScriptGraph" id="OScriptGraph_orolp"]
+graph_name = &"EventGraph"
+flags = 8
+
+[obj type="OScriptVariable" id="OScriptVariable_count"]
+name = "count"
+category = "Default"
+classification = "type:int"
+type = 2
+default_value = 1
+annotations = [{
+"name": &"@bogus"
+}]
+
+[resource]
+base_type = &"Node"
+variables = Array[OScriptVariable]([SubResource("OScriptVariable_count")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_orolp")])

--- a/tests/scenes/errors/export_annotation_unknown.tscn
+++ b/tests/scenes/errors/export_annotation_unknown.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://bann0tunkn0wn"]
+
+[ext_resource type="Script" uid="uid://cann0tunkn0wn" path="res://scenes/errors/export_annotation_unknown.torch" id="1_torch"]
+
+[node name="ExportAnnotationUnknown" type="Node"]
+script = ExtResource("1_torch")

--- a/tests/scenes/errors/node_path_without_onready.out
+++ b/tests/scenes/errors/node_path_without_onready.out
@@ -1,0 +1,5 @@
+OSCRIPT_TEST_FAILURE
+ERROR: Parser Error: The default value uses "get_node()" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this. (Warning treated as error.)
+   at: OScript::reload (res://scenes/errors/node_path_without_onready.torch:-1)
+ERROR: Failed to load script "res://scenes/errors/node_path_without_onready.torch" with error "Parse error".
+   at: _load (src/script/serialization/text/resource_loader_text.cpp)

--- a/tests/scenes/errors/node_path_without_onready.torch
+++ b/tests/scenes/errors/node_path_without_onready.torch
@@ -1,0 +1,18 @@
+[orchestration type="OScript" load_steps=3 format=5 uid="uid://cn0d3pathn00r"]
+
+[obj type="OScriptGraph" id="OScriptGraph_orolp"]
+graph_name = &"EventGraph"
+flags = 8
+
+[obj type="OScriptVariable" id="OScriptVariable_label"]
+name = "label"
+category = "Default"
+classification = "class:Label"
+type = 24
+initializer = 1
+default_value = NodePath("Label")
+
+[resource]
+base_type = &"Node"
+variables = Array[OScriptVariable]([SubResource("OScriptVariable_label")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_orolp")])

--- a/tests/scenes/errors/node_path_without_onready.tscn
+++ b/tests/scenes/errors/node_path_without_onready.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://bn0d3pathn00r"]
+
+[ext_resource type="Script" uid="uid://cn0d3pathn00r" path="res://scenes/errors/node_path_without_onready.torch" id="1_torch"]
+
+[node name="NodePathWithoutOnready" type="Node"]
+script = ExtResource("1_torch")

--- a/tests/scenes/errors/onready_with_export.out
+++ b/tests/scenes/errors/onready_with_export.out
@@ -1,0 +1,5 @@
+OSCRIPT_TEST_FAILURE
+ERROR: Parser Error: "@onready" will set the default value after "@export" takes effect and will override it. (Warning treated as error.)
+   at: OScript::reload (res://scenes/errors/onready_with_export.torch:-1)
+ERROR: Failed to load script "res://scenes/errors/onready_with_export.torch" with error "Parse error".
+   at: _load (src/script/serialization/text/resource_loader_text.cpp)

--- a/tests/scenes/errors/onready_with_export.torch
+++ b/tests/scenes/errors/onready_with_export.torch
@@ -1,0 +1,23 @@
+[orchestration type="OScript" load_steps=3 format=5 uid="uid://c0nr3adyexp0r"]
+
+[obj type="OScriptGraph" id="OScriptGraph_orolp"]
+graph_name = &"EventGraph"
+flags = 8
+
+[obj type="OScriptVariable" id="OScriptVariable_label"]
+name = "label"
+category = "Default"
+classification = "class:Label"
+type = 24
+initializer = 1
+default_value = NodePath("Label")
+annotations = [{
+"name": &"@export"
+}, {
+"name": &"@onready"
+}]
+
+[resource]
+base_type = &"Node"
+variables = Array[OScriptVariable]([SubResource("OScriptVariable_label")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_orolp")])

--- a/tests/scenes/errors/onready_with_export.tscn
+++ b/tests/scenes/errors/onready_with_export.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://b0nr3adyexp0r"]
+
+[ext_resource type="Script" uid="uid://c0nr3adyexp0r" path="res://scenes/errors/onready_with_export.torch" id="1_torch"]
+
+[node name="OnreadyWithExport" type="Node"]
+script = ExtResource("1_torch")

--- a/tests/scenes/errors/rpc_annotation_invalid.out
+++ b/tests/scenes/errors/rpc_annotation_invalid.out
@@ -1,0 +1,5 @@
+OSCRIPT_TEST_FAILURE
+ERROR: Parser Error: Invalid RPC argument. Must be one of: "call_local"/"call_remote" (local calls), "any_peer"/"authority" (permission), "reliable"/"unreliable"/"unreliable_ordered" (transfer mode).
+   at: OScript::reload (res://scenes/errors/rpc_annotation_invalid.torch:0)
+ERROR: Failed to load script "res://scenes/errors/rpc_annotation_invalid.torch" with error "Parse error".
+   at: _load (src/script/serialization/text/resource_loader_text.cpp)

--- a/tests/scenes/errors/rpc_annotation_invalid.torch
+++ b/tests/scenes/errors/rpc_annotation_invalid.torch
@@ -1,0 +1,50 @@
+[orchestration type="OScript" load_steps=5 format=5 uid="uid://crpcann0tbad1"]
+
+[obj type="OScriptFunction" id="OScriptFunction_ping"]
+guid = "1A2B3C4D-0003-4000-8000-00000000A003"
+method = {
+"name": &"ping"
+}
+user_defined = true
+id = 0
+annotations = [{
+"name": &"@rpc",
+"args": ["bogus"]
+}]
+
+[obj type="OScriptGraph" id="OScriptGraph_event"]
+graph_name = &"EventGraph"
+flags = 8
+
+[obj type="OScriptGraph" id="OScriptGraph_ping"]
+graph_name = &"ping"
+flags = 22
+nodes = Array[int]([0, 1])
+functions = Array[int]([0])
+
+[obj type="OScriptNodeFunctionEntry" id="OScriptNodeFunctionEntry_ping"]
+function_id = "1A2B3C4D-0003-4000-8000-00000000A003"
+id = 0
+size = Vector2(29, 41)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}])
+
+[obj type="OScriptNodeFunctionResult" id="OScriptNodeFunctionResult_ping"]
+function_id = "1A2B3C4D-0003-4000-8000-00000000A003"
+id = 1
+size = Vector2(29, 41)
+position = Vector2(300, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}])
+
+[resource]
+base_type = &"Node"
+functions = Array[OScriptFunction]([SubResource("OScriptFunction_ping")])
+connections = Array[int]([0, 0, 1, 0])
+nodes = Array[OScriptNode]([SubResource("OScriptNodeFunctionEntry_ping"), SubResource("OScriptNodeFunctionResult_ping")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_event"), SubResource("OScriptGraph_ping")])

--- a/tests/scenes/errors/rpc_annotation_invalid.tscn
+++ b/tests/scenes/errors/rpc_annotation_invalid.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://brpcann0tbad1"]
+
+[ext_resource type="Script" uid="uid://crpcann0tbad1" path="res://scenes/errors/rpc_annotation_invalid.torch" id="1_torch"]
+
+[node name="RpcAnnotationInvalid" type="Node"]
+script = ExtResource("1_torch")

--- a/tests/scenes/errors/warning_ignore_invalid.out
+++ b/tests/scenes/errors/warning_ignore_invalid.out
@@ -1,0 +1,5 @@
+OSCRIPT_TEST_FAILURE
+ERROR: Parser Error: Invalid warning name: "nope".
+   at: OScript::reload (res://scenes/errors/warning_ignore_invalid.torch:0)
+ERROR: Failed to load script "res://scenes/errors/warning_ignore_invalid.torch" with error "Parse error".
+   at: _load (src/script/serialization/text/resource_loader_text.cpp)

--- a/tests/scenes/errors/warning_ignore_invalid.torch
+++ b/tests/scenes/errors/warning_ignore_invalid.torch
@@ -1,0 +1,50 @@
+[orchestration type="OScript" load_steps=5 format=5 uid="uid://cwarnign0bad1"]
+
+[obj type="OScriptFunction" id="OScriptFunction_tick"]
+guid = "1A2B3C4D-0004-4000-8000-00000000A004"
+method = {
+"name": &"tick"
+}
+user_defined = true
+id = 0
+annotations = [{
+"name": &"@warning_ignore",
+"args": ["nope"]
+}]
+
+[obj type="OScriptGraph" id="OScriptGraph_event"]
+graph_name = &"EventGraph"
+flags = 8
+
+[obj type="OScriptGraph" id="OScriptGraph_tick"]
+graph_name = &"tick"
+flags = 22
+nodes = Array[int]([0, 1])
+functions = Array[int]([0])
+
+[obj type="OScriptNodeFunctionEntry" id="OScriptNodeFunctionEntry_tick"]
+function_id = "1A2B3C4D-0004-4000-8000-00000000A004"
+id = 0
+size = Vector2(29, 41)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}])
+
+[obj type="OScriptNodeFunctionResult" id="OScriptNodeFunctionResult_tick"]
+function_id = "1A2B3C4D-0004-4000-8000-00000000A004"
+id = 1
+size = Vector2(29, 41)
+position = Vector2(300, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}])
+
+[resource]
+base_type = &"Node"
+functions = Array[OScriptFunction]([SubResource("OScriptFunction_tick")])
+connections = Array[int]([0, 0, 1, 0])
+nodes = Array[OScriptNode]([SubResource("OScriptNodeFunctionEntry_tick"), SubResource("OScriptNodeFunctionResult_tick")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_event"), SubResource("OScriptGraph_tick")])

--- a/tests/scenes/errors/warning_ignore_invalid.tscn
+++ b/tests/scenes/errors/warning_ignore_invalid.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://bwarnign0bad1"]
+
+[ext_resource type="Script" uid="uid://cwarnign0bad1" path="res://scenes/errors/warning_ignore_invalid.torch" id="1_torch"]
+
+[node name="WarningIgnoreInvalid" type="Node"]
+script = ExtResource("1_torch")

--- a/tests/scenes/features/export_annotations.out
+++ b/tests/scenes/features/export_annotations.out
@@ -1,0 +1,5 @@
+OSCRIPT_TEST_PASS
+speed type=3 hint=1 hint_string=0.0,20.0,0.5
+mode type=4 hint=2 hint_string=Idle,Walk,Run
+layers type=2 hint=8 hint_string=
+legacy type=2 hint=0 hint_string=

--- a/tests/scenes/features/export_annotations.torch
+++ b/tests/scenes/features/export_annotations.torch
@@ -1,0 +1,51 @@
+[orchestration type="OScript" load_steps=6 format=5 uid="uid://c3xp0rtann0t8"]
+
+[obj type="OScriptGraph" id="OScriptGraph_orolp"]
+graph_name = &"EventGraph"
+flags = 8
+
+[obj type="OScriptVariable" id="OScriptVariable_speed"]
+name = "speed"
+category = "Default"
+exported = true
+classification = "type:float"
+type = 3
+default_value = 4.5
+annotations = [{
+"name": &"@export_range",
+"args": [0, 20, 0.5]
+}]
+
+[obj type="OScriptVariable" id="OScriptVariable_mode"]
+name = "mode"
+category = "Default"
+classification = "type:String"
+type = 4
+default_value = "Idle"
+annotations = [{
+"name": &"@export_enum",
+"args": ["Idle", "Walk", "Run"]
+}]
+
+[obj type="OScriptVariable" id="OScriptVariable_layers"]
+name = "layers"
+category = "Default"
+classification = "type:int"
+type = 2
+default_value = 1
+annotations = [{
+"name": &"@export_flags_2d_physics"
+}]
+
+[obj type="OScriptVariable" id="OScriptVariable_legacy"]
+name = "legacy"
+category = "Default"
+exported = true
+classification = "type:int"
+type = 2
+default_value = 7
+
+[resource]
+base_type = &"Node"
+variables = Array[OScriptVariable]([SubResource("OScriptVariable_speed"), SubResource("OScriptVariable_mode"), SubResource("OScriptVariable_layers"), SubResource("OScriptVariable_legacy")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_orolp")])

--- a/tests/scenes/features/export_annotations.tscn
+++ b/tests/scenes/features/export_annotations.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://bxp0rtann0tsc"]
+
+[ext_resource type="Script" uid="uid://c3xp0rtann0t8" path="res://scenes/features/export_annotations.torch" id="1_torch"]
+[ext_resource type="Script" uid="uid://dxp0rtann0tpr" path="res://scenes/features/export_annotations_probe.gd" id="2_probe"]
+
+[node name="ExportAnnotations" type="Node"]
+script = ExtResource("1_torch")
+
+[node name="Probe" type="Node" parent="."]
+script = ExtResource("2_probe")

--- a/tests/scenes/features/export_annotations_probe.gd
+++ b/tests/scenes/features/export_annotations_probe.gd
@@ -1,0 +1,11 @@
+# Prints the export hints the annotated orchestration variables produce on the parent node.
+# Reference values come from the equivalent GDScript annotations on Godot 4.7.1.
+extends Node
+
+const WATCHED: Array[String] = ["speed", "mode", "layers", "legacy"]
+
+func _ready() -> void:
+	var owner_node: Node = get_parent()
+	for property: Dictionary in owner_node.get_property_list():
+		if property.name in WATCHED:
+			print("%s type=%d hint=%d hint_string=%s" % [property.name, property.type, property.hint, property.hint_string])

--- a/tests/scenes/features/export_annotations_probe.gd.uid
+++ b/tests/scenes/features/export_annotations_probe.gd.uid
@@ -1,0 +1,1 @@
+uid://dxp0rtann0tpr

--- a/tests/scenes/features/onready_annotations.out
+++ b/tests/scenes/features/onready_annotations.out
@@ -1,0 +1,3 @@
+OSCRIPT_TEST_PASS
+label=Label is_label=true text=Hello
+any=Label is_label=true

--- a/tests/scenes/features/onready_annotations.torch
+++ b/tests/scenes/features/onready_annotations.torch
@@ -1,0 +1,32 @@
+[orchestration type="OScript" load_steps=4 format=5 uid="uid://c0nr3adyann0t"]
+
+[obj type="OScriptGraph" id="OScriptGraph_orolp"]
+graph_name = &"EventGraph"
+flags = 8
+
+[obj type="OScriptVariable" id="OScriptVariable_label"]
+name = "label"
+category = "Default"
+classification = "class:Label"
+type = 24
+initializer = 1
+default_value = NodePath("Label")
+annotations = [{
+"name": &"@onready"
+}]
+
+[obj type="OScriptVariable" id="OScriptVariable_any"]
+name = "any"
+category = "Default"
+classification = "class:Node"
+type = 24
+initializer = 1
+default_value = NodePath("Label")
+annotations = [{
+"name": &"@onready"
+}]
+
+[resource]
+base_type = &"Node"
+variables = Array[OScriptVariable]([SubResource("OScriptVariable_label"), SubResource("OScriptVariable_any")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_orolp")])

--- a/tests/scenes/features/onready_annotations.tscn
+++ b/tests/scenes/features/onready_annotations.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=3 format=3 uid="uid://b0nr3adyann0t"]
+
+[ext_resource type="Script" uid="uid://c0nr3adyann0t" path="res://scenes/features/onready_annotations.torch" id="1_torch"]
+[ext_resource type="Script" uid="uid://d0nr3adyprb0e" path="res://scenes/features/onready_annotations_probe.gd" id="2_probe"]
+
+[node name="OnreadyAnnotations" type="Node"]
+script = ExtResource("1_torch")
+
+[node name="Label" type="Label" parent="."]
+text = "Hello"
+
+[node name="Probe" type="Node" parent="."]
+script = ExtResource("2_probe")

--- a/tests/scenes/features/onready_annotations_probe.gd
+++ b/tests/scenes/features/onready_annotations_probe.gd
@@ -1,0 +1,11 @@
+# Reads the node-path variables after the parent's onready assignments have run.
+# The parent's implicit ready runs after its children are ready, so wait for its ready signal.
+extends Node
+
+func _ready() -> void:
+	get_parent().ready.connect(_parent_ready)
+
+func _parent_ready() -> void:
+	var owner_node: Node = get_parent()
+	print("label=", owner_node.label.name, " is_label=", owner_node.label is Label, " text=", owner_node.label.text)
+	print("any=", owner_node.any.name, " is_label=", owner_node.any is Label)

--- a/tests/scenes/features/onready_annotations_probe.gd.uid
+++ b/tests/scenes/features/onready_annotations_probe.gd.uid
@@ -1,0 +1,1 @@
+uid://d0nr3adyprb0e

--- a/tests/scenes/features/rpc_annotations.out
+++ b/tests/scenes/features/rpc_annotations.out
@@ -1,0 +1,2 @@
+OSCRIPT_TEST_PASS
+{ &"ping": { "rpc_mode": 1, "call_local": true, "transfer_mode": 2, "channel": 2 }, &"pong": { "rpc_mode": 2 } }

--- a/tests/scenes/features/rpc_annotations.torch
+++ b/tests/scenes/features/rpc_annotations.torch
@@ -1,0 +1,87 @@
+[orchestration type="OScript" load_steps=10 format=5 uid="uid://crpcann0tati0"]
+
+[obj type="OScriptFunction" id="OScriptFunction_ping"]
+guid = "1A2B3C4D-0001-4000-8000-00000000A001"
+method = {
+"name": &"ping"
+}
+user_defined = true
+id = 0
+annotations = [{
+"name": &"@rpc",
+"args": ["any_peer", "call_local", "reliable", 2]
+}]
+
+[obj type="OScriptFunction" id="OScriptFunction_pong"]
+guid = "1A2B3C4D-0002-4000-8000-00000000A002"
+method = {
+"name": &"pong"
+}
+user_defined = true
+id = 2
+annotations = [{
+"name": &"@rpc"
+}]
+
+[obj type="OScriptGraph" id="OScriptGraph_event"]
+graph_name = &"EventGraph"
+flags = 8
+
+[obj type="OScriptGraph" id="OScriptGraph_ping"]
+graph_name = &"ping"
+flags = 22
+nodes = Array[int]([0, 1])
+functions = Array[int]([0])
+
+[obj type="OScriptGraph" id="OScriptGraph_pong"]
+graph_name = &"pong"
+flags = 22
+nodes = Array[int]([2, 3])
+functions = Array[int]([2])
+
+[obj type="OScriptNodeFunctionEntry" id="OScriptNodeFunctionEntry_ping"]
+function_id = "1A2B3C4D-0001-4000-8000-00000000A001"
+id = 0
+size = Vector2(29, 41)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}])
+
+[obj type="OScriptNodeFunctionResult" id="OScriptNodeFunctionResult_ping"]
+function_id = "1A2B3C4D-0001-4000-8000-00000000A001"
+id = 1
+size = Vector2(29, 41)
+position = Vector2(300, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}])
+
+[obj type="OScriptNodeFunctionEntry" id="OScriptNodeFunctionEntry_pong"]
+function_id = "1A2B3C4D-0002-4000-8000-00000000A002"
+id = 2
+size = Vector2(29, 41)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecOut",
+"dir": 1,
+"flags": 4
+}])
+
+[obj type="OScriptNodeFunctionResult" id="OScriptNodeFunctionResult_pong"]
+function_id = "1A2B3C4D-0002-4000-8000-00000000A002"
+id = 3
+size = Vector2(29, 41)
+position = Vector2(300, 0)
+pin_data = Array[Dictionary]([{
+"pin_name": &"ExecIn",
+"flags": 4
+}])
+
+[resource]
+base_type = &"Node"
+functions = Array[OScriptFunction]([SubResource("OScriptFunction_ping"), SubResource("OScriptFunction_pong")])
+connections = Array[int]([0, 0, 1, 0, 2, 0, 3, 0])
+nodes = Array[OScriptNode]([SubResource("OScriptNodeFunctionEntry_ping"), SubResource("OScriptNodeFunctionResult_ping"), SubResource("OScriptNodeFunctionEntry_pong"), SubResource("OScriptNodeFunctionResult_pong")])
+graphs = Array[OScriptGraph]([SubResource("OScriptGraph_event"), SubResource("OScriptGraph_ping"), SubResource("OScriptGraph_pong")])

--- a/tests/scenes/features/rpc_annotations.tscn
+++ b/tests/scenes/features/rpc_annotations.tscn
@@ -1,0 +1,10 @@
+[gd_scene load_steps=3 format=3 uid="uid://brpcann0tati0"]
+
+[ext_resource type="Script" uid="uid://crpcann0tati0" path="res://scenes/features/rpc_annotations.torch" id="1_torch"]
+[ext_resource type="Script" uid="uid://drpcann0tprbe" path="res://scenes/features/rpc_annotations_probe.gd" id="2_probe"]
+
+[node name="RpcAnnotations" type="Node"]
+script = ExtResource("1_torch")
+
+[node name="Probe" type="Node" parent="."]
+script = ExtResource("2_probe")

--- a/tests/scenes/features/rpc_annotations_probe.gd
+++ b/tests/scenes/features/rpc_annotations_probe.gd
@@ -1,0 +1,7 @@
+# Prints the RPC configuration the annotated orchestration functions compile to on the parent's script.
+# Reference value comes from the equivalent GDScript annotations on Godot 4.7.1.
+extends Node
+
+func _ready() -> void:
+	var script: Script = get_parent().get_script()
+	print(script.get_rpc_config())

--- a/tests/scenes/features/rpc_annotations_probe.gd.uid
+++ b/tests/scenes/features/rpc_annotations_probe.gd.uid
@@ -1,0 +1,1 @@
+uid://drpcann0tprbe


### PR DESCRIPTION
Fixes GH-280
Fixes GH-1055
Fixes GH-1513

## Description

This PR introduces a broad range of changes, mainly because they all build on the same system. The annotation system allows for the following:

* https://github.com/CraterCrash/godot-orchestrator/issues/280
* https://github.com/CraterCrash/godot-orchestrator/issues/1055
* https://github.com/CraterCrash/godot-orchestrator/issues/1513

For variables, users will now be able to pick any number of the standard`@export` and export-like annotations, along with the `@onready` annotation, to set a node-path-based initializer. 

For methods, users can now pick `@warning_ignore` and define `@rpc` metadata on user-defined functions. This allows for multiplayer peer-to-peer remote procedure call support.

## Out of scope

There are several annotations that were left out of scope:

* `@abstract` - there is currently no support for abstract classes, but this sets the groundwork for them.
* `@static_unload` - currently we do not support any static members for scripts
* `@tool` and `@icon` - remain defined as they were; no need to move those to annotations.

## Behavior changes

* Script format is bumped from `4` to `5` due to new annotation metadata being recorded.
* Variable's `Exported` property is now derived based on the selected annotations.

## Example of `@onready`

<img width="503" height="492" alt="image" src="https://github.com/user-attachments/assets/12d9fe00-fa35-43f4-8731-fa304c86d49f" />

## Example of `@export_range(...)`

<img width="503" height="492" alt="image" src="https://github.com/user-attachments/assets/15873795-821b-4cf6-9d56-d70e40274d60" />


