### PR TITLE
GH-1785 Add connection style presets

### DIFF
--- a/doc_classes/OrchestratorSettings.xml
+++ b/doc_classes/OrchestratorSettings.xml
@@ -61,6 +61,12 @@
         <member name="interface/editor/graph/confirm_on_delete" type="bool" setter="" getter="" default="true">
             Prompt for confirmation before deleting nodes from a graph.
         </member>
+        <member name="interface/editor/graph/connection_line_curvature" type="float" setter="" getter="" default="0.5">
+            The bezier curvature applied to connection lines when [member interface/editor/graph/connection_line_style] is [code]Custom[/code]. A value of [code]0[/code] draws straight lines; larger values bow the wire further from a straight path.
+        </member>
+        <member name="interface/editor/graph/connection_line_style" type="String" setter="" getter="" default="&quot;Default&quot;">
+            How connection lines are drawn between node pins. [code]Default[/code] uses the engine's standard curved wires, [code]Straight[/code] draws a single straight segment, [code]45 Degrees[/code] and [code]90 Degrees[/code] route wires along horizontal and vertical runs like circuit-board traces, and [code]Custom[/code] draws curved wires using [member interface/editor/graph/connection_line_curvature]. Wires between two reroute nodes are always straight.
+        </member>
         <member name="interface/editor/graph/disconnect_control_flow_when_dragged" type="bool" setter="" getter="" default="true">
             When dragging a node, automatically break its execution (control flow) connections.
         </member>

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -287,6 +287,8 @@ void OrchestratorSettings::_initialize_settings() {
     GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, "interface/editor/components_panel/show_function_friendly_names"), true);
     GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, "interface/editor/components_panel/show_graph_friendly_names"), true);
 
+    GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "interface/editor/graph/connection_line_style", PROPERTY_HINT_ENUM, "Default,Straight,45 Degrees,90 Degrees,Custom"), "Default");
+    GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "interface/editor/graph/connection_line_curvature", PROPERTY_HINT_RANGE, "0,1,0.01"), 0.5);
     GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, "interface/editor/graph/confirm_on_delete"), true);
     GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, "interface/editor/graph/disconnect_control_flow_when_dragged"), true);
     GLOBAL_DEF_BASIC(PropertyInfo(Variant::BOOL, "interface/editor/graph/grid_enabled"), true);

--- a/src/editor/graph/graph_connection_line_style.cpp
+++ b/src/editor/graph/graph_connection_line_style.cpp
@@ -1,0 +1,185 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "editor/graph/graph_connection_line_style.h"
+
+#include <godot_cpp/classes/curve2d.hpp>
+#include <godot_cpp/core/memory.hpp>
+
+namespace {
+
+/// Matches GraphEdit's MAX_CONNECTION_LINE_CURVE_TESSELATION_STAGES.
+constexpr int BEZIER_TESSELLATION_STAGES = 5;
+/// Matches the tolerance GraphEdit passes to Curve2D::tessellate.
+constexpr float BEZIER_TESSELLATION_TOLERANCE = 2.0f;
+
+/// Unscaled horizontal distance an orthogonal wire travels away from a port before it may turn.
+constexpr float ORTHOGONAL_STUB_LENGTH = 16.0f;
+
+PackedVector2Array make_straight(const Vector2& p_from, const Vector2& p_to) {
+    PackedVector2Array points;
+    points.push_back(p_from);
+    points.push_back(p_to);
+    return points;
+}
+
+/// A single straight segment between the two ports.
+class StraightStyle : public OrchestratorEditorGraphConnectionLineStyle {
+protected:
+    PackedVector2Array _build(const Vector2& p_from, const Vector2& p_to, const Context& p_context) const override {
+        return make_straight(p_from, p_to);
+    }
+};
+
+/// A cubic bezier whose horizontal control-point offset is a fraction of the horizontal distance; this is the
+/// same construction GraphEdit uses internally, so a curvature of 0.5 reproduces the engine's default wire.
+class BezierStyle : public OrchestratorEditorGraphConnectionLineStyle {
+    float _curvature;
+
+protected:
+    PackedVector2Array _build(const Vector2& p_from, const Vector2& p_to, const Context& p_context) const override {
+        const float x_diff = p_to.x - p_from.x;
+        float cp_offset = x_diff * _curvature;
+        if (x_diff < 0) {
+            cp_offset *= -1;
+        }
+
+        Ref<Curve2D> curve;
+        curve.instantiate();
+        curve->add_point(p_from);
+        curve->set_point_out(0, Vector2(cp_offset, 0));
+        curve->add_point(p_to);
+        curve->set_point_in(1, Vector2(-cp_offset, 0));
+
+        if (_curvature > 0) {
+            return curve->tessellate(BEZIER_TESSELLATION_STAGES, BEZIER_TESSELLATION_TOLERANCE);
+        }
+        return curve->tessellate(1);
+    }
+
+public:
+    explicit BezierStyle(float p_curvature) : _curvature(p_curvature) { }
+};
+
+/// Routes the wire along horizontal and vertical runs, in the manner of a circuit-board trace.
+///
+/// When the target lies far enough to the right, the wire leaves the source horizontally, turns vertically at
+/// the horizontal midpoint and enters the target horizontally. Otherwise the wire leaves by a short stub, runs
+/// back at the vertical midpoint and enters the target through a matching stub.
+///
+/// With chamfered corners, each bend is cut by up to half the length of the shorter adjacent run, so a short
+/// vertical collapses into a single 45 degree diagonal while longer runs keep a vertical between two diagonals.
+class OrthogonalStyle : public OrchestratorEditorGraphConnectionLineStyle {
+    bool _chamfer_corners;
+
+    static PackedVector2Array _route(const Vector2& p_from, const Vector2& p_to, float p_stub) {
+        PackedVector2Array points;
+        points.push_back(p_from);
+
+        const Vector2 delta = p_to - p_from;
+        if (delta.x >= 2 * p_stub) {
+            const float mid_x = p_from.x + delta.x * 0.5f;
+            points.push_back(Vector2(mid_x, p_from.y));
+            points.push_back(Vector2(mid_x, p_to.y));
+        } else {
+            const float mid_y = p_from.y + delta.y * 0.5f;
+            points.push_back(Vector2(p_from.x + p_stub, p_from.y));
+            points.push_back(Vector2(p_from.x + p_stub, mid_y));
+            points.push_back(Vector2(p_to.x - p_stub, mid_y));
+            points.push_back(Vector2(p_to.x - p_stub, p_to.y));
+        }
+
+        points.push_back(p_to);
+        return points;
+    }
+
+    static PackedVector2Array _chamfer(const PackedVector2Array& p_points) {
+        const int64_t count = p_points.size();
+        if (count < 3) {
+            return p_points;
+        }
+
+        PackedVector2Array points;
+        points.push_back(p_points[0]);
+
+        for (int64_t i = 1; i < count - 1; i++) {
+            const Vector2 previous = p_points[i - 1];
+            const Vector2 current = p_points[i];
+            const Vector2 next = p_points[i + 1];
+
+            const Vector2 to_previous = previous - current;
+            const Vector2 to_next = next - current;
+            const float cut = MIN(to_previous.length(), to_next.length()) * 0.5f;
+            if (Math::is_zero_approx(cut)) {
+                points.push_back(current);
+                continue;
+            }
+
+            points.push_back(current + to_previous.normalized() * cut);
+            points.push_back(current + to_next.normalized() * cut);
+        }
+
+        points.push_back(p_points[count - 1]);
+        return points;
+    }
+
+    static PackedVector2Array _remove_duplicates(const PackedVector2Array& p_points) {
+        PackedVector2Array points;
+        for (const Vector2& point : p_points) {
+            if (points.is_empty() || !points[points.size() - 1].is_equal_approx(point)) {
+                points.push_back(point);
+            }
+        }
+        return points;
+    }
+
+protected:
+    PackedVector2Array _build(const Vector2& p_from, const Vector2& p_to, const Context& p_context) const override {
+        PackedVector2Array points = _remove_duplicates(_route(p_from, p_to, ORTHOGONAL_STUB_LENGTH * p_context.zoom));
+        if (_chamfer_corners) {
+            points = _remove_duplicates(_chamfer(points));
+        }
+        return points.size() >= 2 ? points : make_straight(p_from, p_to);
+    }
+
+public:
+    explicit OrthogonalStyle(bool p_chamfer_corners) : _chamfer_corners(p_chamfer_corners) { }
+};
+
+}
+
+PackedVector2Array OrchestratorEditorGraphConnectionLineStyle::build(const Vector2& p_from, const Vector2& p_to, const Context& p_context) const {
+    if (p_context.source_is_reroute && p_context.target_is_reroute) {
+        return make_straight(p_from, p_to);
+    }
+    return _build(p_from, p_to, p_context);
+}
+
+OrchestratorEditorGraphConnectionLineStyle* OrchestratorEditorGraphConnectionLineStyle::create(const String& p_style, float p_custom_curvature, float p_default_curvature) {
+    if (p_style == STYLE_STRAIGHT) {
+        return memnew(StraightStyle);
+    }
+    if (p_style == STYLE_ANGLED_45) {
+        return memnew(OrthogonalStyle(true));
+    }
+    if (p_style == STYLE_ANGLED_90) {
+        return memnew(OrthogonalStyle(false));
+    }
+    if (p_style == STYLE_CUSTOM) {
+        return memnew(BezierStyle(p_custom_curvature));
+    }
+    return memnew(BezierStyle(p_default_curvature));
+}

--- a/src/editor/graph/graph_connection_line_style.h
+++ b/src/editor/graph/graph_connection_line_style.h
@@ -1,0 +1,67 @@
+// This file is part of the Godot Orchestrator project.
+//
+// Copyright (c) 2023-present Crater Crash Studios LLC and its contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//		http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#pragma once
+
+#include <godot_cpp/variant/packed_vector2_array.hpp>
+
+using namespace godot;
+
+/// Strategy that shapes the polyline drawn between two connected ports in the graph panel.
+///
+/// The <code>GraphEdit</code> control asks for a polyline through <code>_get_connection_line</code> and uses
+/// the returned points for the wire, its hover hit-testing, rubber-band selection, the minimap and the
+/// drag preview. A style therefore only needs to produce points; the engine renders them.
+///
+/// Endpoints arrive in zoom-scaled screen space for the wire and drag preview, but in graph space for the
+/// minimap. Any fixed pixel distances a style uses should be multiplied by <code>Context::zoom</code>.
+///
+class OrchestratorEditorGraphConnectionLineStyle {
+public:
+    /// Per-connection details that influence the generated polyline.
+    struct Context {
+        float zoom = 1.f;
+        bool source_is_reroute = false;
+        bool target_is_reroute = false;
+    };
+
+    static constexpr const char* STYLE_DEFAULT = "Default";         // Default Godot style
+    static constexpr const char* STYLE_STRAIGHT = "Straight";
+    static constexpr const char* STYLE_ANGLED_45 = "45 Degrees";
+    static constexpr const char* STYLE_ANGLED_90 = "90 Degrees";
+    static constexpr const char* STYLE_CUSTOM = "Custom";           // user-specified curvature
+
+protected:
+    /// Produces the polyline for the given endpoints; implemented by each concrete style.
+    virtual PackedVector2Array _build(const Vector2& p_from, const Vector2& p_to, const Context& p_context) const = 0;
+
+public:
+    /// Produces the polyline for the given endpoints.
+    ///
+    /// A wire that runs between two reroute nodes is always a straight segment, regardless of style, so that
+    /// reroutes remain the user's tool for placing bends.
+    PackedVector2Array build(const Vector2& p_from, const Vector2& p_to, const Context& p_context) const;
+
+    /// Creates the style that corresponds to a <code>connection_line_style</code> setting value.
+    ///
+    /// @param p_style the setting value, one of the <code>STYLE_*</code> constants
+    /// @param p_custom_curvature the curvature used by the custom style
+    /// @param p_default_curvature the curvature used by the default style, taken from the graph edit control
+    /// @return the style, never <code>null</code>; unknown values fall back to the default style
+    static OrchestratorEditorGraphConnectionLineStyle* create(const String& p_style, float p_custom_curvature, float p_default_curvature);
+
+    virtual ~OrchestratorEditorGraphConnectionLineStyle() = default;
+};

--- a/src/editor/graph/graph_panel.cpp
+++ b/src/editor/graph/graph_panel.cpp
@@ -53,7 +53,6 @@
 #include "script/script_server.h"
 
 #include <godot_cpp/classes/center_container.hpp>
-#include <godot_cpp/classes/curve2d.hpp>
 #include <godot_cpp/classes/editor_interface.hpp>
 #include <godot_cpp/classes/editor_settings.hpp>
 #include <godot_cpp/classes/graph_frame.hpp>
@@ -2195,6 +2194,8 @@ void OrchestratorEditorGraphPanel::_settings_changed() {
     _disconnect_control_flow_when_dragged = ORCHESTRATOR_GET("interface/editor/graph/disconnect_control_flow_when_dragged", true);
     _show_advanced_tooltips= ORCHESTRATOR_GET("interface/editor/graph/show_advanced_tooltips", false);
 
+    _update_connection_line_style();
+
     bool node_update_required = false;
     node_update_required |= ORCHESTRATOR_GET_TRACK(_show_type_icons, "interface/editor/graph_nodes/show_type_icons", true);
     node_update_required |= ORCHESTRATOR_GET_TRACK(_resizable_by_default, "interface/editor/graph_nodes/resizable_by_default", true);
@@ -2219,6 +2220,27 @@ void OrchestratorEditorGraphPanel::_settings_changed() {
         });
 
     }
+}
+
+void OrchestratorEditorGraphPanel::_update_connection_line_style() {
+    bool changed = _connection_line_style == nullptr;
+    changed |= ORCHESTRATOR_GET_TRACK(_connection_line_style_name, "interface/editor/graph/connection_line_style",
+        String(OrchestratorEditorGraphConnectionLineStyle::STYLE_DEFAULT));
+    changed |= ORCHESTRATOR_GET_TRACK(_connection_line_curvature, "interface/editor/graph/connection_line_curvature", 0.5f);
+    if (!changed) {
+        return;
+    }
+
+    if (_connection_line_style) {
+        memdelete(_connection_line_style);
+    }
+    _connection_line_style = OrchestratorEditorGraphConnectionLineStyle::create(
+        _connection_line_style_name, _connection_line_curvature, get_connection_lines_curvature());
+
+    // GraphEdit caches each connection's tessellated points and only rebuilds them when an endpoint
+    // moves. The curvature setter invalidates that cache unconditionally, even for an unchanged value,
+    // which is the only public way to force every wire (and the minimap) to be re-shaped.
+    set_connection_lines_curvature(get_connection_lines_curvature());
 }
 
 void OrchestratorEditorGraphPanel::_show_drag_hint(const String& p_hint_text) const {
@@ -3376,29 +3398,24 @@ PackedVector2Array OrchestratorEditorGraphPanel::_get_connection_line(const Vect
     _get_graph_node_and_port(from_adjusted, source_node_id, source_node_port);
     _get_graph_node_and_port(to_adjusted, target_node_id, target_node_port);
 
-    const bool source_is_reroute = source_node_id != -1
+    OrchestratorEditorGraphConnectionLineStyle::Context context;
+    context.zoom = get_zoom();
+    context.source_is_reroute = source_node_id != -1
         && cast_to<OrchestratorEditorGraphNodeReroute>(find_child(itos(source_node_id), false, false));
-    const bool target_is_reroute = target_node_id != -1
+    context.target_is_reroute = target_node_id != -1
         && cast_to<OrchestratorEditorGraphNodeReroute>(find_child(itos(target_node_id), false, false));
 
-    // Suppress curvature between two reroute nodes so the wire runs straight, matching
-    // the original knot behavior where only the first and last segments were curved.
-    const float curvature = (source_is_reroute && target_is_reroute) ? 0.0f : get_connection_lines_curvature();
-
-    float xdiff = p_from_position.x - p_to_position.x;
-    float cp_offset = xdiff * curvature;
-    if (xdiff < 0) {
-        cp_offset *= -1;
+    if (!_connection_line_style) {
+        // Settings have not been applied yet; shape the wire the way GraphEdit would.
+        const float curvature = get_connection_lines_curvature();
+        OrchestratorEditorGraphConnectionLineStyle* fallback = OrchestratorEditorGraphConnectionLineStyle::create(
+            OrchestratorEditorGraphConnectionLineStyle::STYLE_DEFAULT, curvature, curvature);
+        const PackedVector2Array points = fallback->build(p_from_position, p_to_position, context);
+        memdelete(fallback);
+        return points;
     }
 
-    Ref<Curve2D> curve;
-    curve.instantiate();
-    curve->add_point(p_from_position);
-    curve->set_point_out(0, Vector2(cp_offset, 0));
-    curve->add_point(p_to_position);
-    curve->set_point_in(1, Vector2(-cp_offset, 0));
-
-    return curvature > 0 ? curve->tessellate(5, 2.0) : curve->tessellate(1);
+    return _connection_line_style->build(p_from_position, p_to_position, context);
 }
 
 bool OrchestratorEditorGraphPanel::_is_node_hover_valid(const StringName& p_from_node, int32_t p_from_port,
@@ -4119,6 +4136,11 @@ OrchestratorEditorGraphPanel::OrchestratorEditorGraphPanel() {
 }
 
 OrchestratorEditorGraphPanel::~OrchestratorEditorGraphPanel() {
+    if (_connection_line_style) {
+        memdelete(_connection_line_style);
+        _connection_line_style = nullptr;
+    }
+
     memdelete(_markers);
     _markers = nullptr;
 }

--- a/src/editor/graph/graph_panel.h
+++ b/src/editor/graph/graph_panel.h
@@ -20,6 +20,7 @@
 #include "core/godot/object/weak_ref.h"
 #include "editor/actions/definition.h"
 #include "editor/graph/graph_clipboard.h"
+#include "editor/graph/graph_connection_line_style.h"
 #include "editor/graph/graph_node.h"
 #include "editor/graph/graph_panel_styler.h"
 
@@ -125,6 +126,10 @@ private:
     WeakRef<OrchestratorEditorGraphPin> _drag_from_pin;
 
     OrchestratorEditorGraphMarkers* _markers = nullptr;
+
+    OrchestratorEditorGraphConnectionLineStyle* _connection_line_style = nullptr;
+    String _connection_line_style_name;
+    float _connection_line_curvature = 0.5f;
 
     HFlowContainer* _toolbar_hflow = nullptr;
     Control* _center_status = nullptr;
@@ -272,6 +277,7 @@ private:
 
     void _grid_pattern_changed(int p_index);
     void _settings_changed();
+    void _update_connection_line_style();
     void _show_drag_hint(const String& p_hint_text) const;
     bool _is_delete_confirmation_enabled();
     bool _can_duplicate_nodes(const Vector<Ref<OrchestrationGraphNode>>& p_nodes, bool p_error_dialog = true);


### PR DESCRIPTION
Fixes GH-1785

## Description

Introduces several connection line style presets:

<img width="879" height="381" alt="image" src="https://github.com/user-attachments/assets/8148df80-3823-49b3-bdaa-585a4c5220ec" />

## Example - 45 degrees

<img width="1233" height="444" alt="image" src="https://github.com/user-attachments/assets/937d6ffa-d564-4939-b44e-472723d719f8" />

## Example - 90 degrees

<img width="1233" height="444" alt="image" src="https://github.com/user-attachments/assets/b90afbda-b2e4-4d79-8d9b-fe7c344d6925" />

In addition, a new property `connection_line_spacing` defines the spacing given to connection wire lanes when using the 45/90 degree presets. When set to `0`, this disables lane spacing calculations.